### PR TITLE
VPN & Raspberry Pi CM4 Setup

### DIFF
--- a/src/doc/markdown/page01_main.md
+++ b/src/doc/markdown/page01_main.md
@@ -6,8 +6,12 @@
     - [Simulator](page11_simulator.md)
 - [Git Repositories](page19_repository.md)
 - [Building and CI/CD](page20_build.md)
+    - [Embedded Hardware](page25_embedded_setup.md)
 - [Configuration](page30_configuration.md)
 - [Logging](page40_logging.md)
+- [Communications](page50_communications.md)
+    - [VPN](page55_vpn.md)
+
 
 ## Documentation Information
 

--- a/src/doc/markdown/page25_embedded_setup.md
+++ b/src/doc/markdown/page25_embedded_setup.md
@@ -1,0 +1,32 @@
+# Embedded Board Setup
+
+## Raspberry Pi CM4
+
+Jaiabot uses the Raspberry Pi CM4 Lite (without built-in eMMC) as the embedded Linux computer.
+
+Installation steps:
+
+- Download the SD card image (currently Ubuntu Server 20.04.2 LTS 64-bit): https://ubuntu.com/download/raspberry-pi
+- Install (assuming SD card on /dev/sdd):
+
+        unxz ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz
+        sudo dd if=ubuntu-20.04.2-preinstalled-server-arm64+raspi.img of=/dev/sdd bs=1M status=progress
+
+- Enable USB in config.txt:
+
+        [pi4]
+        ...
+        dtoverlay=dwc2,dr_mode=host
+
+- Connect to internet (DHCP)
+- Login as ubuntu and change password.
+- Install apt packages:
+
+        sudo apt update
+        sudo apt install wireguard jaiabot-apps
+        # (optional)
+        sudo apt install emacs
+
+- After adding SSH key to ~/.ssh/authorized_keys, disallow SSH password login in `/etc/ssh/sshd_config` to change the appropriate line to:
+
+        PasswordAuthentication no

--- a/src/doc/markdown/page25_embedded_setup.md
+++ b/src/doc/markdown/page25_embedded_setup.md
@@ -12,7 +12,7 @@ Installation steps:
         unxz ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz
         sudo dd if=ubuntu-20.04.2-preinstalled-server-arm64+raspi.img of=/dev/sdd bs=1M status=progress
 
-- Enable USB in config.txt:
+- Enable USB in config.txt (in the system-boot partition of the sd card):
 
         [pi4]
         ...
@@ -20,13 +20,16 @@ Installation steps:
 
 - Connect to internet (DHCP)
 - Login as ubuntu and change password.
+- Change `/etc/hostname`.
 - Install apt packages:
 
         sudo apt update
-        sudo apt install wireguard jaiabot-apps
+        sudo apt install wireguard
         # (optional)
-        sudo apt install emacs
+        sudo apt install emacs-nox
 
 - After adding SSH key to ~/.ssh/authorized_keys, disallow SSH password login in `/etc/ssh/sshd_config` to change the appropriate line to:
 
         PasswordAuthentication no
+
+- Set up Wireguard client configuration using [VPN](page55_vpn.md) instructions.

--- a/src/doc/markdown/page50_communications.md
+++ b/src/doc/markdown/page50_communications.md
@@ -18,7 +18,7 @@ Install required thirdparty libraries:
 ```
 cd ~/Arduino/libraries
 ln -s ~/jaiabot/src/arduino/libraries/RadioHead-1.117 .
-ln -s ~/opensource/jaiabot/src/arduino/libraries/nanopb-0.4.1 .
+ln -s ~/jaiabot/src/arduino/libraries/nanopb-0.4.1 .
 ```
 
 #### arduino-cli
@@ -34,7 +34,7 @@ arduino-cli board list
 
 #### Feather code
 
-Flash application in `jaiabot/src/arduino/feather_lora9x/jaiabot_lora` using Arduino IDE (`jaiabot` must be [compiled normally](page20_build.md) before flashing with Arduino so that the Protobuf messages are compiled).
+Flash application in `jaiabot/src/arduino/feather_lora9x/jaiabot_lora` using Arduino IDE (`jaiabot` must be [compiled normally](page20_build.md) (or minimally `jaiabot_messages_c` is built) before flashing with Arduino so that the Protobuf messages are compiled).
 
 Or with the `arduino-cli`:
 

--- a/src/doc/markdown/page50_communications.md
+++ b/src/doc/markdown/page50_communications.md
@@ -8,7 +8,7 @@ We're using the Adafruit Feather 32u4 with RFM9x LoRa Radio. This is a microcont
 
 On Ubuntu 20.04:
 
-- [Arduino 1.8.15](https://www.arduino.cc/en/software)
+- [Arduino 1.8.15](https://www.arduino.cc/en/software) or arduino-cli (see below)
     - [Adafruit AVR Boards package (1.4.3)](https://learn.adafruit.com/adafruit-feather-32u4-radio-with-lora-radio-module/using-with-arduino-ide)
 - [RadioHead version 1.117](http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.117.zip)
 - [Nanopb 0.4.1](https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.1.tar.gz)
@@ -17,13 +17,32 @@ Install required thirdparty libraries:
 
 ```
 cd ~/Arduino/libraries
-ln -s ~/opensource/jaiabot/src/arduino/libraries/RadioHead .
+ln -s ~/jaiabot/src/arduino/libraries/RadioHead-1.117 .
 ln -s ~/opensource/jaiabot/src/arduino/libraries/nanopb-0.4.1 .
+```
+
+#### arduino-cli
+
+Instead of the graphical Arduino, you can install the [arduino-cli](https://github.com/arduino/arduino-cli) and set it up as follows:
+
+```
+arduino-cli config init --additional-urls  https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
+arduino-cli core update-index
+arduino-cli core install adafruit:avr
+arduino-cli board list
 ```
 
 #### Feather code
 
 Flash application in `jaiabot/src/arduino/feather_lora9x/jaiabot_lora` using Arduino IDE (`jaiabot` must be [compiled normally](page20_build.md) before flashing with Arduino so that the Protobuf messages are compiled).
+
+Or with the `arduino-cli`:
+
+```
+adafruit:avr:feather32u4
+arduino-cli compile -b adafruit:avr:feather32u4 
+arduino-cli upload -p /dev/ttyACM0 -b adafruit:avr:feather32u4
+```
 
 A binary serial interface centered around the `jaiabot::protobuf::LoRaMessage` Protobuf message is used to communicate between the main vehicle computer and the Adafruit Feather. This protocol is a simple wrapper around the Protobuf message:
 

--- a/src/doc/markdown/page55_vpn.md
+++ b/src/doc/markdown/page55_vpn.md
@@ -12,8 +12,8 @@ We're using the private subnet 172.20.11.0/24:
 
 - Server: 172.20.11.1
 - jaiabot0: 172.20.11.10
-- jaiabot0: 172.20.11.11
-- Toby's dev computer: 172.20.11.240
+- jaiabot1: 172.20.11.11
+- @tsaubergine dev computer: 172.20.11.240
 
 ### Server
 
@@ -69,6 +69,10 @@ On a server (e.g. cloud machine), we configure:
         sudo wg
         sudo ip a show wg_jaia
 
+- Enable IP forwarding so that machines on the VPN can see each other "through" the server:
+
+        sysctl -w net.ipv4.ip_forward=1
+
 ### Client
 
 On the client (jaiabot, dev machines, etc.) side, we need to configure:
@@ -94,7 +98,7 @@ On the client (jaiabot, dev machines, etc.) side, we need to configure:
         
         [Peer]
         # Server public key (from /etc/wireguard/publickey on server)
-        PublicKey =  ApEWq2w/0SIZZ/I5GTqSHts5SoKDsa7rJEE6mEmLLys=
+        PublicKey =  quIp0ErbKXgzbws0juC0YaI2FLmLHVpo8j4ChgTmjXI=
         # Allowed private IPs
         AllowedIPs = 172.20.11.0/24
         

--- a/src/doc/markdown/page55_vpn.md
+++ b/src/doc/markdown/page55_vpn.md
@@ -19,7 +19,7 @@ We're using the private subnet 172.20.11.0/24:
 
 We're using AWS EC2 for hosting the server; other providers will likely be similar.
 
-I used the standard Ubuntu 20.04 server image (`Ubuntu Server 20.04 LTS (HVM), SSD Volume Type - ami-03d5c68bab01f3496 (64-bit x86)`) in EC2, using a t3.micro instance type with 8GB disk space. I associated the Elastic IP address 52.36.157.57 to the machine.
+I used the standard Ubuntu 20.04 server image (`Ubuntu Server 20.04 LTS (HVM), SSD Volume Type - ami-03d5c68bab01f3496 (64-bit x86)`) in EC2, using a t3.micro instance type with 8GB disk space. I associated the Elastic IP address 52.36.157.57 (which has been assigned the domain name of `vpn.jaia.tech`) to the machine.
 
 On a server (e.g. cloud machine), we configure:
 

--- a/src/doc/markdown/page55_vpn.md
+++ b/src/doc/markdown/page55_vpn.md
@@ -1,0 +1,130 @@
+# VPN Setup
+
+We use a VPN to securely connect to the Jaiabots for development and testing.
+
+## Wireguard
+
+[Wireguard](https://www.wireguard.com/) is a simple and fast modern VPN. By using a VPN to send traffic between the jaiabots and various dev machines, we can easily connect behind NAT routers and provide a secure virtual LAN.
+
+### Address summary
+
+We're using the private subnet 172.20.11.0/24:
+
+- Server: 172.20.11.1
+- jaiabot0: 172.20.11.10
+- jaiabot0: 172.20.11.11
+- Toby's dev computer: 172.20.11.240
+
+### Server
+
+We're using AWS EC2 for hosting the server; other providers will likely be similar.
+
+I used the standard Ubuntu 20.04 server image (`Ubuntu Server 20.04 LTS (HVM), SSD Volume Type - ami-03d5c68bab01f3496 (64-bit x86)`) in EC2, using a t3.micro instance type with 8GB disk space. I associated the Elastic IP address 52.36.157.57 to the machine.
+
+On a server (e.g. cloud machine), we configure:
+
+- Install wireguard:
+
+        sudo apt install wireguard
+        
+- Generate the server key pair:
+
+        sudo -i
+        cd /etc/wireguard
+        umask 077; wg genkey | tee privatekey | wg pubkey > publickey
+
+- Create `/etc/wireguard/wg_jaia.conf`:
+
+        [Interface]
+        
+        # VPN Address for server
+        Address = 172.20.11.1/24
+        
+        # VPN Server Port
+        ListenPort = 51820
+        
+        # PrivateKey (contents of /etc/wireguard/privatekey)
+        PrivateKey = ...
+        
+        # Note that this configuration uses NAT to make the VPN traffic appear to the rest of the Virtual Private Cloud (VPC) as if its coming from the VPN instance; this avoids the need for disabling the source/destination check or updating routing tables in EC2.
+        # update eth0 to the actual internet interface
+        PostUp = iptables -A FORWARD -i wg_jaia -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+        PostDown = iptables -D FORWARD -i wg_jaia -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+
+
+- Allow firewall on inbound UDP port 51820 (both UFW if installed and cloud provider firewall rules):
+
+        sudo ufw allow 51820/udp
+
+- Enable the systemd service to start the wireguard server on start:
+
+        sudo systemctl enable wg-quick@wg_jaia
+
+- Start it (or reboot):
+
+        sudo systemctl start wg-quick@wg_jaia
+
+- Verify that there's a `wg_jaia` interface:
+
+        sudo wg
+        sudo ip a show wg_jaia
+
+### Client
+
+On the client (jaiabot, dev machines, etc.) side, we need to configure:
+
+- Install wireguard:
+
+        sudo apt install wireguard
+
+- Generate the client key pair:
+
+        sudo -i
+        cd /etc/wireguard/
+        umask 077; wg genkey | tee privatekey | wg pubkey > publickey
+
+- Create `/etc/wireguard/wg_jaia.conf`:
+
+        [Interface]
+        # from /etc/wireguard/privatekey on client
+        PrivateKey = ...
+        
+        # this client's IP address
+        Address = 172.20.11.10
+        
+        [Peer]
+        # Server public key (from /etc/wireguard/publickey on server)
+        PublicKey =  ApEWq2w/0SIZZ/I5GTqSHts5SoKDsa7rJEE6mEmLLys=
+        # Allowed private IPs
+        AllowedIPs = 172.20.11.0/24
+        
+        # Server IP and port
+        Endpoint = vpn.jaia.tech:51820
+        
+        # Keep connection alive (required for behind NAT routers)
+        PersistentKeepalive = 25
+
+Add the client information to the server's `/etc/wireguard/wg_jaia.conf`:
+
+        [Peer]
+        # client VPN public key (from /etc/wireguard/publickey on client)
+        PublicKey = ...
+        
+        # client VPN IP address
+        AllowedIPs = 192.168.11.10/32
+
+- Restart the **server** Wireguard:
+
+        sudo systemctl restart wg-quick@wg_jaia
+
+- Start the client Wireguard:
+
+        sudo wg-quick start wg_jaia
+
+- Check that you can ping the server:
+
+        ping 172.20.11.1
+
+- (optional) - have the client connect on boot:
+
+        sudo systemctl enable wg-quick@wg_jaia


### PR DESCRIPTION
Documentation for embedded setup:
- Flash stock Ubuntu image on raspi boards.
- Setup basic wireguard VPN centered around vpn.jaia.tech (in AWS EC2) to connect to these boards.