### PR TITLE
Control surfaces UI

### DIFF
--- a/src/bin/test/CMakeLists.txt
+++ b/src/bin/test/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(loratest)
+add_subdirectory(control_surfaces)

--- a/src/bin/test/control_surfaces/CMakeLists.txt
+++ b/src/bin/test/control_surfaces/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(APP jaiabot_control_surfaces_test)
+
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR} config.proto)
+
+add_executable(${APP}
+  app.cpp
+  ${PROTO_SRCS} ${PROTO_HDRS})
+
+target_link_libraries(${APP}
+  goby
+  goby_zeromq
+  jaiabot_messages)
+
+if(export_goby_interfaces)
+  generate_interfaces(${APP})
+endif()
+
+project_install_bin(${APP})

--- a/src/bin/test/control_surfaces/app.cpp
+++ b/src/bin/test/control_surfaces/app.cpp
@@ -1,0 +1,123 @@
+// Copyright 2021:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <goby/middleware/marshalling/protobuf.h>
+// this space intentionally left blank
+#include <goby/zeromq/application/multi_thread.h>
+
+#include "config.pb.h"
+#include "jaiabot/groups.h"
+#include "jaiabot/lora/serial.h"
+#include "jaiabot/messages/low_control.pb.h"
+
+using goby::glog;
+namespace si = boost::units::si;
+namespace config = jaiabot::config;
+namespace groups = jaiabot::groups;
+namespace zeromq = goby::zeromq;
+namespace middleware = goby::middleware;
+
+constexpr goby::middleware::Group serial_in{"test::xbee::serial_in"};
+constexpr goby::middleware::Group serial_out{"test::xbee::serial_out"};
+
+namespace jaiabot
+{
+namespace apps
+{
+class ControlSurfacesTest : public zeromq::MultiThreadApplication<config::ControlSurfacesTest>
+{
+  public:
+    ControlSurfacesTest();
+
+  private:
+    void loop() override;
+};
+
+} // namespace apps
+} // namespace jaiabot
+
+int main(int argc, char* argv[])
+{
+    return goby::run<jaiabot::apps::ControlSurfacesTest>(
+        goby::middleware::ProtobufConfigurator<config::ControlSurfacesTest>(argc, argv));
+}
+
+// Main thread
+
+jaiabot::apps::ControlSurfacesTest::ControlSurfacesTest()
+    : zeromq::MultiThreadApplication<config::ControlSurfacesTest>(10 * si::hertz)
+{
+    glog.add_group("main", goby::util::Colors::yellow);
+
+    using SerialThread = jaiabot::lora::SerialThreadLoRaFeather<serial_in, serial_out>;
+    launch_thread<SerialThread>(cfg().serial());
+
+    switch (cfg().mode())
+    {
+        case config::ControlSurfacesTest::BOX:
+            // command from Liaison -> XBee
+            interprocess().subscribe<groups::control_command>(
+                [this](const jaiabot::protobuf::ControlCommand& pb_msg) {
+                    glog.is_verbose() && glog << group("main")
+                                              << "Sending: " << pb_msg.ShortDebugString()
+                                              << std::endl;
+                    auto io = lora::serialize(pb_msg);
+                    interthread().publish<serial_out>(io);
+                });
+
+            // ack from Xbee -> Liaison
+            interthread().subscribe<serial_in>([this](
+                                                   const goby::middleware::protobuf::IOData& io) {
+                auto pb_msg = lora::parse<jaiabot::protobuf::ControlAck>(io);
+                glog.is_verbose() && glog << group("main")
+                                          << "Received: " << pb_msg.ShortDebugString() << std::endl;
+
+                interprocess().publish<groups::control_ack>(pb_msg);
+            });
+
+            break;
+        case config::ControlSurfacesTest::BOT:
+            // command from Xbee -> jaiabot_lora_test
+            interthread().subscribe<serial_in>([this](
+                                                   const goby::middleware::protobuf::IOData& io) {
+                auto pb_msg = lora::parse<jaiabot::protobuf::ControlCommand>(io);
+                glog.is_verbose() && glog << group("main")
+                                          << "Received: " << pb_msg.ShortDebugString() << std::endl;
+
+                interprocess().publish<groups::control_command>(pb_msg);
+
+                protobuf::ControlAck ack;
+                ack.set_id(pb_msg.id());
+                ack.set_vehicle(pb_msg.vehicle());
+                ack.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
+                ack.set_command_time(pb_msg.time());
+
+                glog.is_verbose() && glog << group("main") << "Sending: " << ack.ShortDebugString()
+                                          << std::endl;
+                auto io_ack = lora::serialize(ack);
+                interthread().publish<serial_out>(io_ack);
+            });
+            break;
+    }
+}
+
+void jaiabot::apps::ControlSurfacesTest::loop() {}

--- a/src/bin/test/control_surfaces/config.proto
+++ b/src/bin/test/control_surfaces/config.proto
@@ -1,0 +1,46 @@
+// Copyright 2021:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+syntax = "proto2";
+
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/zeromq/protobuf/interprocess_config.proto";
+import "goby/middleware/protobuf/serial_config.proto";
+
+package jaiabot.config;
+
+message ControlSurfacesTest
+{
+    // required parameters for ApplicationBase3 class
+    optional goby.middleware.protobuf.AppConfig app = 1;
+    // required parameters for connecting to 'gobyd'
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+
+    enum Mode
+    {
+        BOT = 1;
+        BOX = 2;
+    }
+
+    required Mode mode = 10;
+    required goby.middleware.protobuf.SerialConfig serial = 11;
+}

--- a/src/doc/markdown/page50_communications.md
+++ b/src/doc/markdown/page50_communications.md
@@ -84,3 +84,56 @@ Currently the test program transmits every twenty seconds, using a basic TDMA wi
 
 - <https://learn.adafruit.com/adafruit-feather-32u4-radio-with-lora-radio-module/using-the-rfm-9x-radio>
 - <http://www.airspayce.com/mikem/arduino/RadioHead/>
+
+
+## XBee
+
+The XBee radios (Digi XBee PRO S3B Radio) act as wireless serial ports in their default "transparent" mode. In this mode, they are essentially a Hayes modem with a predefined single endpoint that they are connected to whenever not in Command (AT) mode.
+
+See this document for the AT commands:
+
+- <https://www.digi.com/resources/documentation/Digidocs/90002173/#containers/cont_at_cmds.htm?TocPath=AT%2520commands%257C_____0>
+
+Quick setup from default configuration (arbitrarily using ID 7):
+
+```
+picocom /dev/serial/by-id/usb-FTDI_FT231X_USB_UART_DN0404TP-if00-port0 -b 9600
+```
+
+(I found CTRL+A, CTRL+C which enables local echo to be helpful)
+
+Then send:
+
+```
++++
+# Should respond with OK
+AT
+# Should respond with OK
+ATID=7
+# Should respond with 7
+ATWR
+# Should respond with OK
+```
+
+It appears that the channel (CM), preamble ID (HP) and network ID all need to match to allow the radios to communicate.
+
+### Testing
+
+Local testing (no Xbee)
+
+```
+socat pty,link=/tmp/ttyxbee0,raw,echo=0 pty,link=/tmp/ttyxbee1,raw,echo=0
+```
+
+Running the code on the dev machine but using the radios (using socat to forward the serial links from the jaiabots):
+
+```
+# jaiabot1
+socat file:/dev/serial/by-id/usb-FTDI_FT231X_USB_UART_DN0404TU-if00-port0,b9600,raw,echo=0 tcp-l:50000
+# jaiabot2
+socat file:/dev/serial/by-id/usb-FTDI_FT231X_USB_UART_DN0404TP-if00-port0,b9600,raw,echo=0 tcp-l:50000
+# dev machine
+socat tcp:172.20.11.11:50000 pty,link=/tmp/ttyxbee0,raw,echo=0
+socat tcp:172.20.11.12:50000 pty,link=/tmp/ttyxbee1,raw,echo=0
+```
+

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(messages)
+add_subdirectory(liaison)

--- a/src/lib/groups.h
+++ b/src/lib/groups.h
@@ -35,6 +35,9 @@ constexpr goby::middleware::Group lora_rx{"jaiabot::lora_rx"};
 constexpr goby::middleware::Group lora_tx{"jaiabot::lora_tx"};
 constexpr goby::middleware::Group lora_report{"jaiabot::lora_report"};
 
+constexpr goby::middleware::Group control_command{"jaiabot::control_command"};
+constexpr goby::middleware::Group control_ack{"jaiabot::control_ack"};
+
 } // namespace groups
 } // namespace jaiabot
 

--- a/src/lib/liaison/CMakeLists.txt
+++ b/src/lib/liaison/CMakeLists.txt
@@ -1,0 +1,6 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR} config.proto)
+
+add_library(jaiabot_liaison SHARED jaiabot_liaison_load.cpp liaison_jaiabot.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(jaiabot_liaison goby goby_zeromq ${Boost_LIBRARIES} jaiabot_messages)
+
+configure_file(goby_liaison_jaiabot.in ${project_BIN_DIR}/goby_liaison_jaiabot @ONLY)

--- a/src/lib/liaison/config.proto
+++ b/src/lib/liaison/config.proto
@@ -14,6 +14,8 @@ message JaiabotConfig
         required sint32 min = 1;
         required sint32 max = 2;
         optional uint32 n_ticks = 3 [default = 10];
+        optional uint32 step = 4 [default = 1];
+        optional sint32 center = 5 [default = 0];
     }
     required LowLevelControlBounds motor_bounds = 10;
     required LowLevelControlBounds elevator_bounds = 11;

--- a/src/lib/liaison/config.proto
+++ b/src/lib/liaison/config.proto
@@ -20,6 +20,9 @@ message JaiabotConfig
     required LowLevelControlBounds motor_bounds = 10;
     required LowLevelControlBounds elevator_bounds = 11;
     required LowLevelControlBounds rudder_bounds = 12;
+
+    optional double control_freq = 20 [default = 2];
+
 }
 
 extend goby.apps.zeromq.protobuf.LiaisonConfig

--- a/src/lib/liaison/config.proto
+++ b/src/lib/liaison/config.proto
@@ -1,0 +1,26 @@
+syntax = "proto2";
+
+import "goby/zeromq/protobuf/liaison_config.proto";
+
+package jaiabot.protobuf;
+
+message JaiabotConfig
+{
+    optional bool minimize_vehicle = 1 [default = false];
+    repeated int32 load_vehicle = 2;
+
+    message LowLevelControlBounds
+    {
+        required sint32 min = 1;
+        required sint32 max = 2;
+        optional uint32 n_ticks = 3 [default = 10];
+    }
+    required LowLevelControlBounds motor_bounds = 10;
+    required LowLevelControlBounds elevator_bounds = 11;
+    required LowLevelControlBounds rudder_bounds = 12;
+}
+
+extend goby.apps.zeromq.protobuf.LiaisonConfig
+{
+    optional JaiabotConfig jaiabot_config = 1300;
+}

--- a/src/lib/liaison/goby_liaison_jaiabot.in
+++ b/src/lib/liaison/goby_liaison_jaiabot.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+LD_LIBRARY_PATH=@project_LIB_DIR@:${LD_LIBRARY_PATH} GOBY_LIAISON_PLUGINS=libjaiabot_liaison.so exec goby_liaison $@

--- a/src/lib/liaison/jaiabot_liaison_load.cpp
+++ b/src/lib/liaison/jaiabot_liaison_load.cpp
@@ -1,0 +1,14 @@
+#include "liaison_jaiabot.h"
+
+#include "jaiabot_liaison_load.h"
+
+extern "C"
+{
+    std::vector<goby::zeromq::LiaisonContainer*>
+    goby3_liaison_load(const goby::apps::zeromq::protobuf::LiaisonConfig& cfg)
+    {
+        std::vector<goby::zeromq::LiaisonContainer*> containers;
+        containers.push_back(new jaiabot::LiaisonJaiabot(cfg));
+        return containers;
+    }
+}

--- a/src/lib/liaison/jaiabot_liaison_load.h
+++ b/src/lib/liaison/jaiabot_liaison_load.h
@@ -1,0 +1,14 @@
+#ifndef JAIABOT_LIAISON_LOAD_H
+#define JAIABOT_LIAISON_LOAD_H
+
+#include <vector>
+
+#include "goby/zeromq/liaison/liaison_container.h"
+
+extern "C"
+{
+    std::vector<goby::zeromq::LiaisonContainer*>
+    goby3_liaison_load(const goby::apps::zeromq::protobuf::LiaisonConfig& cfg);
+}
+
+#endif

--- a/src/lib/liaison/liaison_jaiabot.cpp
+++ b/src/lib/liaison/liaison_jaiabot.cpp
@@ -39,7 +39,7 @@ jaiabot::LiaisonJaiabot::LiaisonJaiabot(const goby::apps::zeromq::protobuf::Liai
     vehicle_stack_ = new Wt::WStackedWidget(vehicle_box);
     vehicle_stack_->hide();
 
-    const auto update_freq = 10.0;
+    const auto update_freq = cfg_.control_freq();
     timer_.setInterval(1.0 / update_freq * 1.0e3);
     timer_.timeout().connect(this, &LiaisonJaiabot::loop);
 

--- a/src/lib/liaison/liaison_jaiabot.cpp
+++ b/src/lib/liaison/liaison_jaiabot.cpp
@@ -1,0 +1,141 @@
+#include <Wt/WComboBox>
+#include <Wt/WContainerWidget>
+#include <Wt/WGroupBox>
+#include <Wt/WLabel>
+#include <Wt/WPanel>
+#include <Wt/WSlider>
+#include <Wt/WStackedWidget>
+
+#include "liaison_jaiabot.h"
+
+const std::string STRIPE_ODD_CLASS = "odd";
+const std::string STRIPE_EVEN_CLASS = "even";
+
+using namespace goby::util::logger;
+using goby::glog;
+
+using namespace Wt;
+
+jaiabot::LiaisonJaiabot::LiaisonJaiabot(const goby::apps::zeromq::protobuf::LiaisonConfig& cfg,
+                                        Wt::WContainerWidget* parent)
+    : goby::zeromq::LiaisonContainerWithComms<LiaisonJaiabot, CommsThread>(cfg),
+      cfg_(cfg.GetExtension(protobuf::jaiabot_config))
+{
+    WPanel* vehicle_panel = new Wt::WPanel(this);
+    vehicle_panel->setTitle("Bot");
+    vehicle_panel->setCollapsible(true);
+    vehicle_panel->setCollapsed(cfg_.minimize_vehicle());
+
+    WContainerWidget* vehicle_box = new Wt::WContainerWidget();
+    vehicle_panel->setCentralWidget(vehicle_box);
+    new WLabel("Bot: ", vehicle_box);
+    vehicle_combo_ = new WComboBox(vehicle_box);
+    vehicle_combo_->addItem("(Choose a vehicle)");
+    vehicle_combo_->sactivated().connect(this, &LiaisonJaiabot::vehicle_select);
+
+    vehicle_stack_ = new Wt::WStackedWidget(vehicle_box);
+    vehicle_stack_->hide();
+
+    const auto update_freq = 10;
+    timer_.setInterval(1 / (update_freq * 1.0e3));
+    timer_.timeout().connect(this, &LiaisonJaiabot::loop);
+
+    set_name("JaiaBot");
+
+    for (auto vehicle_id : cfg_.load_vehicle()) check_add_vehicle(vehicle_id);
+}
+
+void jaiabot::LiaisonJaiabot::check_add_vehicle(int vehicle_id)
+{
+    auto it = vehicle_data_.find(vehicle_id);
+    if (it == vehicle_data_.end())
+    {
+        it = vehicle_data_.insert(std::make_pair(vehicle_id, VehicleData(vehicle_stack_, cfg_)))
+                 .first;
+        vehicle_combo_->addItem(std::to_string(vehicle_id));
+        vehicle_combo_->model()->sort(0);
+    }
+
+    auto& vehicle_data = it->second;
+}
+
+void jaiabot::LiaisonJaiabot::vehicle_select(WString msg)
+{
+    std::string m = msg.narrow();
+    int vehicle = goby::util::as<int>(m);
+
+    if (vehicle_data_.count(vehicle))
+    {
+        vehicle_stack_->show();
+        vehicle_stack_->setCurrentIndex(vehicle_data_.at(vehicle).index_in_stack);
+    }
+    else
+    {
+        vehicle_stack_->hide();
+    }
+}
+
+void jaiabot::LiaisonJaiabot::loop()
+{
+    auto it = vehicle_data_.find(vehicle_stack_->currentIndex());
+    if (it != vehicle_data_.end())
+    {
+        std::cout << "M: " << it->second.low_level_control.motor_value
+                  << ",R:" << it->second.low_level_control.rudder_value
+                  << ",E:" << it->second.low_level_control.elevator_value << std::endl;
+    }
+}
+
+jaiabot::LiaisonJaiabot::VehicleData::VehicleData(Wt::WStackedWidget* vehicle_stack,
+                                                  const protobuf::JaiabotConfig& cfg)
+    : vehicle_div(new Wt::WContainerWidget), low_level_control(vehicle_div, cfg)
+{
+    vehicle_stack->addWidget(vehicle_div);
+    // index of the newly added widget
+    index_in_stack = vehicle_stack->count() - 1;
+}
+
+jaiabot::LiaisonJaiabot::VehicleData::Controls::Controls(Wt::WContainerWidget* vehicle_div,
+                                                         const protobuf::JaiabotConfig& cfg)
+    : controls_box(new WGroupBox("Low Level Controls", vehicle_div)),
+      motor_box(new WGroupBox("Motor", controls_box)),
+      fins_box(new WGroupBox("Fins", controls_box)),
+      motor_slider(new WSlider(Horizontal, motor_box)),
+      motor_text(new WText(motor_text_from_value(motor_slider->value()), motor_box)),
+      elevator_slider(new WSlider(Vertical, fins_box)),
+      rudder_slider(new WSlider(Horizontal, fins_box)),
+      fins_text(new WText(fins_text_from_value(elevator_slider->value(), rudder_slider->value()),
+                          fins_box))
+{
+    motor_slider->setMinimum(cfg.motor_bounds().min());
+    motor_slider->setMaximum(cfg.motor_bounds().max());
+    motor_slider->setTickInterval((cfg.motor_bounds().max() - cfg.motor_bounds().min()) /
+                                  cfg.motor_bounds().n_ticks());
+    motor_slider->setTickPosition(Wt::WSlider::TicksBelow);
+    motor_slider->sliderMoved().connect(
+        boost::bind(&LiaisonJaiabot::VehicleData::Controls::motor_slider_moved, _1, motor_text));
+    motor_slider->valueChanged().connect(
+        boost::bind(&LiaisonJaiabot::VehicleData::Controls::update_value, _1, &motor_value));
+
+    elevator_slider->setMinimum(cfg.elevator_bounds().min());
+    elevator_slider->setMaximum(cfg.elevator_bounds().max());
+    elevator_slider->setTickInterval((cfg.elevator_bounds().max() - cfg.elevator_bounds().min()) /
+                                     cfg.elevator_bounds().n_ticks());
+    elevator_slider->setTickPosition(Wt::WSlider::TicksRight);
+    elevator_slider->sliderMoved().connect(
+        boost::bind(&LiaisonJaiabot::VehicleData::Controls::elevator_slider_moved, _1, fins_text,
+                    rudder_slider));
+    elevator_slider->valueChanged().connect(
+        boost::bind(&LiaisonJaiabot::VehicleData::Controls::update_value, _1, &elevator_value));
+
+    rudder_slider->setMinimum(cfg.rudder_bounds().min());
+    rudder_slider->setMaximum(cfg.rudder_bounds().max());
+    rudder_slider->setTickInterval((cfg.rudder_bounds().max() - cfg.rudder_bounds().min()) /
+                                   cfg.rudder_bounds().n_ticks());
+    rudder_slider->setTickPosition(Wt::WSlider::TicksBelow);
+    rudder_slider->sliderMoved().connect(
+        boost::bind(&LiaisonJaiabot::VehicleData::Controls::rudder_slider_moved, _1, fins_text,
+                    elevator_slider));
+    rudder_slider->valueChanged().connect(
+        boost::bind(&LiaisonJaiabot::VehicleData::Controls::update_value, _1, &rudder_value));
+}

--- a/src/lib/liaison/liaison_jaiabot.h
+++ b/src/lib/liaison/liaison_jaiabot.h
@@ -1,0 +1,117 @@
+#ifndef LIAISON_JAIABOT_H
+#define LIAISON_JAIABOT_H
+
+#include <Wt/WSlider>
+#include <boost/thread/mutex.hpp>
+
+#include "goby/zeromq/liaison/liaison_container.h"
+
+#include "jaiabot/groups.h"
+
+#include "config.pb.h"
+
+namespace jaiabot
+{
+class CommsThread;
+
+class LiaisonJaiabot : public goby::zeromq::LiaisonContainerWithComms<LiaisonJaiabot, CommsThread>
+{
+  public:
+    LiaisonJaiabot(const goby::apps::zeromq::protobuf::LiaisonConfig& cfg,
+                   Wt::WContainerWidget* parent = 0);
+
+  private:
+    void loop();
+    void focus() override { timer_.start(); }
+    void unfocus() override { timer_.stop(); }
+
+    void vehicle_select(Wt::WString msg);
+    void check_add_vehicle(int vehicle_id);
+
+  private:
+    Wt::WComboBox* vehicle_combo_;
+    Wt::WStackedWidget* vehicle_stack_;
+
+    struct VehicleData
+    {
+        VehicleData(Wt::WStackedWidget*, const protobuf::JaiabotConfig&);
+
+        Wt::WContainerWidget* vehicle_div;
+
+        struct Controls
+        {
+            Controls(Wt::WContainerWidget* vehicle_div, const protobuf::JaiabotConfig& cfg);
+
+            Wt::WGroupBox* controls_box;
+            Wt::WGroupBox* motor_box;
+            Wt::WGroupBox* fins_box;
+            Wt::WSlider* motor_slider;
+            Wt::WText* motor_text{0};
+            Wt::WSlider* elevator_slider;
+            Wt::WSlider* rudder_slider;
+            Wt::WText* fins_text{0};
+
+            int motor_value{0};
+            int rudder_value{0};
+            int elevator_value{0};
+
+            static void update_value(int v, int* value) { *value = v; }
+
+            // must be static, not sure why (segfault in JSignal otherwise)
+            static void motor_slider_moved(int value, Wt::WText* text)
+            {
+                text->setText(motor_text_from_value(value));
+            }
+
+            static void elevator_slider_moved(int value, Wt::WText* text, Wt::WSlider* rudder)
+            {
+                text->setText(fins_text_from_value(value, rudder->value()));
+            }
+
+            static void rudder_slider_moved(int value, Wt::WText* text, Wt::WSlider* elevator)
+            {
+                text->setText(fins_text_from_value(elevator->value(), value));
+            }
+        };
+
+        Controls low_level_control;
+
+        int index_in_stack{0};
+
+        static std::string motor_text_from_value(int value)
+        {
+            return "Motor: " + std::to_string(value);
+        }
+        static std::string fins_text_from_value(int elevator_value, int rudder_value)
+        {
+            return "Elevator: " + std::to_string(elevator_value) +
+                   ", Rudder: " + std::to_string(rudder_value);
+        }
+    };
+
+    // vehicle id to Data
+    std::map<int, VehicleData> vehicle_data_;
+
+    Wt::WTimer timer_;
+    friend class CommsThread;
+    const protobuf::JaiabotConfig& cfg_;
+};
+
+class CommsThread : public goby::zeromq::LiaisonCommsThread<LiaisonJaiabot>
+{
+  public:
+    CommsThread(LiaisonJaiabot* tab, const goby::apps::zeromq::protobuf::LiaisonConfig& config,
+                int index)
+        : LiaisonCommsThread<LiaisonJaiabot>(tab, config, index), tab_(tab)
+    {
+    } // namespace jaiabot
+    ~CommsThread() {}
+
+  private:
+    friend class LiaisonJaiabot;
+    LiaisonJaiabot* tab_;
+};
+
+} // namespace jaiabot
+
+#endif

--- a/src/lib/liaison/liaison_jaiabot.h
+++ b/src/lib/liaison/liaison_jaiabot.h
@@ -58,6 +58,10 @@ class LiaisonJaiabot : public goby::zeromq::LiaisonContainerWithComms<LiaisonJai
             Wt::WSlider* stbd_elevator_slider;
             Wt::WContainerWidget* fins_text_box;
             Wt::WText* fins_text{0};
+            Wt::WGroupBox* ack_box;
+            Wt::WText* ack_text{0};
+
+            protobuf::ControlAck latest_ack;
 
             // must be static, not sure why (segfault in JSignal otherwise)
             static void motor_slider_moved(int value, Wt::WText* text)

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -2,6 +2,7 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${project_INC_DIR}
   jaiabot/messages/example.proto
   jaiabot/messages/feather.proto
   jaiabot/messages/lora_test.proto
+  jaiabot/messages/low_control.proto
   )
 
 add_library(jaiabot_messages SHARED ${PROTO_SRCS} ${PROTO_HDRS})

--- a/src/lib/messages/feather.proto
+++ b/src/lib/messages/feather.proto
@@ -2,6 +2,16 @@ syntax = "proto2";
 
 package jaiabot.protobuf;
 
+
+message ControlSurfaces
+{
+    required sint32 motor = 1;
+    required sint32 port_elevator = 2;
+    required sint32 stbd_elevator = 3;
+    required sint32 rudder = 4;
+}
+
+
 message LoRaMessage
 {
     required int32 src = 1;
@@ -15,7 +25,10 @@ message LoRaMessage
         PARAMETERS_REJECTED = 4;  // feather -> control
         FEATHER_READY = 5;        // feather -> control
         TRANSMIT_RESULT = 6;      // feather -> control
-        DEBUG_MESSAGE = 100;      // feather -> control
+
+        LOW_CONTROL = 50;  // control -> feather
+
+        DEBUG_MESSAGE = 100;  // feather -> control
     }
     required MessageType type = 4 [default = LORA_DATA];
     optional int32 id = 5;
@@ -50,9 +63,11 @@ message LoRaMessage
         Bw125Cr48Sf4096 = 4;
         Bw125Cr45Sf2048 = 5;
     }
-    
+
     optional ModemConfigChoice modem_config = 20 [default = Bw125Cr45Sf128];
 
-    // +5-+23 dBm 
+    // +5-+23 dBm
     optional int32 tx_power = 21 [default = 13];
+
+    optional ControlSurfaces control = 30;
 }

--- a/src/lib/messages/low_control.proto
+++ b/src/lib/messages/low_control.proto
@@ -1,0 +1,34 @@
+syntax = "proto2";
+
+import "jaiabot/messages/feather.proto";
+import "dccl/option_extensions.proto";
+
+package jaiabot.protobuf;
+
+message ControlCommand
+{
+    option (dccl.msg) = {
+        unit_system: "si"
+    };
+    required uint32 id = 1;
+    required uint32 vehicle = 2;
+    required uint64 time = 3 [
+        (dccl.field) = { units { prefix: "micro" derived_dimensions: "time" } }
+    ];
+    required ControlSurfaces command = 4;
+}
+
+message ControlAck
+{
+    option (dccl.msg) = {
+        unit_system: "si"
+    };
+    required uint32 id = 1;
+    required uint32 vehicle = 2;
+    required uint64 time = 3 [
+        (dccl.field) = { units { prefix: "micro" derived_dimensions: "time" } }
+    ];
+    required uint64 command_time = 4 [
+        (dccl.field) = { units { prefix: "micro" derived_dimensions: "time" } }
+    ];
+}


### PR DESCRIPTION
- Added liaison tab for direct control of the various control surfaces (rudder, port/stbd elevators, rudder) from a web browser using the new `protobuf::ControlCommand` message
- Added `jaiabot_control_surfaces_test` that sends the `ControlCommand` over a serial link (for the Xbee). It can run in two modes: one for the *bot* where it receives `ControlCommand` over the serial and sends `ControlAck`, and one for the *box* where it does the inverse.

Intended to be used with the "control-surfaces-ui" branch jaiabot-configuration with the "*-controltest.launch" scripts:
https://github.com/jaiarobotics/jaiabot-configuration/tree/control-surfaces-ui/test

The serial ports for jaiabot_control_surfaces_test in the "*-controltest.launch" scripts are currently configured for remote testing on my dev machine using socat (see https://github.com/jaiarobotics/jaiabot/blob/control-surfaces-ui/src/doc/markdown/page50_communications.md#xbee). They will need to be changed the correct (USB) serial ports for the XBee when testing directly on the raspis (which we can do once this PR is merged and we have a binary deb package to apt install).

I arbitrarily picked the bounds for the sliders. These can be set in: https://github.com/jaiarobotics/jaiabot-configuration/blob/control-surfaces-ui/templates/topside/_liaison_jaiabot_config.pb.cfg.in

Everything is currently an integer; "step" controls the change in the slider when using the keyboard shortcuts. 
