### PR TITLE
Liaison vehicle info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository houses the source code for the JaiaBot micro-UUV. 
 
-Please see the documentation: [compiled by Doxygen](https://gobysoft.org/doc/jaiabot/html/) or in [Markdown](https://github.com/jaiarobotics/jaiabot/blob/1.y/src/doc/markdown/page01_main.md).
+Please see the documentation: [compiled by Doxygen](https://docs.jaia.tech/) or in [Markdown](https://github.com/jaiarobotics/jaiabot/blob/1.y/src/doc/markdown/page01_main.md).

--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -51,6 +51,9 @@ class Fusion : public ApplicationBase
         latest_status_.mutable_local_fix()->set_z_with_units(
             -latest_status_.global_fix().depth_with_units());
 
+        // set empty pose field so NodeStatus gets generated even without pitch, heading, or roll data
+        latest_status_.mutable_pose();
+        
         interprocess().subscribe<goby::middleware::groups::gpsd::att>(
             [this](const goby::middleware::protobuf::gpsd::Attitude& att) {
                 glog.is_debug1() && glog << "Received Attitude update: " << att.ShortDebugString()

--- a/src/lib/liaison/config.proto
+++ b/src/lib/liaison/config.proto
@@ -6,8 +6,9 @@ package jaiabot.protobuf;
 
 message JaiabotConfig
 {
-    optional bool minimize_vehicle = 1 [default = false];
-    repeated int32 load_vehicle = 2;
+    optional bool minimize_bot_panel = 1 [default = false];
+    optional bool minimize_hub_panel = 2 [default = false];
+    repeated int32 load_vehicle = 3;
 
     message LowLevelControlBounds
     {
@@ -20,12 +21,19 @@ message JaiabotConfig
         optional string min_label = 6 [default = '-'];
         optional string max_label = 7 [default = '+'];
     }
-    required LowLevelControlBounds motor_bounds = 10;
-    required LowLevelControlBounds elevator_bounds = 11;
-    required LowLevelControlBounds rudder_bounds = 12;
+    optional LowLevelControlBounds motor_bounds = 10;
+    optional LowLevelControlBounds elevator_bounds = 11;
+    optional LowLevelControlBounds rudder_bounds = 12;
 
     optional double control_freq = 20 [default = 2];
 
+    enum Mode
+    {
+        HUB = 1;
+        BOT = 2;
+    }
+    optional Mode mode = 30 [default = HUB];
+    
 }
 
 extend goby.apps.zeromq.protobuf.LiaisonConfig

--- a/src/lib/messages/control_surfaces.options
+++ b/src/lib/messages/control_surfaces.options
@@ -1,4 +1,1 @@
 # See https://jpa.kapsi.fi/nanopb/docs/reference.html#proto-file-options
-
-# 251 = RadioHead max packet size for LoRa
-*.ControlSurfaces.data   max_size:251


### PR DESCRIPTION
Added `mode` to Jaiabot Liaison (BOT or HUB).

- Show extra data when in BOT mode with new panel:
![image](https://user-images.githubusercontent.com/732276/131872679-6722a252-d34a-43d8-914f-55ac11d2de3a.png)
   - Currently subscribes to NodeStatus data, could analogously subscribe to additional data and add to the same or additional WText box.
   - Requires https://github.com/jaiarobotics/jaiabot-configuration/pull/4