### PR TITLE
Updates needed for running GEOV with jaiahub

### DIFF
--- a/config/launch/standard/all.launch
+++ b/config/launch/standard/all.launch
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S goby_launch -s -P -k30 -pall -d500 -L
 
-[env=jaia_n_bots=1,env=jaia_mode=simulation] goby_launch -P -d100 hub.launch
-[env=jaia_n_bots=1,env=jaia_bot_index=0,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
-#[env=jaia_n_bots=4,env=jaia_bot_index=1,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
-#[env=jaia_n_bots=4,env=jaia_bot_index=2,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
-#[env=jaia_n_bots=4,env=jaia_bot_index=3,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=4,env=jaia_mode=simulation] goby_launch -P -d100 hub.launch
+[env=jaia_n_bots=4,env=jaia_bot_index=0,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=4,env=jaia_bot_index=1,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=4,env=jaia_bot_index=2,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=4,env=jaia_bot_index=3,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch

--- a/config/launch/standard/hub.launch
+++ b/config/launch/standard/hub.launch
@@ -3,5 +3,10 @@
 gobyd <(../../gen/hub.py gobyd) -vvv -n
 goby_liaison_jaiabot <(../../gen/hub.py goby_liaison)
 goby_opencpn_interface <(../../gen/hub.py goby_opencpn_interface)
+goby_geov_interface <(../../gen/hub.py goby_geov_interface)
 jaiabot_hub_manager <(../../gen/hub.py jaiabot_hub_manager)
 jaiabot_web_portal <(../../gen/hub.py jaiabot_web_portal)
+
+# socat connects the TCP server run by goby_opencpn_interface on the hub to a Virtual serial port (pty) that OpenCPN can use
+# run this on the same computer as OpenCPN (or use a Windows equivalent)
+socat tcp:localhost:30100 pty,link=/tmp/pty_jaiahub,raw,echo=0

--- a/config/templates/bot/bot-sim.moos.in
+++ b/config/templates/bot/bot-sim.moos.in
@@ -37,8 +37,8 @@ ProcessConfig = uSimMarine
   
   prefix        = NAV
 
-  buoyancy_rate        = 0.025 // meters/sec                 
-  max_acceleration     = 0.5     // meters/sec^2               
+  buoyancy_rate        = 0.125 // meters/sec                 
+  max_acceleration     = 0.5     // meters/sec^2              
   max_deceleration     = 0.5   // meters/sec^2               
   max_depth_rate       = 0.5   // meters/sec                 
   max_depth_rate_speed = 2.0   // meters/sec

--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -24,4 +24,4 @@ command_sub_cfg {
 transit_speed: 2  #  (optional) (default=2)
 stationkeep_outer_speed: 1  #  (optional) (default=1)
 dive_depth_eps: 0.1  #  (optional) (default=0.1)
-surfacing_timeout: 60  #  (optional) (default=600)
+surfacing_timeout: 600  #  (optional) (default=600)

--- a/config/templates/hub/goby_geov_interface.pb.cfg.in
+++ b/config/templates/hub/goby_geov_interface.pb.cfg.in
@@ -1,0 +1,9 @@
+$app_block
+$interprocess_block
+
+mysql_host: "127.0.0.1"
+mysql_user: "sea"
+mysql_password: "saline12"
+mysql_port: 3306
+mysql_core_db_name: "geov_core"
+simulation: true

--- a/config/templates/hub/goby_opencpn_interface.pb.cfg.in
+++ b/config/templates/hub/goby_opencpn_interface.pb.cfg.in
@@ -1,7 +1,7 @@
 $app_block
 $interprocess_block
 
-ais_serial {
-    port: "/tmp/pty_jaiahub"
-    baud: 115200
+ais_server {  
+  bind_port: 30100
+  set_reuseaddr: true
 }

--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -54,8 +54,11 @@ class Fusion : public ApplicationBase
 
     void loop()
     {
-        auto time = goby::time::SystemClock::now<goby::time::MicroTime>();
-        latest_bot_status_.set_time_with_units(time);
+        // DCCL uses the real system clock to encode time, so "unwarp" the time first
+        auto unwarped_time = goby::time::convert<goby::time::MicroTime>(
+            goby::time::SystemClock::unwarp(goby::time::SystemClock::now()));
+
+        latest_bot_status_.set_time_with_units(unwarped_time);
 
         if (latest_bot_status_.IsInitialized())
             intervehicle().publish<jaiabot::groups::bot_status>(latest_bot_status_);

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -76,7 +76,7 @@ jaiabot::apps::HubManager::HubManager()
 void jaiabot::apps::HubManager::handle_bot_nav(const jaiabot::protobuf::BotStatus& dccl_nav)
 {
     glog.is_warn() && glog << group("bot_nav")
-                             << "Received DCCL nav: " << dccl_nav.ShortDebugString() << std::endl;
+                           << "Received DCCL nav: " << dccl_nav.ShortDebugString() << std::endl;
 
     // republish for liaison / logger, etc.
     interprocess().publish<jaiabot::groups::bot_status>(dccl_nav);
@@ -85,7 +85,10 @@ void jaiabot::apps::HubManager::handle_bot_nav(const jaiabot::protobuf::BotStatu
 
     node_status.set_name("BOT" + std::to_string(dccl_nav.bot_id()));
 
-    node_status.set_time_with_units(dccl_nav.time_with_units());
+    // rewarp the time if needed
+    node_status.set_time_with_units(goby::time::convert<goby::time::MicroTime>(
+        goby::time::SystemClock::warp(goby::time::convert<std::chrono::system_clock::time_point>(
+            dccl_nav.time_with_units()))));
 
     if (dccl_nav.attitude().has_heading())
         node_status.mutable_pose()->set_heading_with_units(
@@ -101,7 +104,10 @@ void jaiabot::apps::HubManager::handle_bot_nav(const jaiabot::protobuf::BotStatu
         node_status.mutable_speed()->set_over_ground_with_units(
             dccl_nav.speed().over_ground_with_units());
 
+    if (dccl_nav.has_depth())
+        node_status.mutable_global_fix()->set_depth_with_units(dccl_nav.depth_with_units());
+
     // publish for opencpn interface
-    if(node_status.IsInitialized())
-       interprocess().publish<goby::middleware::frontseat::groups::node_status>(node_status);
+    if (node_status.IsInitialized())
+        interprocess().publish<goby::middleware::frontseat::groups::node_status>(node_status);
 }


### PR DESCRIPTION
- Add goby_geov_interface configuration
- Update jaiabot_fusion to "unwarp" time when running simulations before posting DCCL message and have jaiabot_hub_manager "warp" it again upon receipt since the DCCL time codec does not support time warp.
- Split pty used by OpenCPN into a TCP server hosted by goby_opencpn_interface and socat hosted locally. This allows us to run goby_opencpn_interface on the Raspi headless hub and OpenCPN and socat locally on a  laptop/etc.

To install GEOV for testing see the "Install Google Earth" and "Install GEOV server components" from my course: https://hackmd.io/IfLlLZCXTUy11F0LLEr0UQ#Install-Google-Earth