### PR TITLE
Build different architectures to subdirectories within build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,11 +8,13 @@ if [ -z "${JAIABOT_MAKE_FLAGS}" ]; then
     JAIABOT_MAKE_FLAGS=
 fi
 
+ARCH=$(dpkg --print-architecture)
+
 set -e -u
-mkdir -p build
+mkdir -p build/${ARCH}
 
 echo "Configuring..."
-cd build
-(set -x; cmake .. ${JAIABOT_CMAKE_FLAGS})
+cd build/${ARCH}
+(set -x; cmake ../.. ${JAIABOT_CMAKE_FLAGS})
 echo "Building..."
 (set -x; cmake --build . -- -j`nproc` ${JAIABOT_MAKE_FLAGS} $@)

--- a/scripts/_docker_arm64_build.sh
+++ b/scripts/_docker_arm64_build.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -x
-
-script_dir=$(dirname $0)
-
-sudo rm -rf ${script_dir}/../build
-cd ${script_dir}/..
-
-docker run -v `pwd`:/home/ubuntu/jaiabot -w /home/ubuntu/jaiabot -t gobysoft/jaiabot-ubuntu-arm64:20.04.1 bash -c "apt update && apt upgrade -y && ./scripts/arm64_build.sh"
-

--- a/scripts/arm64_build.sh
+++ b/scripts/arm64_build.sh
@@ -2,11 +2,11 @@
 
 script_dir=$(dirname $0)
 
-mkdir -p ${script_dir}/../build
-cd ${script_dir}/../build
+mkdir -p ${script_dir}/../build/arm64
+cd ${script_dir}/../build/arm64
 
 export CC=/usr/bin/clang
 export CXX=/usr/bin/clang++
 
-(set -x; cmake .. -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_FLAGS="-target aarch64-linux-gnu" -DCMAKE_CXX_FLAGS="-target aarch64-linux-gnu")
+(set -x; cmake ../.. -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_FLAGS="-target aarch64-linux-gnu" -DCMAKE_CXX_FLAGS="-target aarch64-linux-gnu")
 (set -x; make -j`nproc`)

--- a/scripts/docker_arm64_build_and_deploy.sh
+++ b/scripts/docker_arm64_build_and_deploy.sh
@@ -5,21 +5,22 @@ set -e
 script_dir=$(dirname $0)
 
 cd ${script_dir}/..
-mkdir -p build
+mkdir -p build/arm64
 
-LAST_BUILD_DATE=$(date -r build +%s)
+LAST_BUILD_DATE=$(date -r build/arm64 +%s)
 ONE_WEEK_LATER=$(expr "$LAST_BUILD_DATE" + 604800)
 
 NOW=$(date +%s)
 
 if [ $NOW -ge $ONE_WEEK_LATER ];
     then
-        echo "****It's been a while since we updated packages in the container, so let's take care of that now."
-        docker run -v `pwd`:/home/ubuntu/jaiabot -w /home/ubuntu/jaiabot -t gobysoft/jaiabot-ubuntu-arm64:20.04.1 bash -c "apt update && apt upgrade -y && ./scripts/arm64_build.sh"
+        echo "****It's been a while since we updated packages in the container, so let's rebuild the container now to update the packages."
+        docker build --no-cache .docker/focal/arm64 -t gobysoft/jaiabot-ubuntu-arm64:20.04.1
     else
         echo "****Up to date - let's get straight to compiling, shall we?"
-        docker run -v `pwd`:/home/ubuntu/jaiabot -w /home/ubuntu/jaiabot -t gobysoft/jaiabot-ubuntu-arm64:20.04.1 bash -c "./scripts/arm64_build.sh"
 fi  
+
+docker run -v `pwd`:/home/ubuntu/jaiabot -w /home/ubuntu/jaiabot -t gobysoft/jaiabot-ubuntu-arm64:20.04.1 bash -c "./scripts/arm64_build.sh"
 
 if [ -z "$1" ]
     then
@@ -29,7 +30,7 @@ if [ -z "$1" ]
         for var in "$@"
 	    do
     		echo "rsync build and config directories"
-		    rsync -aP --exclude={build/src,build/CMakeFiles,src/web/dist,src/web/node_modules} src build config scripts ubuntu@"$var":/home/ubuntu/jaiabot/
+		    rsync -aP --exclude={build/arm64/src,build/arm64/CMakeFiles,build/amd64,src/web/dist,src/web/node_modules} src build config scripts ubuntu@"$var":/home/ubuntu/jaiabot/
 	    done
 fi
 

--- a/scripts/setup_embedded/setup_embedded.sh
+++ b/scripts/setup_embedded/setup_embedded.sh
@@ -79,7 +79,7 @@ then
   echo "---entry already exists"
 else
   echo "---making entry"
-  echo "PATH=\${HOME}/jaiabot/build/bin:\${PATH}" >> /home/ubuntu/.bashrc
+  echo "PATH=\${HOME}/jaiabot/build/arm64/bin:\${PATH}" >> /home/ubuntu/.bashrc
 fi
 
 echo "===Made it to the end! You need to reboot."

--- a/src/bin/drivers/xbee/CMakeLists.txt
+++ b/src/bin/drivers/xbee/CMakeLists.txt
@@ -13,6 +13,12 @@ target_link_libraries(${APP}
   goby
   goby_zeromq)
 
+target_link_libraries(xbee
+  goby
+)
+
+
+
 if(export_goby_interfaces)
   generate_interfaces(${APP})
 endif()

--- a/src/doc/markdown/page20_build.md
+++ b/src/doc/markdown/page20_build.md
@@ -27,15 +27,15 @@ This process is summarized by:
 
 ```
 # make a directory for the generated objects
-mkdir build
-cd build
+mkdir -p build/amd64
+cd build/amd64
 # configure the project
-cmake ..
+cmake ../..
 # build it (using make by default)
 cmake --build .
 ```
 
-This project provides a convenience script called `build.sh` that runs cmake to configure and build the project (using as many jobs as your machine has processors). Additionally, you can set the environmental variables `JAIABOT_CMAKE_FLAGS` and/or `JAIABOT_MAKE_FLAGS` to pass command line parameters to CMake (during configure) or make, respectively.
+This project provides a convenience script called `build.sh` that runs cmake to configure and build the project (using as many jobs as your machine has processors). The build.sh script segregates the CMake working directory by machine architecture (e.g. build/amd64, build/arm64, etc.). Additionally, you can set the environmental variables `JAIABOT_CMAKE_FLAGS` and/or `JAIABOT_MAKE_FLAGS` to pass command line parameters to CMake (during configure) or make, respectively.
 
 Some examples:
 
@@ -165,8 +165,6 @@ Then to cross-compile using this image:
 
 ```bash
 cd jaiabot
-# clear out the build directory assuming it exists with a native build (might need sudo if you've build using the container last)
-rm -rf build
 # run the docker container interactively
 docker run -v `pwd`:/home/ubuntu/jaiabot -w /home/ubuntu/jaiabot -it gobysoft/jaiabot-ubuntu-arm64:20.04.1 
 # update any dependencies since the image was created (not required if you've recently built the image)


### PR DESCRIPTION
Updated various scripts to build to subdirectories based on dpkg architecture. This allows the developer to maintain both a local amd64 copy and an embedded build. *All embedded computers need to have the $PATH updated in .bashrc from jaiabot/build/bin to jaiabot/build/arm64/bin* (I only changed jaiabot0).

```
# for embedded
jaiabot/build/arm64
# for local
jaiabot/build/amd64
```

I also updated the [docker_arm64_build_and_deploy.sh](https://github.com/jaiarobotics/jaiabot/pull/20/files#diff-c97a02f951036873f8e8e04125788f587da64399db71fd029e11f55e7d7b6152) script to regenerate the docker container weekly (the old way the script worked didn't make sense since changes in a docker container don't persist to the image).