### PR TITLE
Add jaia_fleet_index env var

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -12,13 +12,18 @@ import common, common.vehicle, common.comms, common.sim, common.udp
 try:
     number_of_bots=int(os.environ['jaia_n_bots'])
 except:
-    config.fail('Must set jaia_n_bots environmental variable, e.g. "jaia_n_bots=10 jaia_bot_index=0 ./bot.launch"')
+    config.fail('Must set jaia_n_bots environmental variable, e.g. "jaia_n_bots=10 jaia_bot_index=0  jaia_fleet_index=0  ./bot.launch"')
 
 try:
     bot_index=int(os.environ['jaia_bot_index'])
 except:
-    config.fail('Must set jaia_bot_index environmental variable, e.g. "jaia_n_bots=10 jaia_bot_index=0 ./bot.launch"')
+    config.fail('Must set jaia_bot_index environmental variable, e.g. "jaia_n_bots=10 jaia_bot_index=0  jaia_fleet_index=0  ./bot.launch"')
 
+try:
+    fleet_index=int(os.environ['jaia_fleet_index'])
+except:
+    config.fail('Must set jaia_fleet_index environmental variable, e.g. "jaia_n_bots=10 jaia_bot_index=0 jaia_fleet_index=0 ./bot.launch"')
+    
 log_file_dir = common.jaia_log_dir+ '/bot/' + str(bot_index)
 debug_log_file_dir=log_file_dir 
 os.makedirs(log_file_dir, exist_ok=True)
@@ -40,7 +45,7 @@ verbosities = \
 app_common = common.app_block(verbosities, debug_log_file_dir, geodesy='')
 
 interprocess_common = config.template_substitute(templates_dir+'/_interprocess.pb.cfg.in',
-                                                 platform='bot'+str(bot_index))
+                                                 platform='bot'+str(bot_index)+'_fleet' + str(fleet_index))
 
 if is_runtime():
     link_block = config.template_substitute(templates_dir+'/link_xbee.pb.cfg.in',

--- a/config/gen/hub.py
+++ b/config/gen/hub.py
@@ -12,7 +12,12 @@ import common, common.hub, common.comms, common.sim, common.vehicle, common.udp
 try:
     number_of_bots=int(os.environ['jaia_n_bots'])
 except:
-    config.fail('Must set jaia_n_bots environmental variable, e.g. "jaia_n_bots=10 jaia_bot_index=0 ./bot.launch"')
+    config.fail('Must set jaia_n_bots environmental variable, e.g. "jaia_n_bots=10 jaia_fleet_index=0 ./hub.launch"')
+
+try:
+    fleet_index=int(os.environ['jaia_fleet_index'])
+except:
+    config.fail('Must set jaia_fleet_index environmental variable, e.g. "jaia_n_bots=10 jaia_fleet_index=0 ./hub.launch"')
 
 log_file_dir = common.jaia_log_dir+ '/hub'
 os.makedirs(log_file_dir, exist_ok=True)
@@ -38,7 +43,7 @@ verbosities = \
 app_common = common.app_block(verbosities, debug_log_file_dir, geodesy='')
 
 interprocess_common = config.template_substitute(templates_dir+'/_interprocess.pb.cfg.in',
-                                                 platform='hub')
+                                                 platform='hub'+'_fleet' + str(fleet_index))
 
 
 if is_runtime():

--- a/config/launch/standard/preseed.goby
+++ b/config/launch/standard/preseed.goby
@@ -7,3 +7,5 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${goby3_lib_dir}:${jaia_lib_dir}
 export jaia_max_number_vehicles=128
 
 #export GOBY_MODEMDRIVER_PLUGINS=libxbee.so
+
+[ -z "${jaia_fleet_index}" ] && export jaia_fleet_index=0


### PR DESCRIPTION
This gets added to the platform name (e.g. bot0_fleet1) so it gets logged, and also makes the gobyd unique for a given bot id / fleet id pair.

We can migrate this further into the configuration of certain apps if we need to later.