### PR TITLE
Add DivePacket

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -95,7 +95,8 @@ elif common.app == 'jaiabot_simulator':
                                      interprocess_block = interprocess_common,
                                      moos_port=common.vehicle.moos_simulator_port(vehicle_id),
                                      gpsd_simulator_udp_port=common.vehicle.gpsd_simulator_udp_port(vehicle_id),
-                                     pressure_udp_port=common.udp.bar30_cpp_udp_port(vehicle_id)))
+                                     pressure_udp_port=common.udp.bar30_cpp_udp_port(vehicle_id),
+                                     salinity_udp_port=common.udp.atlas_ezo_cpp_udp_port(vehicle_id)))
 elif common.app == 'bluerobotics-pressure-sensor-driver':
     print(config.template_substitute(templates_dir+'/bot/bluerobotics-pressure-sensor-driver.pb.cfg.in',
                                      app_block=app_common,
@@ -109,7 +110,9 @@ elif common.app == 'jaiabot_adafruit-BNO055-driver':
 elif common.app == 'jaiabot_atlas-scientific-ezo-ec-driver':
     print(config.template_substitute(templates_dir+'/bot/jaiabot_atlas-scientific-ezo-ec-driver.pb.cfg.in',
                                      app_block=app_common,
-                                     interprocess_block = interprocess_common))
+                                     interprocess_block = interprocess_common,
+                                     bind_port=common.udp.atlas_ezo_cpp_udp_port(vehicle_id),
+                                     remote_port=common.udp.atlas_ezo_py_udp_port(vehicle_id)))
 elif common.app == 'salinity-subscriber':
     print(config.template_substitute(templates_dir+'/bot/salinity-subscriber.pb.cfg.in',
                                      app_block=app_common,

--- a/config/gen/common/udp.py
+++ b/config/gen/common/udp.py
@@ -15,3 +15,16 @@ def bar30_py_udp_port(vehicle_id):
         return 20000 + vehicle_id
     else:
         return 20001
+
+def atlas_ezo_cpp_udp_port(vehicle_id):
+    if is_simulation():
+        return 20200 + vehicle_id
+    else:
+        return 0
+    
+def atlas_ezo_py_udp_port(vehicle_id):
+    if is_simulation():
+        return 20300 + vehicle_id
+    else:
+        return 20002
+    

--- a/config/launch/standard/bot.launch
+++ b/config/launch/standard/bot.launch
@@ -9,6 +9,7 @@ goby_liaison_jaiabot <(../../gen/bot.py goby_liaison)
 jaiabot_simulator <(../../gen/bot.py jaiabot_simulator)
 jaiabot_fusion <(../../gen/bot.py jaiabot_fusion)
 bluerobotics-pressure-sensor-driver <(../../gen/bot.py bluerobotics-pressure-sensor-driver)
+jaiabot_atlas-scientific-ezo-ec-driver <(../../gen/bot.py jaiabot_atlas-scientific-ezo-ec-driver) -vv
 jaiabot_mission_manager <(../../gen/bot.py jaiabot_mission_manager) -vvv -n
 goby_gps <(../../gen/bot.py goby_gps)
 goby_logger <(../../gen/bot.py goby_logger)

--- a/config/templates/bot/jaiabot_atlas-scientific-ezo-ec-driver.pb.cfg.in
+++ b/config/templates/bot/jaiabot_atlas-scientific-ezo-ec-driver.pb.cfg.in
@@ -2,7 +2,7 @@ $app_block
 $interprocess_block
 
 udp_config { 
-    bind_port: 0
+    bind_port: $bind_port
     remote_address: "127.0.0.1"
-    remote_port: 20002
+    remote_port: $remote_port
 }

--- a/config/templates/bot/jaiabot_simulator.pb.cfg.in
+++ b/config/templates/bot/jaiabot_simulator.pb.cfg.in
@@ -18,5 +18,22 @@ pressure_udp_config {
     remote_port: $pressure_udp_port
 }
 
+salinity_udp_config { 
+    bind_port: 0
+    remote_address: "127.0.0.1"
+    remote_port: $salinity_udp_port
+}
+
+
 # m/s
 vertical_dive_rate: 0.5 
+
+# made up temperature/salinity profile
+sample { depth: 0 temperature: 15 salinity: 20 }
+sample { depth: 10 temperature: 14.5 salinity: 20 }
+sample { depth: 20 temperature: 8 salinity: 25 }
+sample { depth: 50 temperature: 7 salinity: 26 }
+sample { depth: 100 temperature: 6 salinity: 26 }
+
+temperature_stdev: 0.05
+salinity_stdev: 0.05

--- a/config/templates/hub/jaiabot_hub_manager.pb.cfg.in
+++ b/config/templates/hub/jaiabot_hub_manager.pb.cfg.in
@@ -17,3 +17,19 @@ status_sub_cfg {
         }
     }
 }
+
+
+dive_packet_sub_cfg {
+    intervehicle {
+        # publisher_id added in code for each configured managed_bot_modem_id
+        # buffer configuration for BotStatus messages
+        buffer {
+            ack_required: true
+            blackout_time: 0
+            max_queue: 10
+            newest_first: false
+            ttl: 3000
+            value_base: 5
+        }
+    }
+}

--- a/src/bin/hub_manager/config.proto
+++ b/src/bin/hub_manager/config.proto
@@ -37,4 +37,5 @@ message HubManager
     
     repeated int32 managed_bot_modem_id = 10;
     required goby.middleware.protobuf.TransporterConfig status_sub_cfg = 11;
+    required goby.middleware.protobuf.TransporterConfig dive_packet_sub_cfg = 12;
 }

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -47,6 +47,7 @@ class HubManager : public ApplicationBase
 
   private:
     void handle_bot_nav(const jaiabot::protobuf::BotStatus& dccl_nav);
+    void handle_dive_packet(const jaiabot::protobuf::DivePacket& dive_packet);
 };
 } // namespace apps
 } // namespace jaiabot
@@ -61,16 +62,33 @@ jaiabot::apps::HubManager::HubManager()
 {
     for (auto id : cfg().managed_bot_modem_id())
     {
-        goby::middleware::protobuf::TransporterConfig subscriber_cfg = cfg().status_sub_cfg();
-        goby::middleware::intervehicle::protobuf::TransporterConfig& intervehicle_cfg =
-            *subscriber_cfg.mutable_intervehicle();
-        intervehicle_cfg.add_publisher_id(id);
+        {
+            goby::middleware::protobuf::TransporterConfig subscriber_cfg = cfg().status_sub_cfg();
+            goby::middleware::intervehicle::protobuf::TransporterConfig& intervehicle_cfg =
+                *subscriber_cfg.mutable_intervehicle();
+            intervehicle_cfg.add_publisher_id(id);
 
-        goby::middleware::Subscriber<jaiabot::protobuf::BotStatus> nav_subscriber(subscriber_cfg);
+            goby::middleware::Subscriber<jaiabot::protobuf::BotStatus> subscriber(subscriber_cfg);
 
-        intervehicle().subscribe<jaiabot::groups::bot_status, jaiabot::protobuf::BotStatus>(
-            [this](const jaiabot::protobuf::BotStatus& dccl_nav) { handle_bot_nav(dccl_nav); },
-            nav_subscriber);
+            intervehicle().subscribe<jaiabot::groups::bot_status, jaiabot::protobuf::BotStatus>(
+                [this](const jaiabot::protobuf::BotStatus& dccl_nav) { handle_bot_nav(dccl_nav); },
+                subscriber);
+        }
+        {
+            goby::middleware::protobuf::TransporterConfig subscriber_cfg =
+                cfg().dive_packet_sub_cfg();
+            goby::middleware::intervehicle::protobuf::TransporterConfig& intervehicle_cfg =
+                *subscriber_cfg.mutable_intervehicle();
+            intervehicle_cfg.add_publisher_id(id);
+
+            goby::middleware::Subscriber<jaiabot::protobuf::DivePacket> subscriber(subscriber_cfg);
+
+            intervehicle().subscribe<jaiabot::groups::dive_packet, jaiabot::protobuf::DivePacket>(
+                [this](const jaiabot::protobuf::DivePacket& dive_packet) {
+                    handle_dive_packet(dive_packet);
+                },
+                subscriber);
+        }
     }
 }
 
@@ -78,22 +96,36 @@ jaiabot::apps::HubManager::~HubManager()
 {
     for (auto id : cfg().managed_bot_modem_id())
     {
-        goby::middleware::protobuf::TransporterConfig subscriber_cfg = cfg().status_sub_cfg();
-        goby::middleware::intervehicle::protobuf::TransporterConfig& intervehicle_cfg =
-            *subscriber_cfg.mutable_intervehicle();
-        intervehicle_cfg.add_publisher_id(id);
+        {
+            goby::middleware::protobuf::TransporterConfig subscriber_cfg = cfg().status_sub_cfg();
+            goby::middleware::intervehicle::protobuf::TransporterConfig& intervehicle_cfg =
+                *subscriber_cfg.mutable_intervehicle();
+            intervehicle_cfg.add_publisher_id(id);
 
-        goby::middleware::Subscriber<jaiabot::protobuf::BotStatus> nav_subscriber(subscriber_cfg);
+            goby::middleware::Subscriber<jaiabot::protobuf::BotStatus> subscriber(subscriber_cfg);
 
-        intervehicle().unsubscribe<jaiabot::groups::bot_status, jaiabot::protobuf::BotStatus>(
-            nav_subscriber);
+            intervehicle().unsubscribe<jaiabot::groups::bot_status, jaiabot::protobuf::BotStatus>(
+                subscriber);
+        }
+        {
+            goby::middleware::protobuf::TransporterConfig subscriber_cfg =
+                cfg().dive_packet_sub_cfg();
+            goby::middleware::intervehicle::protobuf::TransporterConfig& intervehicle_cfg =
+                *subscriber_cfg.mutable_intervehicle();
+            intervehicle_cfg.add_publisher_id(id);
+
+            goby::middleware::Subscriber<jaiabot::protobuf::DivePacket> subscriber(subscriber_cfg);
+
+            intervehicle().unsubscribe<jaiabot::groups::bot_status, jaiabot::protobuf::DivePacket>(
+                subscriber);
+        }
     }
 }
 
 void jaiabot::apps::HubManager::handle_bot_nav(const jaiabot::protobuf::BotStatus& dccl_nav)
 {
-    glog.is_warn() && glog << group("bot_nav")
-                           << "Received DCCL nav: " << dccl_nav.ShortDebugString() << std::endl;
+    glog.is_debug1() && glog << group("bot_nav")
+                             << "Received DCCL nav: " << dccl_nav.ShortDebugString() << std::endl;
 
     // republish for liaison / logger, etc.
     interprocess().publish<jaiabot::groups::bot_status>(dccl_nav);
@@ -127,4 +159,14 @@ void jaiabot::apps::HubManager::handle_bot_nav(const jaiabot::protobuf::BotStatu
     // publish for opencpn interface
     if (node_status.IsInitialized())
         interprocess().publish<goby::middleware::frontseat::groups::node_status>(node_status);
+}
+
+void jaiabot::apps::HubManager::handle_dive_packet(const jaiabot::protobuf::DivePacket& dive_packet)
+{
+    glog.is_debug1() && glog << group("dive_packet")
+                             << "Received Dive packet: " << dive_packet.ShortDebugString()
+                             << std::endl;
+
+    // republish
+    interprocess().publish<jaiabot::groups::dive_packet>(dive_packet);
 }

--- a/src/bin/mission_manager/app.cpp
+++ b/src/bin/mission_manager/app.cpp
@@ -23,6 +23,9 @@
 #include "machine.h"
 #include "mission_manager.h"
 
+#include "jaiabot/messages/pressure_temperature.pb.h"
+#include "jaiabot/messages/salinity.pb.h"
+
 using goby::glog;
 namespace si = boost::units::si;
 namespace zeromq = goby::zeromq;
@@ -158,6 +161,21 @@ jaiabot::apps::MissionManager::MissionManager()
         [this](const goby::middleware::frontseat::protobuf::NodeStatus& node_status) {
             machine_->process_event(
                 statechart::EvVehicleDepth(node_status.global_fix().depth_with_units()));
+        });
+
+    // subscribe for sensor measurements
+    interprocess().subscribe<jaiabot::groups::pressure_temperature>(
+        [this](const jaiabot::protobuf::PressureTemperatureData& pt) {
+            statechart::EvMeasurement ev;
+            ev.temperature = pt.temperature_with_units();
+            machine_->process_event(ev);
+        });
+
+    interprocess().subscribe<jaiabot::groups::salinity>(
+        [this](const jaiabot::protobuf::SalinityData& sal) {
+            statechart::EvMeasurement ev;
+            ev.salinity = sal.salinity();
+            machine_->process_event(ev);
         });
 }
 

--- a/src/bin/mission_manager/machine_common.h
+++ b/src/bin/mission_manager/machine_common.h
@@ -22,6 +22,13 @@ struct MissionManagerStateMachine;
 template <typename Derived> class AppMethodsAccess
 {
   protected:
+    goby::middleware::InterVehicleForwarder<
+        goby::zeromq::InterProcessPortal<goby::middleware::InterThreadTransporter>>&
+    intervehicle()
+    {
+        return app().intervehicle();
+    }
+
     goby::zeromq::InterProcessPortal<goby::middleware::InterThreadTransporter>& interprocess()
     {
         return app().interprocess();

--- a/src/bin/simulator/config.proto
+++ b/src/bin/simulator/config.proto
@@ -47,7 +47,30 @@ message Simulator
     optional goby.middleware.protobuf.UDPPointToPointConfig gps_udp_config = 20;
     optional goby.middleware.protobuf.UDPPointToPointConfig
         pressure_udp_config = 21;
+    optional goby.middleware.protobuf.UDPPointToPointConfig
+        salinity_udp_config = 22;
 
     optional double vertical_dive_rate = 30
-        [(dccl.field) = { units { derived_dimensions: "velocity" } }];    
+        [(dccl.field) = { units { derived_dimensions: "velocity" } }];
+
+    message ScalarSample
+    {
+        optional double depth = 1
+            [(dccl.field) = { units: { derived_dimensions: "length" } }];
+
+        optional double temperature = 2 [(dccl.field) = {
+            units { derived_dimensions: "temperature" system: "celsius" }
+        }];
+        optional double salinity = 3;
+    }
+
+    repeated ScalarSample sample = 40;
+    optional double temperature_stdev = 41 [(dccl.field) = {
+        units {
+            derived_dimensions: "temperature"
+            system: "celsius"
+            relative_temperature: true
+        }
+    }];
+    optional double salinity_stdev = 5;
 }

--- a/src/doc/deployment/dev_deployment.yml
+++ b/src/doc/deployment/dev_deployment.yml
@@ -3,11 +3,14 @@ platforms:
   - name: HUB
     interfaces:
       - @GOBY_INTERFACES_DIR@/goby_gps_interface.yml
-      - jaiabot_dev_hub_interface.yml
-      - jaiabot_liaison_interface.yml
+      - jaiabot_hub_manager_interface.yml
+      - jaiabot_web_portal_interface.yml
   - name: BOT
     interfaces:
+      - jaiabot_adafruit-BNO055-driver_interface.yml
+      - bluerobotics-pressure-sensor-driver_interface.yml
+      - jaiabot_atlas-scientific-ezo-ec-driver_interface.yml
+      - jaiabot_fusion_interface.yml
       - @GOBY_INTERFACES_DIR@/goby_gps_interface.yml
-      - jaiabot_dev_bot_interface.yml
       - jaiabot_control_surfaces_driver_interface.yml
-      - jaiabot_liaison_interface.yml
+      - bot_pid_control_interface.yml

--- a/src/doc/deployment/simulation_deployment.yml
+++ b/src/doc/deployment/simulation_deployment.yml
@@ -2,20 +2,22 @@ deployment: sim_deployment
 platforms:
   - name: hub
     interfaces:
-      - @GOBY_INTERFACES_DIR@/goby_opencpn_interface_interface.yml
-      - jaiabot_hub_manager_interface.yml
       - application: goby_liaison
-        file: jaiabot_liaison_interface.yml
+        file: jaiabot_liaison_interface.yml        
+      - @GOBY_INTERFACES_DIR@/goby_opencpn_interface_interface.yml
+      - @GOBY_INTERFACES_DIR@/goby_geov_interface_interface.yml
+      - jaiabot_hub_manager_interface.yml
+      - jaiabot_web_portal_interface.yml
   - name: bot
     interfaces:
-      - @GOBY_INTERFACES_DIR@/goby_gps_interface.yml
-      - jaiabot_simulator_interface.yml
-      - jaiabot_fusion_interface.yml
-      - jaiabot_mission_manager_interface.yml
       - application: goby_moos_gateway
         file: jaiabot_moos_gateway_plugin_interface.yml
       - application: goby_moos_gateway
         file: @GOBY_INTERFACES_DIR@/goby_ivp_frontseat_moos_gateway_plugin_interface.yml
       - application: goby_liaison
         file: jaiabot_liaison_interface.yml
-
+      - jaiabot_simulator_interface.yml
+      - jaiabot_fusion_interface.yml
+      - bluerobotics-pressure-sensor-driver_interface.yml
+      - jaiabot_mission_manager_interface.yml
+      - @GOBY_INTERFACES_DIR@/goby_gps_interface.yml

--- a/src/doc/doxygen/jaiabot.doxy.in
+++ b/src/doc/doxygen/jaiabot.doxy.in
@@ -754,7 +754,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = YES
+WARN_AS_ERROR          = NO
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/src/lib/groups.h
+++ b/src/lib/groups.h
@@ -39,8 +39,7 @@ constexpr goby::middleware::Group lora_report{"jaiabot::lora_report"};
 // sensors
 constexpr goby::middleware::Group imu{"jaiabot::imu"};
 constexpr goby::middleware::Group pressure_temperature{"jaiabot::pressure_temperature"};
-constexpr goby::middleware::Group salinity{"jaiabot::salinity",
-                                            goby::middleware::Group::broadcast_group};
+constexpr goby::middleware::Group salinity{"jaiabot::salinity"};
 
 // low control
 constexpr goby::middleware::Group vehicle_command{"jaiabot::vehicle_command"};
@@ -51,13 +50,17 @@ constexpr goby::middleware::Group desired_setpoints{"jaiabot::desired_setpoints"
 
 // mission manager
 constexpr goby::middleware::Group mission_report{"jaiabot::mission_report"};
-constexpr goby::middleware::Group mission_ivp_behavior_update{"jaiabot::mission_ivp_behavior_update"};
-constexpr goby::middleware::Group mission_ivp_behavior_report{"jaiabot::mission_ivp_behavior_report"};
+constexpr goby::middleware::Group mission_ivp_behavior_update{
+    "jaiabot::mission_ivp_behavior_update"};
+constexpr goby::middleware::Group mission_ivp_behavior_report{
+    "jaiabot::mission_ivp_behavior_report"};
 
 // DCCL (intervehicle)
 constexpr goby::middleware::Group bot_status{"jaiabot::bot_status",
                                              goby::middleware::Group::broadcast_group};
 constexpr goby::middleware::Group hub_command{"jaiabot::hub_command",
+                                              goby::middleware::Group::broadcast_group};
+constexpr goby::middleware::Group dive_packet{"jaiabot::dive_packet",
                                               goby::middleware::Group::broadcast_group};
 
 // pid-control-web

--- a/src/lib/messages/jaia_dccl.proto
+++ b/src/lib/messages/jaia_dccl.proto
@@ -131,11 +131,8 @@ message BotStatus
 
     optional MissionState mission_state = 40;
 
-    optional double salinity = 51 [(dccl.field) = {
-            min: 0
-            max: 100
-            precision: 1
-        }];
+    optional double salinity = 51
+        [(dccl.field) = { min: 0 max: 100 precision: 1 }];
 
     optional double temperature = 52 [(dccl.field) = {
         min: -50
@@ -143,5 +140,74 @@ message BotStatus
         precision: 2
         units { derived_dimensions: "temperature" system: "celsius" }
     }];
+}
 
+message DivePacket
+{
+    option (dccl.msg) = {
+        id: 0x5001
+        max_bytes: 200
+        codec_version: 3
+        unit_system: "si"
+    };
+
+    required uint32 bot_id = 1 [(dccl.field) = { min: 0 max: 255 }];
+    required uint64 start_time = 2 [(dccl.field) = {
+        codec: "dccl.time2"
+        units { prefix: "micro" derived_dimensions: "time" }
+    }];
+    required uint64 end_time = 3 [(dccl.field) = {
+        codec: "dccl.time2"
+        units { prefix: "micro" derived_dimensions: "time" }
+    }];
+
+    required double dive_rate = 10 [(dccl.field) = {
+        min: 0
+        max: 10
+        precision: 1
+        units { derived_dimensions: "velocity" }
+    }];
+
+    required double unpowered_rise_rate = 11 [(dccl.field) = {
+        min: 0
+        max: 10
+        precision: 1
+        units { derived_dimensions: "velocity" }
+    }];
+
+    optional double powered_rise_rate = 12 [(dccl.field) = {
+        min: 0
+        max: 10
+        precision: 1
+        units { derived_dimensions: "velocity" }
+    }];
+
+    required double depth_achieved = 13 [(dccl.field) = {
+        min: 0
+        max: 100
+        precision: 1
+        units: { derived_dimensions: "length" }
+    }];
+
+    message Measurements
+    {
+        optional double mean_depth = 1 [(dccl.field) = {
+            min: 0
+            max: 100
+            precision: 1
+            units: { derived_dimensions: "length" }
+        }];
+
+        optional double mean_temperature = 2 [(dccl.field) = {
+            min: -1
+            max: 50
+            precision: 1
+            units { derived_dimensions: "temperature" system: "celsius" }
+        }];
+
+        optional double mean_salinity = 3
+            [(dccl.field) = { min: 0 max: 45 precision: 1 }];
+    }
+
+    repeated Measurements measurement = 14 [(dccl.field) = { max_repeat: 50 }];
 }

--- a/src/lib/messages/salinity.proto
+++ b/src/lib/messages/salinity.proto
@@ -6,11 +6,7 @@ package jaiabot.protobuf;
 
 message SalinityData
 {
-
     option (dccl.msg) = {
-        id: 94
-        max_bytes: 64
-        codec_version: 3
         unit_system: "si"
     };
 


### PR DESCRIPTION
See https://trello.com/c/Muyo49H5/22-dive-packets

This DivePacket gets published after each dive over intervehicle, and is currently subscribed for by `jaiabot_hub_manager` which just republishes it on interprocess.

![image](https://user-images.githubusercontent.com/732276/160348340-397c8ce4-a5c2-472f-b00d-32e714a9d143.png)


Still need to figure out "Deceleration indication". 

Also added support to the jaiabot_simulator for temperature and salinity, read off a basic profile in the config file with linear interpolation centering a normal distribution with configurable standard deviations to provide some randomness to the values. These feed into the applicable Goby applications using the string based comma delimited syntax that the python part of the driver produces.