### PR TITLE
Fix race condition for datum updates at the start of the mission

### DIFF
--- a/config/launch/simulation/bot.launch
+++ b/config/launch/simulation/bot.launch
@@ -24,4 +24,6 @@ goby_logger <(../../gen/bot.py goby_logger)
 # simulator MOOS components
 [kill=SIGTERM] MOOSDB /tmp/jaiabot_sim_${jaia_bot_index}.moos
 [kill=SIGTERM] uSimMarine /tmp/jaiabot_sim_${jaia_bot_index}.moos
-[kill=SIGTERM] pMarinePID /tmp/jaiabot_sim_${jaia_bot_index}.moos
+# [kill=SIGTERM] pMarinePID /tmp/jaiabot_sim_${jaia_bot_index}.moos
+
+jaiabot_pid_control <(../../gen/bot.py jaiabot_pid_control)

--- a/src/lib/moos_gateway/jaiabot_gateway_plugin.cpp
+++ b/src/lib/moos_gateway/jaiabot_gateway_plugin.cpp
@@ -24,6 +24,20 @@ extern "C"
 void jaiabot::moos::IvPHelmTranslation::publish_bhv_update(
     const protobuf::IvPBehaviorUpdate& update)
 {
+    // if we're waiting for the new NAV_* to be published post datum update,
+    // hold back on publishing this update until we get a new NAV_X
+    if (pending_datum_update_)
+    {
+        glog.is_debug1() &&
+            glog << "Waiting on NAV_* to be republished before writing a new IvPBehaviorUpdate"
+                 << std::endl;
+        pending_bhv_update_.reset(new protobuf::IvPBehaviorUpdate(update));
+        return;
+    }
+
+    glog.is_debug1() && glog << "Processing IvPBehaviorUpdate: " << update.ShortDebugString()
+                             << std::endl;
+
     // we don't want the Helm in Park ever
     moos().comms().Notify("MOOS_MANUAL_OVERRIDE", "false");
 

--- a/src/lib/moos_gateway/jaiabot_gateway_plugin.h
+++ b/src/lib/moos_gateway/jaiabot_gateway_plugin.h
@@ -17,6 +17,28 @@ class IvPHelmTranslation : public goby::moos::Translator
     IvPHelmTranslation(const goby::apps::moos::protobuf::GobyMOOSGatewayConfig& cfg)
         : goby::moos::Translator(cfg)
     {
+        // once get a datum update, wait until the next NAV_X (published from NodeStatus)
+        // before we send any new IvPBehaviorUpdate messages. If not, we can get a race condition where
+        // the Helm completes a Transit if the current position (in X,Y) is the same as the recovery position (in X,Y).
+        goby().interprocess().subscribe<goby::middleware::groups::datum_update>(
+            [this](const goby::middleware::protobuf::DatumUpdate& datum_update) {
+                goby::glog.is_debug1() && goby::glog << "Datum update received." << std::endl;
+                pending_datum_update_ = true;
+            });
+        // use NAV_X as a proxy for a new full NAV_* update (via goby::moos::FrontSeatTranslation from NodeStatus)
+        // once received, flush any pending update
+        moos().add_trigger("NAV_X", [this](const CMOOSMsg&) {
+            pending_datum_update_ = false;
+            if (pending_bhv_update_)
+            {
+                goby::glog.is_debug1() &&
+                    goby::glog << "NAV_X received, flushing pending IvPBehaviorUpdate" << std::endl;
+
+                publish_bhv_update(*pending_bhv_update_);
+                pending_bhv_update_.reset();
+            }
+        });
+
         goby().interprocess().subscribe<jaiabot::groups::mission_ivp_behavior_update>(
             [this](const protobuf::IvPBehaviorUpdate& update) { publish_bhv_update(update); });
 
@@ -25,7 +47,6 @@ class IvPHelmTranslation : public goby::moos::Translator
                 moos().comms().Notify("JAIABOT_MISSION_STATE",
                                       jaiabot::protobuf::MissionState_Name(report.state()));
             });
-
         moos().add_trigger("JAIABOT_TRANSIT_COMPLETE", [this](const CMOOSMsg& msg) {
             if (msg.GetString() == "true")
             {
@@ -38,7 +59,12 @@ class IvPHelmTranslation : public goby::moos::Translator
 
   private:
     void publish_bhv_update(const protobuf::IvPBehaviorUpdate& update);
-};
+
+  private:
+    bool pending_datum_update_{false};
+    std::unique_ptr<protobuf::IvPBehaviorUpdate> pending_bhv_update_;
+
+}; // namespace moos
 
 } // namespace moos
 } // namespace jaiabot


### PR DESCRIPTION
- Fixes problem where the vehicle might go straight into Recovery Station Keep if the IvP Behavior update is received before the recalculated NAV_X/NAV_Y position.
