### PR TITLE
Log MOOS publications and configuration messages

### DIFF
--- a/cmake/FindProtobufLocal.cmake
+++ b/cmake/FindProtobufLocal.cmake
@@ -70,7 +70,10 @@ endfunction()
 
 function(PROTOBUF_GENERATE_CPP SRCS HDRS CPP_OUT_DIR)
   protobuf_include_dirs(${CMAKE_CURRENT_BINARY_DIR})
-
+  # so that we can use Google's included descriptor.proto
+  protobuf_include_dirs(${PROTOBUF_INCLUDE_DIR})
+ 
+  
   if(NOT ARGN)
     message(SEND_ERROR "Error: PROTOBUF_GENERATE_CPP() called without any proto files")
     return()
@@ -95,7 +98,7 @@ function(PROTOBUF_GENERATE_CPP SRCS HDRS CPP_OUT_DIR)
     else() # avoid an extra /
       set(FULL_OUT_DIR "${CPP_OUT_DIR}")
     endif()
-    
+
     list(APPEND ${SRCS} "${FULL_OUT_DIR}/${FIL_WE}.pb.cc")
     list(APPEND ${HDRS} "${FULL_OUT_DIR}/${FIL_WE}.pb.h")   
 
@@ -103,8 +106,12 @@ function(PROTOBUF_GENERATE_CPP SRCS HDRS CPP_OUT_DIR)
     # files correctly for later inclusion into other protos (Protobuf is picky about this)
     set(FIL_DEST ${FULL_OUT_DIR}/${FIL_WE}.proto)
 
-    # copy proto to destination 
-    configure_file(${FIL_WE}.proto ${FIL_DEST} COPYONLY)
+    # copy proto to destination
+    if(EXISTS ${ABS_FIL})
+      configure_file(${ABS_FIL} ${FIL_DEST} COPYONLY)
+    else()
+      configure_file(${FIL_WE}.proto ${FIL_DEST} COPYONLY)
+    endif()
     
     add_custom_command(
       OUTPUT "${FULL_OUT_DIR}/${FIL_WE}.pb.cc"
@@ -184,9 +191,6 @@ endfunction()
 
 
 find_path(PROTOBUF_INCLUDE_DIR google/protobuf/service.h)
-
-# so that we can use Google's included descriptor.proto
-list(APPEND ALL_PROTOBUF_INCLUDE_DIRS "-I${PROTOBUF_INCLUDE_DIR}")
 
 
 # Google's provided vcproj files generate libraries with a "lib"

--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -72,6 +72,10 @@ if common.app == 'gobyd':
                                      interprocess_block = interprocess_common,
                                      link_block=link_block,
                                      persist_subscriptions='persist_subscriptions { name: "bot" dir: "' + debug_log_file_dir + '" }'))
+elif common.app == 'goby_coroner':    
+    print(config.template_substitute(templates_dir+'/goby_coroner.pb.cfg.in',
+                                     app_block=app_common,
+                                     interprocess_block = interprocess_common))
 elif common.app == 'goby_logger':    
     print(config.template_substitute(templates_dir+'/goby_logger.pb.cfg.in',
                                      app_block=app_common,

--- a/config/gen/hub.py
+++ b/config/gen/hub.py
@@ -74,6 +74,10 @@ elif common.app == 'goby_opencpn_interface':
     print(config.template_substitute(templates_dir+'/hub/goby_opencpn_interface.pb.cfg.in',
                                      app_block=app_common,
                                      interprocess_block = interprocess_common))
+elif common.app == 'goby_coroner':    
+    print(config.template_substitute(templates_dir+'/goby_coroner.pb.cfg.in',
+                                     app_block=app_common,
+                                     interprocess_block = interprocess_common))
 elif common.app == 'goby_liaison':
     print(config.template_substitute(templates_dir+'/goby_liaison.pb.cfg.in',
                                      app_block=app_common,

--- a/config/launch/standard/bot.launch
+++ b/config/launch/standard/bot.launch
@@ -1,4 +1,7 @@
-#!/usr/bin/env -S goby_launch -L -P -d 1000
+#!/usr/bin/env -S goby_launch -L -P -d 100
+
+# start this first so it's done before we get to the MOOS parts
+[kill=SIGTERM] ../../gen/moos_gen.sh
 
 [kill=SIGTERM] gpsd $(../../gen/bot.py gpsd)
 
@@ -14,7 +17,6 @@ goby_gps <(../../gen/bot.py goby_gps)
 goby_logger <(../../gen/bot.py goby_logger)
 
 # vehicle MOOS components
-[kill=SIGTERM] ../../gen/moos_gen.sh
 [kill=SIGTERM] MOOSDB /tmp/jaiabot_${jaia_bot_index}.moos
 [kill=SIGTERM] pHelmIvP /tmp/jaiabot_${jaia_bot_index}.moos
 #[kill=SIGTERM] pMarineViewer /tmp/jaiabot_pmv_${jaia_bot_index}.moos
@@ -27,3 +29,5 @@ goby_logger <(../../gen/bot.py goby_logger)
 # [kill=SIGTERM] pMarinePID /tmp/jaiabot_sim_${jaia_bot_index}.moos
 
 jaiabot_pid_control <(../../gen/bot.py jaiabot_pid_control)
+
+goby_coroner <(../../gen/bot.py goby_coroner) --expected_name goby_liaison --expected_name jaiabot_simulator --expected_name jaiabot_fusion --expected_name jaiabot_bluerobotics_pressure_sensor_driver --expected_name jaiabot_mission_manager --expected_name goby_gps --expected_name goby_logger --expected_name jaiabot_metadata --expected jaiabot_pid_control

--- a/config/launch/standard/hub.launch
+++ b/config/launch/standard/hub.launch
@@ -5,6 +5,9 @@ goby_liaison_jaiabot <(../../gen/hub.py goby_liaison)
 jaiabot_hub_manager <(../../gen/hub.py jaiabot_hub_manager) -v
 jaiabot_web_portal <(../../gen/hub.py jaiabot_web_portal) -v
 goby_logger <(../../gen/hub.py goby_logger)
+jaiabot_metadata <(../../gen/hub.py jaiabot_metadata)
 
 goby_opencpn_interface <(../../gen/hub.py goby_opencpn_interface)
 [kill=SIGTERM] socat tcp:localhost:30100 pty,link=/tmp/pty_jaiahub,raw,echo=0
+
+goby_coroner <(../../gen/hub.py goby_coroner) --expected_name goby_liaison --expected_name jaiabot_hub_manager --expected_name jaiabot_web_portal --expected_name jaiabot_metadata

--- a/config/launch/standard/hub.launch
+++ b/config/launch/standard/hub.launch
@@ -4,3 +4,7 @@ gobyd <(../../gen/hub.py gobyd) -zzz -n
 goby_liaison_jaiabot <(../../gen/hub.py goby_liaison)
 jaiabot_hub_manager <(../../gen/hub.py jaiabot_hub_manager) -v
 jaiabot_web_portal <(../../gen/hub.py jaiabot_web_portal) -v
+goby_logger <(../../gen/hub.py goby_logger)
+
+goby_opencpn_interface <(../../gen/hub.py goby_opencpn_interface)
+[kill=SIGTERM] socat tcp:localhost:30100 pty,link=/tmp/pty_jaiahub,raw,echo=0

--- a/config/launch/standard/preseed.goby
+++ b/config/launch/standard/preseed.goby
@@ -4,8 +4,10 @@ export goby3_lib_dir=$(realpath "$(dirname $(which gobyd))/../lib")
 export jaia_lib_dir=$(realpath "$(dirname $(which jaiabot_single_thread_pattern))/../lib")
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${goby3_lib_dir}:${jaia_lib_dir}
 
-export jaia_max_number_vehicles=128
-
 export GOBY_MODEMDRIVER_PLUGINS=libxbee.so
 
+# defaults so we can run ./hub.launch and ./bot.launch for a single bot test
+[ -z "${jaia_bot_index}" ] && export jaia_bot_index=0
 [ -z "${jaia_fleet_index}" ] && export jaia_fleet_index=0
+[ -z "${jaia_n_bots}" ] && export jaia_n_bots=1
+[ -z "${jaia_mode}" ] && export jaia_mode=simulation

--- a/config/templates/bot/goby_moos_gateway.pb.cfg.in
+++ b/config/templates/bot/goby_moos_gateway.pb.cfg.in
@@ -7,3 +7,9 @@ moos {
 }
 
 poll_frequency: 10
+
+[jaiabot.protobuf.jaiabot_config] {
+# double dollar sign because of the python Template becomes single
+    logging_omit_var_regex: "^.*_ITER_GAP$$|^.*_ITER_LEN$$|^.*_STATUS$$|^APPCAST$$|^GOBY_MOOS_TRANSLATOR_TIME$$|^DB_VARSUMMARY$$|^DB_RWSUMMARY$$"
+#  logging_omit_app_regex: ""
+}

--- a/config/templates/goby_coroner.pb.cfg.in
+++ b/config/templates/goby_coroner.pb.cfg.in
@@ -1,4 +1,2 @@
 $app_block
 $interprocess_block
-
-expected_name: ["goby_frontseat_interface", "goby_liaison", "goby3_course_usv_manager", "goby_liaison"]

--- a/config/templates/goby_liaison.pb.cfg.in
+++ b/config/templates/goby_liaison.pb.cfg.in
@@ -4,6 +4,8 @@ $interprocess_block
 http_address: "0.0.0.0"
 http_port: $http_port
 load_shared_library: "libjaiabot_messages.so.1"
+load_shared_library: "libjaiabot_config.so.1"
+load_shared_library: "libjaiabot_liaison.so.1"
 
 pb_commander_config {
     $load_protobufs

--- a/config/templates/goby_logger.pb.cfg.in
+++ b/config/templates/goby_logger.pb.cfg.in
@@ -3,3 +3,6 @@ $interprocess_block
 
 log_dir: "$goby_logger_dir"
 load_shared_library: "libjaiabot_messages.so.1"
+# order matters - load the jaiabot_config extension first
+load_shared_library: "libjaiabot_liaison.so.1"
+load_shared_library: "libjaiabot_config.so.1"

--- a/config/templates/gobyd.pb.cfg.in
+++ b/config/templates/gobyd.pb.cfg.in
@@ -5,3 +5,8 @@ intervehicle {
     $link_block
     $persist_subscriptions
 }
+
+hold {
+  # don't allow any apps to publish until the logger is ready
+  required_client: "goby_logger"
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,3 +10,14 @@ if(build_doc)
   install(DIRECTORY ${project_BUILD_DIR}/src/doc/figures DESTINATION share/doc/jaiabot)
 
 endif()
+
+# library with all the config.protos
+file(GLOB_RECURSE CONFIG_PROTOS  RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}  "bin/*/config.proto")
+
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS
+  ${project_INC_DIR}
+  ${CONFIG_PROTOS}
+  )
+add_library(jaiabot_config SHARED ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(jaiabot_config ${PROTOBUF_LIBRARIES} jaiabot_messages goby goby_zeromq goby_moos)
+project_install_lib(jaiabot_config)

--- a/src/bin/dev/bot/config.proto
+++ b/src/bin/dev/bot/config.proto
@@ -28,7 +28,7 @@ import "goby/middleware/protobuf/serial_config.proto";
 
 package jaiabot.config;
 
-message ControlSurfacesTest
+message BotDevTest
 {
     // required parameters for ApplicationBase3 class
     optional goby.middleware.protobuf.AppConfig app = 1;

--- a/src/bin/dev/hub/app.cpp
+++ b/src/bin/dev/hub/app.cpp
@@ -49,10 +49,10 @@ namespace jaiabot
 {
 namespace apps
 {
-class ControlSurfacesTest : public zeromq::MultiThreadApplication<config::ControlSurfacesTest>
+class HubDevTest : public zeromq::MultiThreadApplication<config::HubDevTest>
 {
   public:
-    ControlSurfacesTest();
+    HubDevTest();
 
   private:
     std::unique_ptr<goby::util::UTMGeodesy> geodesy_;
@@ -66,14 +66,14 @@ class ControlSurfacesTest : public zeromq::MultiThreadApplication<config::Contro
 
 int main(int argc, char* argv[])
 {
-    return goby::run<jaiabot::apps::ControlSurfacesTest>(
-        goby::middleware::ProtobufConfigurator<config::ControlSurfacesTest>(argc, argv));
+    return goby::run<jaiabot::apps::HubDevTest>(
+        goby::middleware::ProtobufConfigurator<config::HubDevTest>(argc, argv));
 }
 
 // Main thread
 
-jaiabot::apps::ControlSurfacesTest::ControlSurfacesTest()
-    : zeromq::MultiThreadApplication<config::ControlSurfacesTest>(10 * si::hertz)
+jaiabot::apps::HubDevTest::HubDevTest()
+    : zeromq::MultiThreadApplication<config::HubDevTest>(10 * si::hertz)
 {
     glog.add_group("main", goby::util::Colors::yellow);
     glog.add_group("debug", goby::util::Colors::red);
@@ -157,4 +157,4 @@ jaiabot::apps::ControlSurfacesTest::ControlSurfacesTest()
 
 }
 
-void jaiabot::apps::ControlSurfacesTest::loop() {}
+void jaiabot::apps::HubDevTest::loop() {}

--- a/src/bin/dev/hub/config.proto
+++ b/src/bin/dev/hub/config.proto
@@ -28,7 +28,7 @@ import "goby/middleware/protobuf/serial_config.proto";
 
 package jaiabot.config;
 
-message ControlSurfacesTest
+message HubDevTest
 {
     // required parameters for ApplicationBase3 class
     optional goby.middleware.protobuf.AppConfig app = 1;

--- a/src/bin/jaiabot_metadata/app.cpp
+++ b/src/bin/jaiabot_metadata/app.cpp
@@ -36,38 +36,42 @@ using namespace jaiabot::groups;
 
 using goby::glog;
 namespace si = boost::units::si;
-using ApplicationBase =
-    goby::zeromq::SingleThreadApplication<jaiabot::config::SingleThreadPattern>;
+using ApplicationBase = goby::zeromq::SingleThreadApplication<jaiabot::config::Metadata>;
 
 namespace jaiabot
 {
 namespace apps
 {
-class SingleThreadPattern : public ApplicationBase
+class Metadata : public ApplicationBase
 {
   public:
-    SingleThreadPattern() : ApplicationBase(0.0 * si::hertz) {
-      auto jaia_name_c = getenv("JAIA_DEVICE_NAME");
-      string jaia_device_name;
-      if (jaia_name_c) {
-        jaia_device_name = string(jaia_name_c);
-      }
-      else {
-        char buffer[256];
-        if (gethostname(buffer, 256) == 0) {
-          jaia_device_name = string(buffer);
+    Metadata() : ApplicationBase(0.0 * si::hertz)
+    {
+        auto jaia_name_c = getenv("JAIA_DEVICE_NAME");
+        string jaia_device_name;
+        if (jaia_name_c)
+        {
+            jaia_device_name = string(jaia_name_c);
         }
-        else {
-          jaia_device_name = "<No Name>";
+        else
+        {
+            char buffer[256];
+            if (gethostname(buffer, 256) == 0)
+            {
+                jaia_device_name = string(buffer);
+            }
+            else
+            {
+                jaia_device_name = "<No Name>";
+            }
         }
-      }
 
-      glog.is_verbose() && glog << "jaia_device_name = " << jaia_device_name << endl;
+        glog.is_verbose() && glog << "jaia_device_name = " << jaia_device_name << endl;
 
-      auto metadata = DeviceMetadata();
-      metadata.set_name(jaia_device_name);
+        auto metadata = DeviceMetadata();
+        metadata.set_name(jaia_device_name);
 
-      interprocess().publish<jaia_metadata>(metadata);
+        interprocess().publish<jaia_metadata>(metadata);
     }
 
   private:
@@ -78,12 +82,11 @@ class SingleThreadPattern : public ApplicationBase
 
 int main(int argc, char* argv[])
 {
-    return goby::run<jaiabot::apps::SingleThreadPattern>(
-        goby::middleware::ProtobufConfigurator<jaiabot::config::SingleThreadPattern>(argc,
-                                                                                          argv));
+    return goby::run<jaiabot::apps::Metadata>(
+        goby::middleware::ProtobufConfigurator<jaiabot::config::Metadata>(argc, argv));
 }
 
-void jaiabot::apps::SingleThreadPattern::loop()
+void jaiabot::apps::Metadata::loop()
 {
     // called at frequency passed to SingleThreadApplication (ApplicationBase)
 }

--- a/src/bin/jaiabot_metadata/config.proto
+++ b/src/bin/jaiabot_metadata/config.proto
@@ -27,7 +27,7 @@ import "goby/zeromq/protobuf/interprocess_config.proto";
 
 package jaiabot.config;
 
-message SingleThreadPattern
+message Metadata
 {
     // required parameters for ApplicationBase3 class
     optional goby.middleware.protobuf.AppConfig app = 1;

--- a/src/lib/groups.h
+++ b/src/lib/groups.h
@@ -73,6 +73,9 @@ constexpr goby::middleware::Group control_surfaces_ack{"jaiabot::control_surface
 // Metadata
 constexpr goby::middleware::Group jaia_metadata{"jaiabot::metadata"};
 
+// MOOS
+constexpr goby::middleware::Group moos{"jaiabot::moos"};
+
 } // namespace groups
 } // namespace jaiabot
 

--- a/src/lib/liaison/CMakeLists.txt
+++ b/src/lib/liaison/CMakeLists.txt
@@ -1,10 +1,12 @@
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR} config.proto)
 
 add_library(jaiabot_liaison SHARED jaiabot_liaison_load.cpp liaison_jaiabot.cpp ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(jaiabot_liaison goby goby_zeromq ${Boost_LIBRARIES} jaiabot_messages)
+target_link_libraries(jaiabot_liaison goby goby_zeromq ${Boost_LIBRARIES} jaiabot_messages wt)
 
 configure_file(goby_liaison_jaiabot.in ${project_BIN_DIR}/goby_liaison_jaiabot @ONLY)
 
 if(export_goby_interfaces)
   generate_interfaces(jaiabot_liaison)
 endif()
+
+project_install_lib(jaiabot_liaison)

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -19,7 +19,7 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${project_INC_DIR}
   )
 
 add_library(jaiabot_messages SHARED ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(jaiabot_messages ${PROTOBUF_LIBRARIES})
+target_link_libraries(jaiabot_messages ${PROTOBUF_LIBRARIES} goby)
 
 project_install_lib(jaiabot_messages)
 

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -15,6 +15,7 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${project_INC_DIR}
   jaiabot/messages/vehicle_command.proto
   jaiabot/messages/portal.proto
   jaiabot/messages/metadata.proto
+  jaiabot/messages/moos.proto
   )
 
 add_library(jaiabot_messages SHARED ${PROTO_SRCS} ${PROTO_HDRS})

--- a/src/lib/messages/moos.proto
+++ b/src/lib/messages/moos.proto
@@ -1,0 +1,31 @@
+syntax = "proto2";
+
+import "dccl/option_extensions.proto";
+
+package jaiabot.protobuf;
+
+// Protobuf version of CMOOSMsg
+message MOOSMessage
+{
+    enum Type
+    {
+        TYPE_DOUBLE = 0x44;         // 'D'
+        TYPE_STRING = 0x53;         // 'S'
+        TYPE_BINARY_STRING = 0x42;  // 'B'
+    }
+    required Type type = 1;
+    required string key = 2;
+
+    oneof value
+    {
+        string svalue = 3;
+        double dvalue = 4;
+        bytes bvalue = 5;
+    }
+
+    required double unixtime = 6;
+    required int32 id = 7;
+    required string source = 8;
+    optional string source_aux = 9;
+    required string community = 10;
+}

--- a/src/lib/moos_gateway/CMakeLists.txt
+++ b/src/lib/moos_gateway/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LIB jaiabot_moos_gateway_plugin)
-add_library(${LIB} SHARED jaiabot_gateway_plugin.cpp)
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR} config.proto)
+add_library(${LIB} SHARED jaiabot_gateway_plugin.cpp ${PROTO_SRCS} ${PROTO_HDRS})
 target_link_libraries(${LIB}
   goby goby_zeromq goby_moos jaiabot_messages)
 

--- a/src/lib/moos_gateway/CMakeLists.txt
+++ b/src/lib/moos_gateway/CMakeLists.txt
@@ -7,3 +7,4 @@ target_link_libraries(${LIB}
 if(export_goby_interfaces)
   generate_interfaces(${LIB})
 endif()
+project_install_lib(${LIB})

--- a/src/lib/moos_gateway/config.proto
+++ b/src/lib/moos_gateway/config.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+import "goby/moos/protobuf/moos_gateway_config.proto";
+import "dccl/option_extensions.proto";
+
+package jaiabot.protobuf;
+
+message MOOSGatewayConfig
+{
+    optional string logging_omit_var_regex = 1;
+    optional string logging_omit_app_regex = 2;
+}
+
+extend .goby.apps.moos.protobuf.GobyMOOSGatewayConfig
+{
+    optional MOOSGatewayConfig jaiabot_config = 1001;
+}

--- a/src/lib/moos_gateway/jaiabot_gateway_plugin.cpp
+++ b/src/lib/moos_gateway/jaiabot_gateway_plugin.cpp
@@ -10,6 +10,7 @@ extern "C"
         goby::zeromq::MultiThreadApplication<goby::apps::moos::protobuf::GobyMOOSGatewayConfig>*
             handler)
     {
+        handler->launch_thread<jaiabot::moos::AllMessagesForLoggingTranslation>();
         handler->launch_thread<jaiabot::moos::IvPHelmTranslation>();
     }
 
@@ -18,6 +19,7 @@ extern "C"
             handler)
     {
         handler->join_thread<jaiabot::moos::IvPHelmTranslation>();
+        handler->join_thread<jaiabot::moos::AllMessagesForLoggingTranslation>();
     }
 }
 

--- a/src/lib/moos_gateway/jaiabot_gateway_plugin.h
+++ b/src/lib/moos_gateway/jaiabot_gateway_plugin.h
@@ -6,7 +6,9 @@
 
 #include "jaiabot/groups.h"
 #include "jaiabot/messages/mission.pb.h"
+#include "jaiabot/messages/moos.pb.h"
 
+#include "config.pb.h"
 namespace jaiabot
 {
 namespace moos
@@ -38,6 +40,49 @@ class IvPHelmTranslation : public goby::moos::Translator
 
   private:
     void publish_bhv_update(const protobuf::IvPBehaviorUpdate& update);
+};
+
+class AllMessagesForLoggingTranslation : public goby::moos::Translator
+{
+  public:
+    AllMessagesForLoggingTranslation(const goby::apps::moos::protobuf::GobyMOOSGatewayConfig& cfg)
+        : goby::moos::Translator(cfg),
+          jaiabot_cfg_(cfg.GetExtension(jaiabot::protobuf::jaiabot_config)),
+          omit_var_(jaiabot_cfg_.logging_omit_var_regex()),
+          omit_app_(jaiabot_cfg_.logging_omit_app_regex())
+    {
+        moos().add_wildcard_trigger("*", "*", [this](const CMOOSMsg& msg) {
+            if (jaiabot_cfg_.has_logging_omit_var_regex() &&
+                std::regex_match(msg.m_sKey, omit_var_))
+                return;
+            if (jaiabot_cfg_.has_logging_omit_app_regex() &&
+                std::regex_match(msg.m_sSrc, omit_app_))
+                return;
+
+            protobuf::MOOSMessage pb_msg;
+            pb_msg.set_type(static_cast<protobuf::MOOSMessage::Type>(msg.m_cDataType));
+            pb_msg.set_key(msg.m_sKey);
+            switch (pb_msg.type())
+            {
+                case protobuf::MOOSMessage::TYPE_DOUBLE: pb_msg.set_dvalue(msg.m_dfVal); break;
+                case protobuf::MOOSMessage::TYPE_STRING: pb_msg.set_svalue(msg.m_sVal); break;
+                case protobuf::MOOSMessage::TYPE_BINARY_STRING:
+                    pb_msg.set_bvalue(msg.m_sVal);
+                    break;
+            }
+            pb_msg.set_unixtime(msg.m_dfTime);
+            pb_msg.set_id(msg.m_nID);
+            pb_msg.set_source(msg.m_sSrc);
+            pb_msg.set_source_aux(msg.m_sSrcAux);
+            pb_msg.set_community(msg.m_sOriginatingCommunity);
+            interprocess().publish<jaiabot::groups::moos>(pb_msg);
+        });
+    }
+
+  private:
+    const jaiabot::protobuf::MOOSGatewayConfig jaiabot_cfg_;
+    std::regex omit_var_;
+    std::regex omit_app_;
 };
 
 } // namespace moos


### PR DESCRIPTION
1. Log all MOOS variables (except those excluded by a regex) to the Goby Log by publishing them into a Protobuf equivalent (in moos.proto)
2. Support logging of configuration to "goby::configuration" (requires yet-to-be merged https://github.com/GobySoft/goby3/pull/242)
3. Added `goby_coroner` to standard launch scripts for reporting whether apps are running or not (more to come on this).