### PR TITLE
Only set datum using new mission in initial PreDeploy state, not during Replan

### DIFF
--- a/config/launch/standard/all.launch
+++ b/config/launch/standard/all.launch
@@ -1,7 +1,4 @@
 #!/usr/bin/env -S goby_launch -s -P -k30 -pall -d500 -L
 
-[env=jaia_n_bots=4,env=jaia_mode=simulation] goby_launch -P -d100 hub.launch
-[env=jaia_n_bots=4,env=jaia_bot_index=0,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
-[env=jaia_n_bots=4,env=jaia_bot_index=1,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
-[env=jaia_n_bots=4,env=jaia_bot_index=2,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
-[env=jaia_n_bots=4,env=jaia_bot_index=3,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=1,env=jaia_mode=simulation] goby_launch -P -d100 hub.launch
+[env=jaia_n_bots=1,env=jaia_bot_index=0,env=jaia_mode=simulation] goby_launch -P -d100 bot.launch


### PR DESCRIPTION
Hopefully this will solve the pesty race condition causing pHelmIvP to declare the mission point reached on single-point back-to-back missions.