### PR TITLE
Set active goal in bot status message

### DIFF
--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -32,12 +32,12 @@
 
 #include "config.pb.h"
 #include "jaiabot/groups.h"
+#include "jaiabot/messages/control_surfaces.pb.h"
+#include "jaiabot/messages/engineering.pb.h"
+#include "jaiabot/messages/imu.pb.h"
 #include "jaiabot/messages/jaia_dccl.pb.h"
 #include "jaiabot/messages/pressure_temperature.pb.h"
-#include "jaiabot/messages/imu.pb.h"
-#include "jaiabot/messages/control_surfaces.pb.h"
 #include "jaiabot/messages/salinity.pb.h"
-#include "jaiabot/messages/engineering.pb.h"
 
 #include "wmm/WMM.h"
 
@@ -48,7 +48,6 @@ using namespace std;
 
 namespace si = boost::units::si;
 using ApplicationBase = goby::zeromq::SingleThreadApplication<jaiabot::config::Fusion>;
-
 
 namespace jaiabot
 {
@@ -71,8 +70,10 @@ class Fusion : public ApplicationBase
 
         latest_bot_status_.set_time_with_units(unwarped_time);
 
-        if (latest_bot_status_.IsInitialized()) {
-            glog.is_debug1() && glog << "Publishing bot status over intervehicle(): " << latest_bot_status_.ShortDebugString() << endl;
+        if (latest_bot_status_.IsInitialized())
+        {
+            glog.is_debug1() && glog << "Publishing bot status over intervehicle(): "
+                                     << latest_bot_status_.ShortDebugString() << endl;
             intervehicle().publish<jaiabot::groups::bot_status>(latest_bot_status_);
         }
     }
@@ -110,9 +111,13 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(2 * si::hertz)
 
             if (att.has_heading())
             {
-                auto magneticDeclination = wmm.magneticDeclination(latest_node_status_.global_fix().lon(), latest_node_status_.global_fix().lat());
-                glog.is_debug2() && glog << "Location: " << latest_node_status_.global_fix().ShortDebugString() << "  Magnetic declination: " << magneticDeclination << endl;
-                auto heading = att.heading_with_units() + magneticDeclination * boost::units::degree::plane_angle();
+                auto magneticDeclination = wmm.magneticDeclination(
+                    latest_node_status_.global_fix().lon(), latest_node_status_.global_fix().lat());
+                glog.is_debug2() &&
+                    glog << "Location: " << latest_node_status_.global_fix().ShortDebugString()
+                         << "  Magnetic declination: " << magneticDeclination << endl;
+                auto heading =
+                    att.heading_with_units() + magneticDeclination * boost::units::degree::degrees;
                 latest_node_status_.mutable_pose()->set_heading_with_units(heading);
                 latest_bot_status_.mutable_attitude()->set_heading_with_units(heading);
             }
@@ -124,44 +129,49 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(2 * si::hertz)
                 latest_bot_status_.mutable_attitude()->set_roll_with_units(roll);
             }
         });
-    interprocess().subscribe<groups::imu>(
-        [this](const jaiabot::protobuf::IMUData& imu_data) {
-            glog.is_debug1() && glog << "Received Attitude update from IMU: " << imu_data.ShortDebugString()
-                                     << std::endl;
+    interprocess().subscribe<groups::imu>([this](const jaiabot::protobuf::IMUData& imu_data) {
+        glog.is_debug1() && glog << "Received Attitude update from IMU: "
+                                 << imu_data.ShortDebugString() << std::endl;
 
-            auto euler_angles = imu_data.euler_angles();
+        auto euler_angles = imu_data.euler_angles();
 
-            if (euler_angles.has_alpha())
+        if (euler_angles.has_alpha())
+        {
+            using boost::units::degree::degrees;
+
+            // This produces a heading that is off by 180 degrees, so we need to rotate it
+            auto heading = euler_angles.alpha_with_units() + 180 * degrees;
+            if (heading > 360 * degrees)
             {
-                // This produces a heading that is off by 180 degrees, so we need to rotate it
-                auto heading = euler_angles.alpha_with_units() + 180 * boost::units::degree::plane_angle();
-                if (heading > 360 * boost::units::degree::plane_angle()) {
-                    heading -= (360 * boost::units::degree::plane_angle());
-                }
-
-                // Apply magnetic declination
-                auto magneticDeclination = wmm.magneticDeclination(latest_node_status_.global_fix().lon(), latest_node_status_.global_fix().lat());
-                glog.is_debug2() && glog << "Location: " << latest_node_status_.global_fix().ShortDebugString() << "  Magnetic declination: " << magneticDeclination << endl;
-                heading = heading + magneticDeclination * boost::units::degree::plane_angle();
-
-                latest_node_status_.mutable_pose()->set_heading_with_units(heading);
-                latest_bot_status_.mutable_attitude()->set_heading_with_units(heading);
+                heading -= (360 * degrees);
             }
 
-            if (euler_angles.has_gamma())
-            {
-                auto pitch = euler_angles.gamma_with_units();
-                latest_node_status_.mutable_pose()->set_pitch_with_units(pitch);
-                latest_bot_status_.mutable_attitude()->set_pitch_with_units(pitch);
-            }
+            // Apply magnetic declination
+            auto magneticDeclination = wmm.magneticDeclination(
+                latest_node_status_.global_fix().lon(), latest_node_status_.global_fix().lat());
+            glog.is_debug2() &&
+                glog << "Location: " << latest_node_status_.global_fix().ShortDebugString()
+                     << "  Magnetic declination: " << magneticDeclination << endl;
+            heading = heading + magneticDeclination * degrees;
 
-            if (euler_angles.has_beta())
-            {
-                auto roll = euler_angles.beta_with_units();
-                latest_node_status_.mutable_pose()->set_roll_with_units(roll);
-                latest_bot_status_.mutable_attitude()->set_roll_with_units(roll);
-            }
-        });
+            latest_node_status_.mutable_pose()->set_heading_with_units(heading);
+            latest_bot_status_.mutable_attitude()->set_heading_with_units(heading);
+        }
+
+        if (euler_angles.has_gamma())
+        {
+            auto pitch = euler_angles.gamma_with_units();
+            latest_node_status_.mutable_pose()->set_pitch_with_units(pitch);
+            latest_bot_status_.mutable_attitude()->set_pitch_with_units(pitch);
+        }
+
+        if (euler_angles.has_beta())
+        {
+            auto roll = euler_angles.beta_with_units();
+            latest_node_status_.mutable_pose()->set_roll_with_units(roll);
+            latest_bot_status_.mutable_attitude()->set_roll_with_units(roll);
+        }
+    });
     interprocess().subscribe<goby::middleware::groups::gpsd::tpv>(
         [this](const goby::middleware::protobuf::gpsd::TimePositionVelocity& tpv) {
             glog.is_debug1() && glog << "Received TimePositionVelocity update: "
@@ -193,7 +203,7 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(2 * si::hertz)
                 latest_bot_status_.mutable_speed()->set_over_ground_with_units(speed);
             }
 
-            if (tpv.has_track()) 
+            if (tpv.has_track())
             {
                 auto track = tpv.track_with_units();
                 latest_node_status_.mutable_pose()->set_course_over_ground_with_units(track);
@@ -212,7 +222,8 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(2 * si::hertz)
                 latest_node_status_.set_time_with_units(time);
             }
 
-            if (latest_node_status_.IsInitialized()) {
+            if (latest_node_status_.IsInitialized())
+            {
                 interprocess().publish<goby::middleware::frontseat::groups::node_status>(
                     latest_node_status_);
             }
@@ -228,7 +239,8 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(2 * si::hertz)
                 -latest_node_status_.global_fix().depth_with_units());
             latest_bot_status_.set_depth_with_units(depth);
 
-            if (pt.has_temperature()) {
+            if (pt.has_temperature())
+            {
                 latest_bot_status_.set_temperature_with_units(pt.temperature_with_units());
             }
         });
@@ -236,6 +248,10 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(2 * si::hertz)
     interprocess().subscribe<jaiabot::groups::mission_report>(
         [this](const protobuf::MissionReport& report) {
             latest_bot_status_.set_mission_state(report.state());
+            if (report.has_active_goal())
+                latest_bot_status_.set_active_goal(report.active_goal());
+            else
+                latest_bot_status_.clear_active_goal();
         });
 
     interprocess().subscribe<jaiabot::groups::control_surfaces_ack>(
@@ -250,12 +266,12 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(2 * si::hertz)
         });
 
     // subscribe for commands, to set last_command_time
-    interprocess().subscribe<jaiabot::groups::engineering_command>([this](const jaiabot::protobuf::Engineering& command) {
-            glog.is_debug1() && glog << "=> " << command.ShortDebugString() << std:: endl;
+    interprocess().subscribe<jaiabot::groups::engineering_command>(
+        [this](const jaiabot::protobuf::Engineering& command) {
+            glog.is_debug1() && glog << "=> " << command.ShortDebugString() << std::endl;
 
             latest_bot_status_.set_last_command_time_with_units(command.time_with_units());
         });
-
 }
 
 void jaiabot::apps::Fusion::init_node_status()

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -212,13 +212,13 @@ struct MissionManagerStateMachine
     MissionManagerStateMachine(apps::MissionManager& a) : app_(a) {}
 
     void set_state(jaiabot::protobuf::MissionState state) { state_ = state; }
-    jaiabot::protobuf::MissionState state() { return state_; }
+    jaiabot::protobuf::MissionState state() const { return state_; }
 
     void set_setpoint_type(jaiabot::protobuf::SetpointType setpoint_type)
     {
         setpoint_type_ = setpoint_type;
     }
-    jaiabot::protobuf::SetpointType setpoint_type() { return setpoint_type_; }
+    jaiabot::protobuf::SetpointType setpoint_type() const { return setpoint_type_; }
 
     apps::MissionManager& app() { return app_; }
     const apps::MissionManager& app() const { return app_; }
@@ -245,9 +245,9 @@ struct MissionManagerStateMachine
         goby::glog.is_debug1() && goby::glog << "Set new mission plan. Updated datum to: "
                                              << update.ShortDebugString() << std::endl;
     }
-    const jaiabot::protobuf::MissionPlan& mission_plan() { return plan_; }
+    const jaiabot::protobuf::MissionPlan& mission_plan() const { return plan_; }
 
-    bool has_geodesy() { return geodesy_ ? true : false; }
+    bool has_geodesy() const { return geodesy_ ? true : false; }
     goby::util::UTMGeodesy& geodesy()
     {
         if (has_geodesy())
@@ -355,6 +355,8 @@ struct InMission
     : boost::statechart::state<InMission, MissionManagerStateMachine, inmission::Underway>,
       AppMethodsAccess<InMission>
 {
+    constexpr static int RECOVERY_GOAL_INDEX{-1};
+
     using StateBase =
         boost::statechart::state<InMission, MissionManagerStateMachine, inmission::Underway>;
 
@@ -364,24 +366,25 @@ struct InMission
     }
     ~InMission() { goby::glog.is_debug1() && goby::glog << "~InMission" << std::endl; }
 
-    int goal_index() { return goal_index_; }
+    int goal_index() const { return goal_index_; }
 
-    boost::optional<protobuf::MissionPlan::Goal> current_goal()
+    boost::optional<protobuf::MissionPlan::Goal> current_goal() const
     {
-        if (goal_index() >= this->machine().mission_plan().goal_size())
+        if (goal_index() >= this->machine().mission_plan().goal_size() ||
+            goal_index() == RECOVERY_GOAL_INDEX)
             return boost::none;
         else
             return boost::optional<protobuf::MissionPlan::Goal>(
                 this->machine().mission_plan().goal(goal_index()));
     }
 
-    protobuf::MissionPlan::Goal final_goal()
+    protobuf::MissionPlan::Goal final_goal() const
     {
         const auto& mission_plan = this->machine().mission_plan();
         return mission_plan.goal(mission_plan.goal_size() - 1);
     }
 
-    boost::optional<protobuf::MissionTask> current_planned_task()
+    boost::optional<protobuf::MissionTask> current_planned_task() const
     {
         if (mission_complete_)
             return boost::none;
@@ -404,6 +407,7 @@ struct InMission
                                                   << std::endl;
 
             set_mission_complete();
+            goal_index_ = RECOVERY_GOAL_INDEX;
         }
     }
 

--- a/src/bin/mission_manager/machine_common.h
+++ b/src/bin/mission_manager/machine_common.h
@@ -36,18 +36,20 @@ template <typename Derived> class AppMethodsAccess
 
     goby::middleware::InterThreadTransporter& interthread() { return app().interthread(); }
 
-    const apps::MissionManager& app() const
-    {
-        return static_cast<const Derived*>(this)->outermost_context().app();
-    }
-
     const config::MissionManager& cfg() const { return this->app().active_cfg(); }
 
     MissionManagerStateMachine& machine()
     {
         return static_cast<Derived*>(this)->outermost_context();
     }
+
+    const MissionManagerStateMachine& machine() const
+    {
+        return static_cast<const Derived*>(this)->outermost_context();
+    }
+
     apps::MissionManager& app() { return machine().app(); }
+    const apps::MissionManager& app() const { return machine().app(); }
 };
 } // namespace statechart
 } // namespace jaiabot

--- a/src/lib/messages/jaia_dccl.proto
+++ b/src/lib/messages/jaia_dccl.proto
@@ -131,6 +131,9 @@ message BotStatus
 
     optional MissionState mission_state = 40;
 
+    // bounds should match MissionPlan.goal max_repeat value
+    optional int32 active_goal = 41 [(dccl.field) = { min: 0 max: 13 }]; 
+
     optional double salinity = 51
         [(dccl.field) = { min: 0 max: 100 precision: 1 }];
 

--- a/src/lib/messages/mission.proto
+++ b/src/lib/messages/mission.proto
@@ -47,6 +47,7 @@ message MissionReport
     };
 
     required MissionState state = 10;
+    optional int32 active_goal = 11;
 }
 
 message MissionTask
@@ -142,6 +143,7 @@ message MissionPlan
         required GeographicCoordinate location = 2;
         optional MissionTask task = 3;
     }
+    // max_repeat should match BotStatus.active_goal bounds
     repeated Goal goal = 3 [(dccl.field).max_repeat = 14];
 
     message Recovery


### PR DESCRIPTION
Added "active_goal" index to the BotStatus message which maps onto the order in which the Goals are defined in the MissionPlan (starting with 0). When in MOVEMENT__TRANSIT, this value indicates the next waypoint. When in TASK__*, this indicates the Goal for which the current task resides.

Also tidied up use of `boost::units::degree::plane_angle()` to `boost::units::degree::degrees`.