### PR TITLE
Improvements for installing over rsync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ option(install_motd "Install MOTD script" ON)
 if(install_motd)
   install(PROGRAMS ${project_SCRIPTS_DIR}/75-jaiabot-status DESTINATION /etc/update-motd.d/)
 endif()
-install(PROGRAMS ${project_SCRIPTS_DIR}/75-jaiabot-status DESTINATION ${CMAKE_INSTALL_BINDIR}/jaiabot-status)
+install(PROGRAMS ${project_SCRIPTS_DIR}/75-jaiabot-status DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jaiabot-status)
 
 # add the code
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ option(install_motd "Install MOTD script" ON)
 if(install_motd)
   install(PROGRAMS ${project_SCRIPTS_DIR}/75-jaiabot-status DESTINATION /etc/update-motd.d/)
 endif()
+install(PROGRAMS ${project_SCRIPTS_DIR}/75-jaiabot-status DESTINATION ${CMAKE_INSTALL_BINDIR}/jaiabot-status)
 
 # add the code
 add_subdirectory(src)

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -57,7 +57,7 @@ subprocess.run('bash -ic "' +
                'export jaia_bot_index=' + str(args.bot_index) + '; ' +
                'export jaia_fleet_index=' + str(args.fleet_index) + '; ' + 
                'export jaia_n_bots=' + str(args.n_bots) + '; ' +
-              'source ' + args.gen_dir + '/../preseed.goby; env | egrep \'^jaia|^LD_LIBRARY_PATH\' > ' + args.env_file + '"',
+              'source ' + args.gen_dir + '/../preseed.goby; env | egrep \'^jaia|^LD_LIBRARY_PATH\' > /tmp/runtime.env; cp --backup=numbered /tmp/runtime.env ' + args.env_file + '; rm /tmp/runtime.env"',
                check=True, shell=True)
 
 common_macros=dict()

--- a/config/templates/systemd/py-app.service.in
+++ b/config/templates/systemd/py-app.service.in
@@ -6,8 +6,10 @@ After=jaiabot_gobyd.service
 $extra_unit
 
 [Service]
-User=$user
-Group=$group
+
+## for some reason we get "Failed at step EXEC spawning /home/ubuntu/jaiabot/build/arm64/share/jaiabot/python/venv/bin/python3: No such file or directory" when running unprivileged
+#User=$user
+#Group=$group
 
 EnvironmentFile=$env_file
 # Run python code within a pre-installed venv

--- a/config/templates/systemd/py-app.service.in
+++ b/config/templates/systemd/py-app.service.in
@@ -6,10 +6,8 @@ After=jaiabot_gobyd.service
 $extra_unit
 
 [Service]
-
-## for some reason we get "Failed at step EXEC spawning /home/ubuntu/jaiabot/build/arm64/share/jaiabot/python/venv/bin/python3: No such file or directory" when running unprivileged
-#User=$user
-#Group=$group
+User=$user
+Group=$group
 
 EnvironmentFile=$env_file
 # Run python code within a pre-installed venv

--- a/scripts/docker_arm64_build_and_deploy.sh
+++ b/scripts/docker_arm64_build_and_deploy.sh
@@ -44,6 +44,7 @@ else
    	    echo "🟢 Installing and enabling systemd services"
             ssh ubuntu@"$var" "bash -c 'cd /home/ubuntu/jaiabot/config/gen; ./systemd-local.sh ${jaiabot_systemd_type} --enable'"
             ssh ubuntu@"$var" "bash -c 'sudo cp /home/ubuntu/jaiabot/scripts/75-jaiabot-status /etc/update-motd.d/'"
+            ssh ubuntu@"$var" "bash -c 'sudo cp /home/ubuntu/jaiabot/scripts/75-jaiabot-status /usr/local/bin/jaiabot-status'"
         fi
 
     	echo "🟢 Creating and setting permissons on log dir"

--- a/scripts/docker_arm64_build_and_deploy.sh
+++ b/scripts/docker_arm64_build_and_deploy.sh
@@ -43,6 +43,7 @@ else
         if [ ! -z "$jaiabot_systemd_type" ]; then
    	    echo "🟢 Installing and enabling systemd services"
             ssh ubuntu@"$var" "bash -c 'cd /home/ubuntu/jaiabot/config/gen; ./systemd-local.sh ${jaiabot_systemd_type} --enable'"
+            ssh ubuntu@"$var" "bash -c 'sudo cp /home/ubuntu/jaiabot/scripts/75-jaiabot-status /etc/update-motd.d/'"
         fi
 
     	echo "🟢 Creating and setting permissons on log dir"

--- a/scripts/docker_arm64_build_and_deploy.sh
+++ b/scripts/docker_arm64_build_and_deploy.sh
@@ -41,7 +41,7 @@ else
 	rsync -zaP --delete --force --relative ./src/web ./src/lib ./src/python ./build/arm64/bin ./build/arm64/lib ./build/arm64/include ./build/arm64/share/ ./config ./scripts ./src/arduino ubuntu@"$var":/home/ubuntu/jaiabot/
 
         if [ ! -z "$jaiabot_systemd_type" ]; then
-   	    echo "🟢 Installing and enabling systemd services"
+   	    echo "🟢 Installing and enabling systemd services (you can safely ignore bash 'Inappropriate ioctl for device' and 'no job control in this shell' errors)"
             ssh ubuntu@"$var" "bash -c 'cd /home/ubuntu/jaiabot/config/gen; ./systemd-local.sh ${jaiabot_systemd_type} --enable'"
             ssh ubuntu@"$var" "bash -c 'sudo cp /home/ubuntu/jaiabot/scripts/75-jaiabot-status /etc/update-motd.d/'"
             ssh ubuntu@"$var" "bash -c 'sudo cp /home/ubuntu/jaiabot/scripts/75-jaiabot-status /usr/local/bin/jaiabot-status'"


### PR DESCRIPTION
- Install message of the day script (also to `/usr/local/bin/jaiabot-status` so you can just run `jaiabot-status` at anytime for the quick summary)
- Backup old runtime.env scripts when reinstalling systemd
- Put message in `scripts/docker_arm64_build_and_deploy.sh` indicating that bash errors are ok to ignore. (There's no easy way to remove them at the moment since I'm depending on interactive shell's $PATH (that is, ~/.bashrc) to set the correct binary and library locations).