### PR TITLE
Increase timeout connecting to gobyd to 10 seconds

### DIFF
--- a/config/templates/_interprocess.pb.cfg.in
+++ b/config/templates/_interprocess.pb.cfg.in
@@ -1,4 +1,4 @@
 interprocess { 
   platform: "$platform"
+  manager_timeout_seconds: 10
 }
-


### PR DESCRIPTION
Should hopefully avoid errors like this:
```
Jun 10 13:46:01 jaiabot4 goby_logger[801]: goby_logger [2022-Jun-10 13:46:01.129565]: (Error): No response from gobyd: platform: "bot0_fleet0" client_name: "goby_logger"
Jun 10 13:46:01 jaiabot4 systemd[1]: jaiabot_goby_logger.service: Main process exited, code=exited, status=1/FAILURE
Jun 10 13:46:01 jaiabot4 systemd[1]: jaiabot_goby_logger.service: Failed with result 'exit-code'.
```