### PR TITLE
Disallow depth interval of zero, which leads to an infinite loop

### DIFF
--- a/src/lib/messages/mission.proto
+++ b/src/lib/messages/mission.proto
@@ -78,7 +78,7 @@ message MissionTask
         optional double depth_interval = 2 [
             default = inf,
             (dccl.field) = {
-                min: 0
+                min: 0.1
                 max: 50
                 precision: 1
                 units { base_dimensions: "L" }


### PR DESCRIPTION
This command leads to an infinite loop (as the vehicle tries to calculate a dive to two meters with 0 meters between holds):

```
bot_id: 0
time: 16551937515918180
type: REMOTE_CONTROL_TASK
rc_task {
  type: DIVE
  dive {
    max_depth: 2
    depth_interval: 0
    hold_time: 0
  }
}
```

Disallow by removing 0 as a valid DCCL value.