### PR TITLE
Docs on updating cm4 bootloader

### DIFF
--- a/src/doc/markdown/page25_embedded_setup.md
+++ b/src/doc/markdown/page25_embedded_setup.md
@@ -39,10 +39,6 @@ The result will be something like `jaiabot_img-1.0.0~alpha1+5+g90e72a3.img`.
 
 - ssh or login as `jaia` / `jaia` and follow the prompts to configure the new system.
 
-- After adding SSH key to ~/.ssh/authorized_keys, disallow SSH password login in `/etc/ssh/sshd_config` by changing the appropriate line to:
-
-      PasswordAuthentication no
-
 ## Systemd
 
 We use `systemd` to launch the jaiabot services on the embedded system, just as any other Ubuntu daemon.

--- a/src/doc/markdown/page65_port_map.md
+++ b/src/doc/markdown/page65_port_map.md
@@ -1,7 +1,13 @@
 # JaiaBot Port Map
 
+## TCP
+
 - 2947 - GPSD (Default)
-- 20000 - Systemd
+- 9001 + bot_id - MOOSDB
+- 30000 (hub), 30001 + bot_id (bot) - Goby Liaison
+
+## UDP 
+
+- 20000 - Adafruit IMU
 - 20001 - Bar30 Pressure and Temperature
 - 20002 - Atlas Scientific Salinity
-- 20003 - Adafruit IMU

--- a/src/doc/markdown/page70_hardware.md
+++ b/src/doc/markdown/page70_hardware.md
@@ -9,7 +9,7 @@
 |  4  | +5V         | +5V              |
 |  5  | A7          | J1 - BRK_3       |  
 |  6  | A6          | LED 1            |
-|  7  | A5          | LED 2            |  Doesn't work - can't drive LED from Analog Pin
+|  7  | A5          | LED 2  (Doesn't work - can't drive LED from Analog Pin) |
 |  8  | A4          | LED EXT          |
 |  9  | A3          | Current - 5V     |
 | 10  | A2          | Current - Vcc    |


### PR DESCRIPTION
Minor documentation update to bring in line with new setup and bootloader flashing required for CM4 to boot from USB.