### PR TITLE
Always prepend a "Select" option to the fleet and bot dropdowns

### DIFF
--- a/src/plot/client/src/LogSelector.js
+++ b/src/plot/client/src/LogSelector.js
@@ -98,9 +98,7 @@ export default class LogSelector extends React.Component {
             return <option value={name} key={name}>{name}</option>
         })
 
-        if (elements.length > 1) {
-            elements = [first_option].concat(elements)
-        }
+        elements = [ first_option ].concat(elements)
 
         return elements
     }


### PR DESCRIPTION
This allows the user to select a fleet and bot when there are only one of them, populating the log time dropdown.