### PR TITLE
Add optional JAIA_BUILD_NPROC to control the number of processes that the build scripts use

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,11 @@ if [ -z "${JAIABOT_MAKE_FLAGS}" ]; then
     JAIABOT_MAKE_FLAGS=
 fi
 
+# Allow user to set nproc for their system, if desired
+if [ -z "${JAIA_BUILD_NPROC}" ]; then
+    JAIA_BUILD_NPROC=`nproc`
+fi
+
 script_dir=$(dirname $0)
 
 ARCH=$(dpkg --print-architecture)
@@ -21,5 +26,5 @@ mkdir -p ${script_dir}/build/${ARCH}
 echo "Configuring..."
 cd ${script_dir}/build/${ARCH}
 (set -x; cmake ../.. ${JAIABOT_CMAKE_FLAGS})
-echo "Building..."
-(set -x; cmake --build . -- -j`nproc` ${JAIABOT_MAKE_FLAGS} $@)
+echo "Building with ${JAIA_BUILD_NPROC} parallel processes..."
+(set -x; time cmake --build . -- -j${JAIA_BUILD_NPROC} ${JAIABOT_MAKE_FLAGS} $@)

--- a/scripts/arm64-build.sh
+++ b/scripts/arm64-build.sh
@@ -11,6 +11,13 @@ cd ${script_dir}/../build/arm64
 export CC=/usr/bin/clang
 export CXX=/usr/bin/clang++
 
+# Allow user to set nproc for their system, if desired
+if [ -z "${JAIA_BUILD_NPROC}" ]; then
+    JAIA_BUILD_NPROC=`nproc`
+fi
+
+echo "Building with ${JAIA_BUILD_NPROC} parallel processes..."
+
 (set -x; cmake ../.. -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_FLAGS="-target aarch64-linux-gnu" -DCMAKE_CXX_FLAGS="-target aarch64-linux-gnu")
-(set -x; make -j`nproc`)
+(set -x; time make -j${JAIA_BUILD_NPROC})
 (set -x; chmod -R ugo+r *)

--- a/scripts/docker-arm64-build-and-arduino-upload.sh
+++ b/scripts/docker-arm64-build-and-arduino-upload.sh
@@ -27,7 +27,7 @@ then
 fi
 
 echo "🟢 Building jaiabot apps"
-docker run -v `pwd`:/home/${botuser}/jaiabot -w /home/${botuser}/jaiabot -t build_system bash -c "./scripts/arm64-build.sh"
+docker run --env JAIA_BUILD_NPROC -v `pwd`:/home/${botuser}/jaiabot -w /home/${botuser}/jaiabot -t build_system bash -c "./scripts/arm64-build.sh"
 
 if [ -z "$1" ]
 then

--- a/scripts/docker-arm64-build-and-arduino-upload.sh
+++ b/scripts/docker-arm64-build-and-arduino-upload.sh
@@ -2,13 +2,11 @@
 
 ##
 ## Usage:
-## jaiabot_arduino_type=usb_old jaiabot_systemd_type=bot ./docker-arm64-build-and-deploy.sh 172.20.11.102
+## jaiabot_arduino_type=usb_old ./docker-arm64-build-and-deploy.sh 172.20.11.102
 ##
 ## Command line arguments is a list of Jaiabots to push deployed code to.
 ## If omitted, the code is just built, but not pushed
 ## Env var "jaiabot_arduino_type" can be set to one of: usb_old, usb_new, spi which will upload the arduino code (jaiabot_runtime) based on the connection type. If unset, the arduino code will not be flashed.
-## Env var "jaiabot_systemd_type" can be set to one of: bot, hub, which will generate and enable the appropriate systemd services. If unset, the systemd services will not be installed and enabled
-## 
 
 set -e
 

--- a/scripts/docker-arm64-build-and-arduino-upload.sh
+++ b/scripts/docker-arm64-build-and-arduino-upload.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+##
+## Usage:
+## jaiabot_arduino_type=usb_old jaiabot_systemd_type=bot ./docker-arm64-build-and-deploy.sh 172.20.11.102
+##
+## Command line arguments is a list of Jaiabots to push deployed code to.
+## If omitted, the code is just built, but not pushed
+## Env var "jaiabot_arduino_type" can be set to one of: usb_old, usb_new, spi which will upload the arduino code (jaiabot_runtime) based on the connection type. If unset, the arduino code will not be flashed.
+## Env var "jaiabot_systemd_type" can be set to one of: bot, hub, which will generate and enable the appropriate systemd services. If unset, the systemd services will not be installed and enabled
+## 
+
+set -e
+
+botuser=jaia
+
+script_dir=$(dirname $0)
+
+# install clang-format hook if not installed
+[ ! -e ${script_dir}/../.git/hooks/pre-commit ] && ${script_dir}/../scripts/clang-format-hooks/git-pre-commit-format install
+
+cd ${script_dir}/..
+mkdir -p build/arm64
+
+if [ "$(docker image ls build_system --format='true')" != "true" ];
+then
+    echo "🟢 Building the docker build_system image"
+    docker build -t build_system .docker/focal/arm64
+fi
+
+echo "🟢 Building jaiabot apps"
+docker run -v `pwd`:/home/${botuser}/jaiabot -w /home/${botuser}/jaiabot -t build_system bash -c "./scripts/arm64-build.sh"
+
+if [ -z "$1" ]
+then
+    echo "             -----------"
+    echo "Not Deploying as you didn't specify any targets"
+else
+    for var in "$@"
+    do
+    	echo "🟢 Uploading to "$var
+	rsync -zaP --delete --force --relative ./build/arm64/share/jaiabot/arduino ${botuser}@"$var":/home/${botuser}/jaiabot/
+        
+        if [ ! -z "$jaiabot_arduino_type" ]; then
+            echo "🟢 Loading arduino type $jaiabot_arduino_type on "$var
+            ssh ${botuser}@"$var" "/home/${botuser}/jaiabot/build/arm64/share/jaiabot/arduino/jaiabot_runtime/$jaiabot_arduino_type/upload.sh"
+        fi
+
+        echo "Finished Arduino Upload"
+    done
+fi
+

--- a/scripts/docker-arm64-build-and-deploy.sh
+++ b/scripts/docker-arm64-build-and-deploy.sh
@@ -29,7 +29,7 @@ then
 fi
 
 echo "🟢 Building jaiabot apps"
-docker run -v `pwd`:/home/${botuser}/jaiabot -w /home/${botuser}/jaiabot -t build_system bash -c "./scripts/arm64-build.sh"
+docker run --env JAIA_BUILD_NPROC -v `pwd`:/home/${botuser}/jaiabot -w /home/${botuser}/jaiabot -t build_system bash -c "./scripts/arm64-build.sh"
 
 if [ -z "$1" ]
 then


### PR DESCRIPTION
Motivation:  I have a lot of cores on a couple of my machines, and building can take all the RAM and crash the OS.
