### PR TITLE
Disable MOOS load check to allow further debugging

### DIFF
--- a/config/templates/systemd/moosdb.service.in
+++ b/config/templates/systemd/moosdb.service.in
@@ -13,8 +13,10 @@ EnvironmentFile=$env_file
 ExecStartPre=/bin/bash -c '$gen moos > $moos_file'
 ExecStartPre=/bin/bash -c '$gen bhv > $bhv_file'
 
-# Allow CPU load to drop before starting MOOS
-ExecStartPre=$bin_dir/jaiabot-checkloadavg.py 3.0
+#   Allow CPU load to drop before starting MOOS
+# (DISABLED TO ALLOW FURTHER DEBUGGING)
+# ExecStartPre=$bin_dir/jaiabot-checkloadavg.py 3.0
+
 ExecStartPre=$jaiabot_bin_dir/jaiabot_failure_reporter -C '$gen jaiabot_failure_reporter' --state START --error_code $error_on_fail --service_name $service
 ExecStart=$moos_bin_dir/MOOSDB $moos_file
 ExecStopPost=$jaiabot_bin_dir/jaiabot_failure_reporter -C '$gen jaiabot_failure_reporter' --state STOP --error_code $error_on_fail --service_name $service --service_result $$SERVICE_RESULT


### PR DESCRIPTION
Since we're seeing load averages over 3.0 regularly (perhaps due to i2c?), and we have better health reporting so we can hopefully know when we have a problem with MOOS data getting through, I'm disabling this check in hopes we can get to a better resolution.