### PR TITLE
Fix error when pidControl is not present in engineering object

### DIFF
--- a/config/launch/simulation/all.launch
+++ b/config/launch/simulation/all.launch
@@ -1,7 +1,5 @@
 #!/usr/bin/env -S goby_launch -s -P -k30 -pall -d500 -L
 
-[env=jaia_n_bots=4,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 hub.launch
-[env=jaia_n_bots=4,env=jaia_bot_index=0,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 bot.launch
-[env=jaia_n_bots=4,env=jaia_bot_index=1,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 bot.launch
-[env=jaia_n_bots=4,env=jaia_bot_index=2,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 bot.launch
-[env=jaia_n_bots=4,env=jaia_bot_index=3,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=2,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 hub.launch
+[env=jaia_n_bots=2,env=jaia_bot_index=0,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=2,env=jaia_bot_index=1,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 bot.launch

--- a/src/web/central_command/client/components/BotDetails.jsx
+++ b/src/web/central_command/client/components/BotDetails.jsx
@@ -126,12 +126,12 @@ function healthRow(bot) {
 
     let errors = bot.error ?? []
     let errorElements = errors.map((error) => {
-        return <div className='healthFailed'>{error}</div>
+        return <div key={error} className='healthFailed'>{error}</div>
     })
     
     let warnings = bot.warning ?? []
     let warningElements = warnings.map((warning) => {
-        return <div className='healthDegraded'>{warning}</div>
+        return <div key={warning} className='healthDegraded'>{warning}</div>
     })
 
     return (

--- a/src/web/central_command/client/components/PIDGainsPanel.jsx
+++ b/src/web/central_command/client/components/PIDGainsPanel.jsx
@@ -74,7 +74,7 @@ export class PIDGainsPanel extends React.Component {
                                             let botId_pid_type_gain = self.botId + "_" + pid_type_gain
             
                                             return (
-                                                <td key={botId_pid_type_gain}><input style={{maxWidth: "80px"}} type="text" id={pid_type_gain} name={pid_type_gain} defaultValue={engineering?.pidControl[pid_type][pid_gain] ?? "-"} /></td>
+                                                <td key={botId_pid_type_gain}><input style={{maxWidth: "80px"}} type="text" id={pid_type_gain} name={pid_type_gain} defaultValue={engineering?.pidControl?.[pid_type]?.[pid_gain] ?? "-"} /></td>
                                             )
                                         })
                                     }


### PR DESCRIPTION
Fix warnings about missing keys in the error/warning message divs in BotDetails