### PR TITLE
CC issues RCMode commands using bot's current location

### DIFF
--- a/src/web/central_command/client/components/CentralCommand.jsx
+++ b/src/web/central_command/client/components/CentralCommand.jsx
@@ -2473,7 +2473,20 @@ export default class CentralCommand extends React.Component {
 			warning("No bots selected")
 			return
 		}
-		this.runMissions(Missions.RCMode(botId))
+
+		var datum_location = this.podStatus?.bots?.[botId]?.location 
+
+		if (datum_location == null) {
+			const warning_string = 'RC mode issued, but bot has no location.  Should I use (0, 0) as the datum, which may result in unexpected waypoint behavior?'
+
+			if (!confirm(warning_string)) {
+				return
+			}
+
+			datum_location = {lat: 0, lon: 0}
+		}
+
+		this.runMissions(Missions.RCMode(botId, datum_location))
 	}
 
 	runRCDive() {

--- a/src/web/central_command/client/components/Missions.jsx
+++ b/src/web/central_command/client/components/Missions.jsx
@@ -79,7 +79,7 @@ export class Missions {
         return missions
     }
 
-    static RCMode(botId) {
+    static RCMode(botId, datum_location) {
         var mission_dict = {}
         mission_dict[botId] = {
             botId: botId,
@@ -90,10 +90,7 @@ export class Missions {
                 movement: 'REMOTE_CONTROL',
                 recovery: {
                     recoverAtFinalGoal: false,
-                    location: {
-                        lat: 0,
-                        lon: 0
-                    }
+                    location: datum_location
                 }
             }
         }


### PR DESCRIPTION
If there is no GPS location, CC will warn the user and confirm that they still want to use (0, 0) as the datum.