### PR TITLE
bug/Hold-Of-Zero-Task-Packet

### DIFF
--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -354,8 +354,11 @@ void jaiabot::statechart::inmission::underway::task::dive::PoweredDescent::depth
                                  << "\n post_event(EvDepthTargetReached());"
                                  << "\n"
                                  << std::endl;
-        post_event(EvDepthTargetReached());
+
+        // Set depth achieved if we have reached our goal depth
+        context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);
         dive_pdescent_debug_.set_depth_reached(true);
+        post_event(EvDepthTargetReached());
     }
 
     auto now = goby::time::SystemClock::now<goby::time::MicroTime>();
@@ -403,6 +406,10 @@ void jaiabot::statechart::inmission::underway::task::dive::PoweredDescent::depth
                  << "\n"
                  << std::endl;
         context<Dive>().set_seafloor_reached(ev.depth);
+
+        // Set depth achieved if we had a bottoming timeout
+        context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);
+
         // used to correct dive rate calculation
         duration_correction_ = (now - last_depth_change_time_);
         post_event(EvDepthTargetReached());


### PR DESCRIPTION
Fixed bug where the depth achieved would be posted as zero on occasion, this bug was seen when setting hold = zero