### PR TITLE
bug/gps-req-need-to-be-looser

### DIFF
--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -28,8 +28,8 @@ rc_setpoint_end: RC_SETPOINT_ENDS_IN_SURFACE_DRIFT
 bottoming_timeout: 10 # (optional) (default=5)
 total_gps_fix_checks: 15 # (optional) (default=5)
 total_gps_degraded_fix_checks: 1 # (optional) (default=1)
-gps_hdop_fix: 1 # (optional) (default=1)
-gps_pdop_fix: 1.5 # (optional) (default=1.5)
+gps_hdop_fix: 1.3 # (optional) (default=1)
+gps_pdop_fix: 2.2 # (optional) (default=1.5)
 
 data_offload_command: "jaiabot-dataoffload.sh $log_dir"  #  (required)
 

--- a/src/doc/markdown/page02_change_log.md
+++ b/src/doc/markdown/page02_change_log.md
@@ -2,6 +2,12 @@
 
 This following sections note the changes in each release version of jaiabot.
 
+### 1.1.3
+
+* GPS requirements were to tight. We loosened the pdop and hdop requirements.
+* PDOP <= 2.2 (GOOD)
+* HDOP <= 1.3 (GOOD)
+
 ### 1.1.2
 
 * Fixed IMU port switching


### PR DESCRIPTION

* GPS requirements were to tight. We loosened the pdop and hdop requirements.
* PDOP <= 2.2 (GOOD)
* HDOP <= 1.3 (GOOD)