### PR TITLE
bug/build-fails-fiona-version

### DIFF
--- a/src/web/requirements.txt
+++ b/src/web/requirements.txt
@@ -5,4 +5,4 @@ cmocean==2.0
 matplotlib==3.6.0
 geopandas==0.11.1
 networkx==2.8.7
-fiona==1.8.21
+fiona==1.8.22

--- a/src/web/requirements.txt
+++ b/src/web/requirements.txt
@@ -5,3 +5,4 @@ cmocean==2.0
 matplotlib==3.6.0
 geopandas==0.11.1
 networkx==2.8.7
+fiona==1.8.21


### PR DESCRIPTION
Updated requirements txt in src/web so that fiona is kept at version1.8.21 for now