### PR TITLE
Fixed bug where bot status panel close button was in wrong location

### DIFF
--- a/src/web/command_control/client/style/CommandControl.less
+++ b/src/web/command_control/client/style/CommandControl.less
@@ -1155,6 +1155,7 @@ div.hoverable:hover {
 }
 
 div.closeButton {
+  margin: 0;
   .unselectable;
   font-size: larger;
   cursor: pointer;


### PR DESCRIPTION
Overrode "margin: auto;" set on all divs by adding "margin: 0;" to the more specific selector: div.closeButton