### PR TITLE
Fix hub selection highlight bug in BotListPanel

### DIFF
--- a/src/web/command_control/client/components/BotListPanel.tsx
+++ b/src/web/command_control/client/components/BotListPanel.tsx
@@ -2,16 +2,19 @@ import { HubStatus, BotStatus, HealthState } from "./gui/JAIAProtobuf"
 import React = require("react")
 import { PodStatus } from "./PortalStatus"
 
+interface HubOrBot {
+	type: 'hub' | 'bot',
+	id: number
+}
 
 interface Props {
     podStatus: PodStatus | null
     selectedBotId: number | null
-    selectedHubId: number | null
     trackedBotId: string | number | null
+    detailsBoxItem: HubOrBot | null
     didClickBot: (bot_id: number) => void
     didClickHub: (hub_id: number) => void
 }
-
 
 function faultLevel(health_state: HealthState) {
     return {
@@ -32,6 +35,16 @@ export function BotListPanel(props: Props) {
         return bot1.bot_id - bot2.bot_id
     }
 
+    function get_selected_panel_item_id(panelItemType: String) {
+        if (props.detailsBoxItem == null) {
+            return null
+        } else if (props.detailsBoxItem.type == 'bot' && panelItemType == 'bot') {
+            return props.detailsBoxItem.id
+        } else if (props.detailsBoxItem.type == 'hub' && panelItemType == 'hub') {
+            return props.detailsBoxItem.id
+        } return null
+    }
+
     let bots = Object.values(props.podStatus?.bots ?? {}).sort(compare_by_botId)
     let hubs = Object.values(props.podStatus?.hubs ?? {}).sort(compare_by_hubId)
     
@@ -40,7 +53,7 @@ export function BotListPanel(props: Props) {
         var botClass = 'bot-item'
 
         let faultLevelClass = 'faultLevel' + faultLevel(bot.health_state)
-        let selected = bot.bot_id == props.selectedBotId ? 'selected' : ''
+        let selected = bot.bot_id == get_selected_panel_item_id('bot') ? 'selected' : ''
         let tracked = bot.bot_id == props.trackedBotId ? 'tracked' : ''
 
         return (
@@ -64,7 +77,7 @@ export function BotListPanel(props: Props) {
         var bothubClass = 'hub-item'
 
         let faultLevelClass = 'faultLevel' + faultLevel(hub.health_state)
-        let selected = hub.hub_id == props.selectedHubId ? 'selected' : ''
+        let selected = hub.hub_id == get_selected_panel_item_id('hub') ? 'selected' : ''
 
         //For now we are naming HUB, HUB with no id
         //In the future we will have to revisit this

--- a/src/web/command_control/client/components/BotListPanel.tsx
+++ b/src/web/command_control/client/components/BotListPanel.tsx
@@ -6,6 +6,7 @@ import { PodStatus } from "./PortalStatus"
 interface Props {
     podStatus: PodStatus | null
     selectedBotId: number | null
+    selectedHubId: number | null
     trackedBotId: string | number | null
     didClickBot: (bot_id: number) => void
     didClickHub: (hub_id: number) => void
@@ -63,6 +64,7 @@ export function BotListPanel(props: Props) {
         var bothubClass = 'hub-item'
 
         let faultLevelClass = 'faultLevel' + faultLevel(hub.health_state)
+        let selected = hub.hub_id == props.selectedHubId ? 'selected' : ''
 
         //For now we are naming HUB, HUB with no id
         //In the future we will have to revisit this
@@ -72,7 +74,7 @@ export function BotListPanel(props: Props) {
                 onClick={
                     () => props.didClickHub(hub.hub_id)
                 }
-                className={`${bothubClass} ${faultLevelClass}`}
+                className={`${bothubClass} ${faultLevelClass} ${selected}`}
             >
                 {"HUB"} 
             </div>

--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -258,6 +258,7 @@ interface State {
 	surveyExclusions?: number[][],
 	selectedFeatures?: OlCollection<OlFeature>,
 	detailsBoxItem?: HubOrBot,
+	selectedHub?: HubOrBot,
 	detailsExpanded: DetailsExpandedState,
 	goalBeingEditedBotId?: number,
 	goalBeingEditedGoalIndex?: number,
@@ -376,6 +377,7 @@ export default class CommandControl extends React.Component {
 			selectedFeatures: null,
 			// noaaEncSource: new TileArcGISRest({ url: 'https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/ENCOnline/MapServer/exts/MaritimeChartService/MapServer' }),
 			detailsBoxItem: null,
+			selectedHub: null,
 			detailsExpanded: {
 				quickLook: true,
 				commands: false,
@@ -2465,7 +2467,8 @@ export default class CommandControl extends React.Component {
 
 				<div id="botsDrawer">
 					<BotListPanel podStatus={this.podStatus} 
-						selectedBotId={this.selectedBotId()} 
+						selectedBotId={this.selectedBotId()}
+						selectedHubId={this.selectedHubId()}
 						trackedBotId={this.state.trackingTarget}
 						didClickBot={this.didClickBot.bind(this)}
 						didClickHub={this.didClickHub.bind(this)} />
@@ -2505,11 +2508,22 @@ export default class CommandControl extends React.Component {
 		const item = {'type': 'hub', id: hub_id}
 
 		if (areEqual(this.state.detailsBoxItem, item)) {
-			this.setState({detailsBoxItem: null})
+			// Hub clicked off
+			this.setState({detailsBoxItem: null, selectedHub: null})
+		} else if (this.state.selectedHub !== null && areEqual(item, this.state.selectedHub)) {
+			// Hub clicked off
+			// This condition happens when the user clicks (in the BotListPanel) the hub first, then a bot, and then clicks the hub again to deselect it
+			this.setState({selectedHub: null})
+		} else {
+			// Hub clicked on
+			this.setState({detailsBoxItem: item, selectedHub: item})
 		}
-		else {
-			this.setState({detailsBoxItem: item})
-		}
+	}
+
+	selectedHubId() {
+		if (this.state.selectedHub !== null) {
+			return this.state.selectedHub.id
+		} return null
 	}
 
 	takeControlPanel() {

--- a/src/web/command_control/client/style/CommandControl.less
+++ b/src/web/command_control/client/style/CommandControl.less
@@ -222,6 +222,10 @@ div {
       > div.bot-item.controlled {
         .bgcolor(@controlled-color);
       }  
+
+      > div.hub-item.selected {
+        outline: 5px solid @selected-color;
+      }
     }
 
   }


### PR DESCRIPTION
Added selectedHub to state becasue the active hub info needed to be separated from detailsBoxItem which holds the info for the most recent click in the BotListPanel. Otherwise, if the user clicked (in the panel) the hub, then a bot, and then the hub again, React would register it as the hub being clicked on, not off.