### PR TITLE
Update build_messages.sh to not hardcode Goby/DCCL paths

### DIFF
--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_target(command_control
 set(server_outdir ${project_SHARE_DIR}/jaiabot/web/server)
 add_custom_command(OUTPUT ${server_outdir}/dccl/option_extensions_pb2.py
   COMMAND ./build_messages.sh
-  ARGS ${server_outdir} ${CMAKE_CURRENT_BINARY_DIR}/proto_include
+  ARGS ${server_outdir} ${CMAKE_CURRENT_BINARY_DIR}/proto_include ${GOBY_INCLUDE_DIR} ${DCCL_INCLUDE_DIR}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/server
   COMMENT "Running server build_messages.sh"
   )

--- a/src/web/server/build_messages.sh
+++ b/src/web/server/build_messages.sh
@@ -7,17 +7,24 @@ python_outdir='.'
 mkdir -p $python_outdir
 
 PROTO_INCLUDE=/etc/jaiabot/proto_include/
-[[ ! -z "$1" ]] && PROTO_INCLUDE="$2"
+[[ ! -z "$2" ]] && PROTO_INCLUDE="$2"
 
-if [ ! -d ${PROTO_INCLUDE} ]
-then
-    mkdir -p ${PROTO_INCLUDE}
-    
-    ln -sf /usr/include/goby ${PROTO_INCLUDE}/goby
-    ln -sf /usr/include/dccl ${PROTO_INCLUDE}/dccl
-    mkdir -p ${PROTO_INCLUDE}/jaiabot
-    ln -sf $(pwd)/../../lib/messages ${PROTO_INCLUDE}/jaiabot/messages
-fi
+GOBY_INCLUDE_DIR=/usr/include
+[[ ! -z "$3" ]] && GOBY_INCLUDE_DIR="$3"
+
+DCCL_INCLUDE_DIR=/usr/include
+[[ ! -z "$4" ]] && DCCL_INCLUDE_DIR="$4"
+
+
+mkdir -p ${PROTO_INCLUDE}    
+
+[[ -e "${PROTO_INCLUDE}/goby" ]] && rm ${PROTO_INCLUDE}/goby
+ln -sf ${GOBY_INCLUDE_DIR}/goby ${PROTO_INCLUDE}/goby
+[[ -e "${PROTO_INCLUDE}/dccl" ]] && rm ${PROTO_INCLUDE}/dccl
+ln -sf ${DCCL_INCLUDE_DIR}/dccl ${PROTO_INCLUDE}/dccl
+mkdir -p ${PROTO_INCLUDE}/jaiabot
+[[ -e "${PROTO_INCLUDE}/jaiabot/messages" ]] && rm ${PROTO_INCLUDE}/jaiabot/messages
+ln -sf $(pwd)/../../lib/messages ${PROTO_INCLUDE}/jaiabot/messages
 
 echo "🟢 Building Jaia protobuf python modules"
 


### PR DESCRIPTION
Required when building with -DGOBY_DIR=/some/path and/or -DDCCL_DIR=/some/path that is not the default system install (/usr/include).