### PR TITLE
Fix deb versioning circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,25 +52,8 @@ job-template-amd64: &job-template-amd64
     - run: &run-set-deb-rep-and-version
         name: Set environmental variables for which packages.jaia.tech repo to use
         command: |
-          if [[ "$CIRCLE_TAG" == *"_"* ]]; then
-            repo="beta";
-          elif [ ! -z "$CIRCLE_TAG" ]; then
-            repo="release";
-          else
-            repo="continuous";
-          fi
-
-          # placeholder for future version branches
-          if [[ "$CIRCLE_BRANCH" == "1.y" ]]; then
-            version="1.y";
-          # elif [[ "$CIRCLE_BRANCH" == "2.y" ]]; then
-          #  version="2.y";
-          else
-            # default to test/X.y repo on non-standard branches
-            repo="test";
-            version="X.y";
-          fi
-
+          repo=$(/root/jaiabot/.circleci/deb_repo.sh "$CIRCLE_BRANCH" "$CIRCLE_TAG" "repo")
+          version=$(/root/jaiabot/.circleci/deb_repo.sh "$CIRCLE_BRANCH" "$CIRCLE_TAG" "version")
           # export these for later use
           echo "export JAIABOT_APT_REPO=${repo}" >> $BASH_ENV
           echo "export JAIABOT_APT_VERSION=${version}" >> $BASH_ENV
@@ -188,16 +171,14 @@ filter-template-master-only: &filter-template-master-only
     branches:
       only:
         - "1.y"
-        - "systemd-sim"
-        - "jcc-as-apache"
+        - "fix-deb-versioning-circleci"
 
 filter-template-non-master: &filter-template-non-master
   filters:
     branches:
       ignore:
         - "1.y"
-        - "systemd-sim"
-        - "jcc-as-apache"
+        - "fix-deb-versioning-circleci"
 
         
 ## Begin actual config
@@ -234,6 +215,11 @@ workflows:
 
       # bundle after each package upload
       - bundle:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
           requires:
             - upload          
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ job-template-deb-amd64: &job-template-deb-amd64
   <<: *job-template-amd64
   resource_class: large
   steps:
+    - checkout
     - run: *run-add-gobysoft-packages-key
     - run: *run-add-jaia-packages-key
     - run: *run-set-deb-rep-and-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ job-template-amd64: &job-template-amd64
     - run: &run-set-deb-rep-and-version
         name: Set environmental variables for which packages.jaia.tech repo to use
         command: |
-          repo=$(/root/jaiabot/.circleci/deb_repo.sh "$CIRCLE_BRANCH" "$CIRCLE_TAG" "repo")
-          version=$(/root/jaiabot/.circleci/deb_repo.sh "$CIRCLE_BRANCH" "$CIRCLE_TAG" "version")
+          repo=$(${CIRCLE_WORKING_DIRECTORY}/.circleci/deb_repo.sh "$CIRCLE_BRANCH" "$CIRCLE_TAG" "repo")
+          version=$(${CIRCLE_WORKING_DIRECTORY}/.circleci/deb_repo.sh "$CIRCLE_BRANCH" "$CIRCLE_TAG" "version")
           # export these for later use
           echo "export JAIABOT_APT_REPO=${repo}" >> $BASH_ENV
           echo "export JAIABOT_APT_VERSION=${version}" >> $BASH_ENV

--- a/.circleci/deb_repo.sh
+++ b/.circleci/deb_repo.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e -u
+
+CIRCLE_BRANCH="$1"
+CIRCLE_TAG="$2"
+
+# either "repo" or "version"
+RETURN_TYPE="$3"
+
+if [ "$#" -ne 3 ]; then
+    echo "Wrong number of parameters, expects 3: CIRCLE_BRANCH CIRCLE_TAG [repo|version]"
+    exit 1
+fi
+
+if [[ "$RETURN_TYPE" != "repo" && "$RETURN_TYPE" != "version" ]]; then
+   echo "3rd argument must be 'repo' or 'version'"
+   exit 1
+fi
+
+if [ ! -z "$CIRCLE_TAG" ]; then
+    # tagged release
+    if [[ "$CIRCLE_TAG" == *"_"* ]]; then
+        repo="beta";
+    else
+        repo="release";
+    fi
+    # extract version from tag major
+    version="${CIRCLE_TAG%%.*}.y"
+else
+    # branch
+
+    if [[ "$CIRCLE_BRANCH" =~ ^[0-9]+\.y$ ]]; then
+       # 1.y, 2.y ,etc.
+       version="$CIRCLE_BRANCH"
+       repo="continuous"
+    else
+        # default to test/X.y repo on non-standard branches
+        repo="test";
+        version="X.y";
+    fi
+fi
+
+[[ "$RETURN_TYPE" == "version" ]] && echo "$version" || true
+[[ "$RETURN_TYPE" == "repo" ]] && echo "$repo" || true

--- a/.circleci/test_deb_repo.sh
+++ b/.circleci/test_deb_repo.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e -u
+
+dsh="./deb_repo.sh"
+
+
+function test() {
+    branch="$1"
+    tag="$2"
+    expected_repo="$3"
+    expected_version="$4"
+    repo=$($dsh "$branch" "$tag" "repo")
+    version=$($dsh "$branch" "$tag" "version")
+    
+    if [[ "$repo" != "$expected_repo" ]]; then
+        echo "ERROR: For branch: \"$branch\", tag: \"$tag\": Expected repo: $expected_repo, got $repo"
+        exit 1;
+    fi
+
+    if [[ "$version" != "$expected_version" ]]; then
+        echo "ERROR: For branch: \"$branch\", tag: \"$tag\": Expected version: $expected_version, got $version"
+        exit 1;
+    fi   
+}
+
+
+test "1.y" "" "continuous" "1.y"
+test "2.y" "" "continuous" "2.y"
+test "12.y" "" "continuous" "12.y"
+
+test "" "1.4.0_beta2" "beta" "1.y"
+test "" "2.3.0_alpha1" "beta" "2.y"
+test "" "12.6.0_beta12" "beta" "12.y"
+
+test "" "1.4.0" "release" "1.y"
+test "" "2.3.0" "release" "2.y"
+test "" "12.6.0" "release" "12.y"
+
+test "foobar" "" "test" "X.y"
+
+
+echo "All tests passed"


### PR DESCRIPTION
The old script that determined which Debian APT repo to push packages to had a bug that didn't set the correct repo version when building for tagged releases. This bug was exposed when I added the new test/X.y repo for non-1.y test builds.

I moved the logic into a standalone script (`.circleci/deb_repo.sh`) and created a unit test for it (`test_deb_repo.sh`). I fixed the script logic so it gets the version from:

- For tagged releases, the tag major and ".y" -> 1.4.0 -> "1.y". For tags that have an underscore (e.g. 1.4.0_beta2) use the "beta" repo, otherwise use the "release" one.
- For branches that match [0-9]+\.y (e.g. 1.y, 2.y, etc.) use that branch name. Otherwise use test/X.y