### PR TITLE
bug/change-gps-checks-to-reflect-new-output-speed

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -17,20 +17,24 @@ if "jaia_electronics_stack" in os.environ:
 
 if jaia_electronics_stack == '0':
     jaia_arduino_dev_location="/dev/ttyUSB0"
-    helmAppTick=1
-    helmCommsTick=4
+    helm_app_tick=1
+    helm_comms_tick=4
+    total_after_dive_gps_fix_checks=15
 if jaia_electronics_stack == '1':
     jaia_arduino_dev_location="/dev/ttyUSB0"
-    helmAppTick=5
-    helmCommsTick=5
+    helm_app_tick=5
+    helm_comms_tick=5
+    total_after_dive_gps_fix_checks=75
 elif jaia_electronics_stack == '2':
     jaia_arduino_dev_location="/dev/ttyAMA1"
-    helmAppTick=5
-    helmCommsTick=5
+    helm_app_tick=5
+    helm_comms_tick=5
+    total_after_dive_gps_fix_checks=75
 else:
     jaia_arduino_dev_location="/dev/ttyUSB0"
-    helmAppTick=1
-    helmCommsTick=4
+    helm_app_tick=1
+    helm_comms_tick=4
+    total_after_dive_gps_fix_checks=15
 
 try:
     number_of_bots=int(os.environ['jaia_n_bots'])
@@ -188,7 +192,8 @@ elif common.app == 'jaiabot_mission_manager':
                                      interprocess_block = interprocess_common,
                                      bot_id=bot_index,
                                      log_dir=log_file_dir,
-                                     mission_manager_in_simulation=is_simulation()))
+                                     mission_manager_in_simulation=is_simulation(),
+                                     total_after_dive_gps_fix_checks=total_after_dive_gps_fix_checks))
 elif common.app == 'jaiabot_failure_reporter':
     print(config.template_substitute(templates_dir+'/jaiabot_failure_reporter.pb.cfg.in',
                                      app_block=app_common,
@@ -212,8 +217,8 @@ elif common.app == 'moos':
                                      moos_community='BOT' + str(bot_index),
                                      warp=common.sim.warp,                                
                                      bhv_file='/tmp/jaiabot_' + str(bot_index) + '.bhv',
-                                     helmAppTick=helmAppTick,
-                                     helmCommsTick=helmCommsTick))
+                                     helm_app_tick=helm_app_tick,
+                                     helm_comms_tick=helm_comms_tick))
 elif common.app == 'bhv':
     print(config.template_substitute(templates_dir+'/bot/bot.bhv.in'))    
 elif common.app == 'moos_sim':

--- a/config/launch/simulation/all.launch
+++ b/config/launch/simulation/all.launch
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S goby_launch -s -P -k30 -pall -d500 -L
 
-[env=jaia_n_bots=2,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 hub.launch
-[env=jaia_n_bots=2,env=jaia_bot_index=0,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 bot.launch
-[env=jaia_n_bots=2,env=jaia_bot_index=1,env=jaia_mode=simulation,env=jaia_warp=5] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=2,env=jaia_mode=simulation,env=jaia_warp=1] goby_launch -P -d100 hub.launch
+[env=jaia_n_bots=2,env=jaia_bot_index=0,env=jaia_mode=simulation,env=jaia_warp=1,env=jaia_electronics_stack=2] goby_launch -P -d100 bot.launch
+[env=jaia_n_bots=2,env=jaia_bot_index=1,env=jaia_mode=simulation,env=jaia_warp=1,env=jaia_electronics_stack=2] goby_launch -P -d100 bot.launch

--- a/config/launch/simulation/generate_all_launch.sh
+++ b/config/launch/simulation/generate_all_launch.sh
@@ -28,7 +28,7 @@ cat <<EOF > ${launchfile}
 EOF
 
 for i in `seq 0 $((n_bots-1))`; do
-    echo "[env=jaia_n_bots=${n_bots},env=jaia_bot_index=${i},env=jaia_mode=simulation,env=jaia_warp=${warp}] goby_launch -P -d${launchdelay} bot.launch" >> ${launchfile}
+    echo "[env=jaia_n_bots=${n_bots},env=jaia_bot_index=${i},env=jaia_mode=simulation,env=jaia_warp=${warp},env=jaia_electronics_stack=2] goby_launch -P -d${launchdelay} bot.launch" >> ${launchfile}
 done
 
 echo "Generated all.launch with ${n_bots} bots @ warp ${warp}x"

--- a/config/templates/bot/bot.moos.in
+++ b/config/templates/bot/bot.moos.in
@@ -21,8 +21,8 @@ ProcessConfig = uProcessWatch
 
 ProcessConfig = pHelmIvP
 {
-  AppTick    = $helmAppTick
-  CommsTick  = $helmCommsTick
+  AppTick    = $helm_app_tick
+  CommsTick  = $helm_comms_tick
 
   bhv_dir_not_found_ok = true
 

--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -37,7 +37,7 @@ gps_hdop_fix: 1.3 # (optional) (default=1.3)
 gps_pdop_fix: 2.2 # (optional) (default=2.2)
 
 # GPS Requirements after a Dive 
-total_after_dive_gps_fix_checks: 15 # (optional) (default=15)
+total_after_dive_gps_fix_checks: $total_after_dive_gps_fix_checks # (optional) (default=15 for electronics stack 1, default=75 for electronics stack 1,2)
 gps_after_dive_hdop_fix: 1.3 # (optional) (default=1.3)
 gps_after_dive_pdop_fix: 2.2 # (optional) (default=2.2)
 

--- a/src/lib/messages/engineering.proto
+++ b/src/lib/messages/engineering.proto
@@ -84,11 +84,11 @@ message GPSRequirements
 
     optional double after_dive_pdop_req = 4 [(dccl.field) = { min: 1 max: 100 precision: 2 }];
 
-    optional uint32 transit_gps_fix_checks = 5 [(dccl.field) = { min: 1 max: 30 }];
+    optional uint32 transit_gps_fix_checks = 5 [(dccl.field) = { min: 1 max: 100 }];
 
-    optional uint32 transit_gps_degraded_fix_checks = 6 [(dccl.field) = { min: 1 max: 30 }];
+    optional uint32 transit_gps_degraded_fix_checks = 6 [(dccl.field) = { min: 1 max: 100 }];
 
-    optional uint32 after_dive_gps_fix_checks = 7 [(dccl.field) = { min: 1 max: 30 }];
+    optional uint32 after_dive_gps_fix_checks = 7 [(dccl.field) = { min: 1 max: 100 }];
 }
 
 message RFDisableOptions
@@ -100,11 +100,11 @@ message RFDisableOptions
 message Engineering
 {
     /*
-    Actual maximum size of message: 92 bytes / 736 bits
+    Actual maximum size of message: 94 bytes / 752 bits
         dccl.id head...........................8
         user head..............................0
-        body.................................723
-        padding to full byte...................5
+        body.................................742
+        padding to full byte...................2
     Allowed maximum size of message: 200 bytes / 1600 bits
     */
     option (dccl.msg) = {

--- a/src/web/command_control/client/components/PIDGainsPanel.tsx
+++ b/src/web/command_control/client/components/PIDGainsPanel.tsx
@@ -287,7 +287,7 @@ export class PIDGainsPanel extends React.Component {
                                             name="transit_gps_checks_input" 
                                             defaultValue={engineering?.gps_requirements?.transit_gps_fix_checks ?? "-"} 
                                             min="1"
-                                            max="30"
+                                            max="100"
                                             step="1"
                                         />
                                     </td>
@@ -301,7 +301,7 @@ export class PIDGainsPanel extends React.Component {
                                             name="transit_gps_degraded_checks_input" 
                                             defaultValue={engineering?.gps_requirements?.transit_gps_degraded_fix_checks ?? "-"}
                                             min="1"
-                                            max="30"
+                                            max="100"
                                             step="1" 
                                         />
                                     </td>
@@ -315,7 +315,7 @@ export class PIDGainsPanel extends React.Component {
                                             name="after_dive_gps_checks_input" 
                                             defaultValue={engineering?.gps_requirements?.after_dive_gps_fix_checks ?? "-"} 
                                             min="1"
-                                            max="30"
+                                            max="100"
                                             step="1"
                                         />
                                     </td>


### PR DESCRIPTION
Added ability to update gps checks based off electronics stack

This is important because on electronics stack 1 and 2 we use the gps to output at 5hz and on electronics stack 0 we output at 1hz.

This would mean the logic would not be suitable for electronics stack 1 and 2. We do not want to make a change that breaks stack 0 though.

We know what electronics stack each bot is using so by utilizing this information we set the gps check values.