### PR TITLE
bug/goal-settings-and-optimize-mission-panel

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -2418,7 +2418,8 @@ export default class CommandControl extends React.Component {
 							mode: '',
 							surveyPolygonChanged: false,
 							missionPlanningGrid: null,
-							missionPlanningLines: null
+							missionPlanningLines: null,
+							goalBeingEdited: null
 						});
 
 						this.updateMissionLayer();

--- a/src/web/command_control/client/components/GoalSettings.tsx
+++ b/src/web/command_control/client/components/GoalSettings.tsx
@@ -42,10 +42,6 @@ export class GoalSettingsPanel extends React.Component {
         this.oldGoal = deepcopy(props.goal)
     }
 
-    componentDidUpdate() {
-        this.props.onChange?.()
-    }
-
     render() {
         const { botId, goalIndex, goal } = this.props
         let self = this


### PR DESCRIPTION
React Error #185:
Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.

GoalSettings component had an onChange event handler called in componentDidUpdate which called updateMissionLayer. When the line tool created a mission, the number of state calls made from creating a mission with the line tool and from the GoalSettings component exceeded the React max depth.