### PR TITLE
feature/create-single-lat-lon-endpoint

### DIFF
--- a/src/lib/messages/mission.proto
+++ b/src/lib/messages/mission.proto
@@ -62,7 +62,7 @@ message Speeds
     optional double transit = 1 [
         default = 2,
         (dccl.field) = {
-            min: 0.0,
+            min: 0.1,
             max: 3.0,
             precision: 1,
             units { base_dimensions: "LT^-1" }
@@ -200,7 +200,7 @@ message MissionTask
             default = 2,
             (dccl.field) = {
                 min: 0.1,
-                max: 6.0,
+                max: 3.0,
                 precision: 1,
                 units { base_dimensions: "LT^-1" }
             }

--- a/src/web/command_control/client/components/MissionSpeedSettingsPanel.tsx
+++ b/src/web/command_control/client/components/MissionSpeedSettingsPanel.tsx
@@ -63,7 +63,7 @@ export default class MissionSpeedSettingsPanel extends React.Component {
                                     valueLabelDisplay="auto"
                                     step={0.5}
                                     marks
-                                    min={0}
+                                    min={0.5}
                                     max={this.state.speed_max}
                                     onChange={
                                         (evt) => 
@@ -113,7 +113,7 @@ export default class MissionSpeedSettingsPanel extends React.Component {
                                     valueLabelDisplay="auto"
                                     step={0.5}
                                     marks
-                                    min={0}
+                                    min={0.5}
                                     max={this.state.speed_max}
                                     onChange={
                                         (evt) => 

--- a/src/web/command_control/client/components/ScanForBotPanel.tsx
+++ b/src/web/command_control/client/components/ScanForBotPanel.tsx
@@ -38,7 +38,7 @@ export default class ScanForBotPanel extends React.Component {
                                     id="scan_for_bot_input" 
                                     name="scan_for_bot_input" 
                                     defaultValue="1"
-                                    min="1"
+                                    min="0"
                                     max="30"
                                     step="1" 
                                 />

--- a/src/web/server/app.py
+++ b/src/web/server/app.py
@@ -104,6 +104,11 @@ def postEngineeringPanel():
     jaia_interface.post_ep_command(request.json, clientId=request.headers['clientId'])
     return JSONResponse({"status": "ok"})
 
+@app.route('/jaia/single-waypoint-mission', methods=['POST'])
+def postSingleWaypointMission():
+    jaia_interface.post_single_waypoint_mission(request.json, clientId=request.headers['clientId'])
+    return JSONResponse({"status": "ok"})
+
 ######## Map tiles
 
 @app.route('/tiles/index', methods=['GET'])

--- a/src/web/server/jaia.py
+++ b/src/web/server/jaia.py
@@ -178,7 +178,7 @@ class Interface:
             return {'status': 'fail', 'message': 'You are in spectator mode, and cannot send commands.'}
     
     def post_single_waypoint_mission(self, single_waypoint_mission_dict, clientId):
-        logging.warning(f'Sending single waypoint coordinate: {single_waypoint_mission_dict}')
+        logging.debug(f'Sending single waypoint coordinate: {single_waypoint_mission_dict}')
 
         if 'lat' and 'lon' in single_waypoint_mission_dict:
             command_dict = {'bot_id': 1, 'time': now(), 'type': 'MISSION_PLAN', 
@@ -219,13 +219,13 @@ class Interface:
 
             if 'bot_id' in single_waypoint_mission_dict:
                 command_dict['bot_id'] = single_waypoint_mission_dict['bot_id']
-                logging.warning(f'Sending single waypoint mission: {command_dict}')
+                logging.debug(f'Sending single waypoint mission: {command_dict}')
                     
                 self.post_command(command_dict, clientId)
             else:
                 for bot in self.bots.values():
                     command_dict['bot_id'] = bot['bot_id']
-                    logging.warning(f'Sending single waypoint mission: {command_dict}')
+                    logging.debug(f'Sending single waypoint mission: {command_dict}')
                     
                     self.post_command(command_dict, clientId)
 

--- a/src/web/server/jaia.py
+++ b/src/web/server/jaia.py
@@ -176,6 +176,65 @@ class Interface:
             return {'status': 'ok'}
         else:
             return {'status': 'fail', 'message': 'You are in spectator mode, and cannot send commands.'}
+    
+    def post_single_waypoint_mission(self, single_waypoint_mission_dict, clientId):
+        logging.warning(f'Sending single waypoint coordinate: {single_waypoint_mission_dict}')
+
+        if 'lat' and 'lon' in single_waypoint_mission_dict:
+            command_dict = {'bot_id': 1, 'time': now(), 'type': 'MISSION_PLAN', 
+                            'plan': {'start': 'START_IMMEDIATELY', 'movement': 'TRANSIT', 
+                            'goal': [{'location': {'lat': single_waypoint_mission_dict["lat"], 'lon': single_waypoint_mission_dict["lon"]}}], 
+                            'recovery': {'recover_at_final_goal': True}, 'speeds': {'transit': 2, 'stationkeep_outer': 1.5}}}
+
+            if 'dive_depth' in single_waypoint_mission_dict:
+                # default 10 seconds
+                drift_time = 10
+
+                if 'surface_drift_time' in single_waypoint_mission_dict:
+                    drift_time = single_waypoint_mission_dict['surface_drift_time']
+
+                command_dict['plan']['goal'] = [{
+                        'location': {
+                            'lat': single_waypoint_mission_dict["lat"],
+                            'lon': single_waypoint_mission_dict["lon"]
+                        },
+                        'task': {
+                            'type': 'DIVE',
+                            'dive': {
+                                'max_depth': single_waypoint_mission_dict['dive_depth'],
+                                'depth_interval': single_waypoint_mission_dict['dive_depth'],
+                                'hold_time': 0  
+                            },
+                            'surface_drift': {
+                                'drift_time': drift_time
+                            }
+                        }
+                    }]
+
+            if 'tansit_speed' in single_waypoint_mission_dict:
+                command_dict['plan']['speeds']['transit'] = single_waypoint_mission_dict['tansit_speed']
+
+            if 'station_keep_speed' in single_waypoint_mission_dict:
+                command_dict['plan']['speeds']['stationkeep_outer'] = single_waypoint_mission_dict['station_keep_speed']
+
+            if 'bot_id' in single_waypoint_mission_dict:
+                command_dict['bot_id'] = single_waypoint_mission_dict['bot_id']
+                logging.warning(f'Sending single waypoint mission: {command_dict}')
+                    
+                self.post_command(command_dict, clientId)
+            else:
+                for bot in self.bots.values():
+                    command_dict['bot_id'] = bot['bot_id']
+                    logging.warning(f'Sending single waypoint mission: {command_dict}')
+                    
+                    self.post_command(command_dict, clientId)
+
+            self.setControllingClientId(clientId)
+
+            return {'status': 'ok'}
+        
+        else:
+            return {'status': 'fail', 'message': 'You need at least a lat lon for single wpt mission: Ex: {"bot_id": 1, "lat": 41.661849, "lon": -71.273131, "dive_depth": 2, "surface_drift_time": 15,"tansit_speed": 2.5, "station_keep_speed": 0.5}'}
 
     def post_command_for_hub(self, command_for_hub_dict, clientId):
         command_for_hub = google.protobuf.json_format.ParseDict(command_for_hub_dict, CommandForHub())


### PR DESCRIPTION
added endpoint for a single point mission

Python:

API_ENDPOINT_WPT = "http://localhost:40001/jaia/single-waypoint-mission"

#define the headers for the request
headers = {'clientid': 'backseat-control', 'Content-Type' : 'application/json; charset=utf-8'}

Ex: 
data = {'bot_id': 1, 'lat': 41.661849, 'lon': -71.273131, 'dive_depth': 2, 'surface_drift_time': 15,'tansit_speed': 2.5, 'station_keep_speed': 0.5}
data = {'lat': 41.661849, 'lon': -71.273131, 'dive_depth': 2, 'surface_drift_time': 15,'tansit_speed': 2.5, 'station_keep_speed': 0.5}  
data = {'lat': 41.661849, 'lon': -71.273131, 'dive_depth': 2,'tansit_speed': 2.5, 'station_keep_speed': 0.5} 
data = {'lat': 41.661849, 'lon': -71.273131, 'surface_drift_time': 15, 'tansit_speed': 2.5, 'station_keep_speed': 0.5}
data = {'lat': 41.661849, 'lon': -71.273131, 'station_keep_speed': 2}
data = {'lat': 41.661849, 'lon': -71.273131, 'tansit_speed': 3}
data = {'lat': 41.661849, 'lon': -71.273131}

wpt_resp = requests.post(url=API_ENDPOINT_WPT, json=data, headers=headers)

#extracting response text 
pastebin_url = wpt_resp.text
print("The pastebin URL is:%s"%pastebin_url)