### PR TITLE
bug/apache2-not-restarting-on-restart

### DIFF
--- a/src/bin/health/app.cpp
+++ b/src/bin/health/app.cpp
@@ -67,10 +67,8 @@ class Health : public ApplicationBase
 
     void restart_services()
     {
-        // Restart jaiabot applications
-        system("systemctl restart jaiabot");
-        // Restart apache which is hosting JCC
-        system("systemctl restart apache2");
+        // Restart jaiabot applications and apache which is hosting JCC
+        system("systemctl restart apache2 jaiabot");
     }
     void restart_imu_py() { system("systemctl restart jaiabot_imu_py"); }
     void process_coroner_report(const goby::middleware::protobuf::VehicleHealth& vehicle_health);


### PR DESCRIPTION
Fix issue with apache2 not restarting because the jaiabot services restarted first