### PR TITLE
bug/moos-log-overload

### DIFF
--- a/config/templates/goby_logger.pb.cfg.in
+++ b/config/templates/goby_logger.pb.cfg.in
@@ -7,4 +7,4 @@ load_shared_library: "libjaiabot_liaison.so.1"
 load_shared_library: "libjaiabot_config.so.1"
 
 # exclude internal groups
-group_regex: "(?!.*_internal.*).*"
+group_regex: "(?!(.*_internal.*|.*moos.*)).*"

--- a/src/doc/markdown/page02_change_log.md
+++ b/src/doc/markdown/page02_change_log.md
@@ -2,6 +2,11 @@
 
 This following sections note the changes in each release version of jaiabot.
 
+### 1.5.3
+
+* Goby Logger Config
+  * Exclude moos group because the goby log got too big for Raspberry Pi to convert to h5 file
+
 ### 1.5.2
 
 * JCC


### PR DESCRIPTION
Blacklist moos logs to reduce goby size

In release we set this manually. In 1.y we have the ability to switch between goby log output. 