### PR TITLE
bug/jcc-crash-bot-no-gps

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -889,8 +889,8 @@ export default class CommandControl extends React.Component {
 		const zoomExtentWidth = 0.001 / 2 // Degrees
 		const bots = Object.values(this.getPodStatus().bots)
 
-		const lons = bots.map((bot) => { return bot.location.lon }).filter((lon) => { return lon })
-		const lats = bots.map((bot) => { return bot.location.lat }).filter((lat) => { return lat })
+		const lons = bots.map((bot) => { return bot.location?.lon })
+		const lats = bots.map((bot) => { return bot.location?.lat })
 
 		if (lons.length == 0 || lats.length == 0) return undefined
 


### PR DESCRIPTION
Also removed the filter method since it did not include a function that altered the array produced by the map method