### PR TITLE
bug/nodejs-timer-bug

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -218,8 +218,8 @@ export default class CommandControl extends React.Component {
 	surveyPolygon: SurveyPolygon
 	surveyExclusions: SurveyExclusions
 
-	timerID: NodeJS.Timer
-	metadataTimerID: NodeJS.Timer
+	timerID: NodeJS.Timeout
+	metadataTimerID: NodeJS.Timeout
 
 	oldPodStatus?: PodStatus
 


### PR DESCRIPTION
The clearInterval function is failing to build because NodeJS.Timer was not one of the parameter types allowed.

Changed to NodeJS.Timeout to match parameter type inputs. 

![image](https://github.com/jaiarobotics/jaiabot/assets/109534520/4961211c-bba8-4312-9eac-998451f59a2e)
