### PR TITLE
bug/fleet-id-not-set-in-hub-manager-config

### DIFF
--- a/config/gen/hub.py
+++ b/config/gen/hub.py
@@ -144,7 +144,8 @@ elif common.app == 'jaiabot_hub_manager':
                                      app_block=app_common,
                                      interprocess_block = interprocess_common,
                                      hub_id=hub_index,
-                                     xbee_config=common.comms.xbee_config()))
+                                     xbee_config=common.comms.xbee_config(),
+                                     fleet_id=fleet_index))
 elif common.app == 'jaiabot_failure_reporter':
     print(config.template_substitute(templates_dir+'/jaiabot_failure_reporter.pb.cfg.in',
                                      app_block=app_common,

--- a/config/templates/hub/jaiabot_hub_manager.pb.cfg.in
+++ b/config/templates/hub/jaiabot_hub_manager.pb.cfg.in
@@ -1,6 +1,7 @@
 $app_block
 $interprocess_block
 
+fleet_id: $fleet_id
 hub_id: $hub_id
 
 status_sub_cfg {


### PR DESCRIPTION
Setting fleet id in the hub manager config