### PR TITLE
bug/distance-to-hub-not-working

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -2456,7 +2456,7 @@ export default class CommandControl extends React.Component {
 			case 'bot':
 				const botDetailsProps: BotDetailsProps = {
 					bot: bots?.[this.selectedBotId()], 
-					hub: hubs?.[0], 
+					hub: hubs?.[Object.keys(hubs)[0]], 
 					api: this.api, 
 					mission: this.getRunList(),
 					run: this.getRun(this.selectedBotId()),


### PR DESCRIPTION
Grabbing first hub to get the distance. Currently we should only see one hub on jcc because they do not talk to each other.