### PR TITLE
feature/allow-only-one-run-to-be-editable-at-a-time

### DIFF
--- a/src/web/command_control/client/components/Details.tsx
+++ b/src/web/command_control/client/components/Details.tsx
@@ -431,8 +431,7 @@ export interface BotDetailsProps {
     deleteSingleMission: () => void,
     setDetailsExpanded: (section: keyof DetailsExpandedState, expanded: boolean) => void,
     isRCModeActive: (botId: number) => boolean,
-    updateEditModeToggle: (run: RunInterface) => boolean,
-    toggleEditMode: (run: RunInterface) => boolean,
+    toggleEditMode: (evt: React.ChangeEvent, run: RunInterface) => boolean,
     downloadIndividualBot: (bot: PortalBotStatus) => void
 }
 
@@ -555,8 +554,8 @@ export function BotDetailsComponent(props: BotDetailsProps) {
                         </Button>
 
                         <EditModeToggle 
-                            checked={props.updateEditModeToggle}
                             onClick={props.toggleEditMode}
+                            mission={props.mission}
                             run={props.run}
                             label='Edit'
                             title='ToggleEditMode'

--- a/src/web/command_control/client/components/Details.tsx
+++ b/src/web/command_control/client/components/Details.tsx
@@ -622,6 +622,19 @@ export function BotDetailsComponent(props: BotDetailsProps) {
         botOffloadPercentage = ' ' + bot.data_offload_percentage + '%'
     }
 
+    let clickOnMap = (
+        <h3 className='name'>Click on the map to create waypoints</h3>
+    )
+
+    // Clear message for clicking on map if the bot has a run,
+    // but it is not in edit mode
+    if (!disableClearRunButton(bot, mission).isDisabled
+            && !props?.mission?.runIdInEditMode[bot?.bot_id]) {
+        clickOnMap = (
+            <h3 className='name'>Click edit toggle to create waypoints</h3>
+        )
+    }
+
     return (
         <React.Fragment>
             <div id='botDetailsBox'>
@@ -630,7 +643,7 @@ export function BotDetailsComponent(props: BotDetailsProps) {
                         <h2 className='name'>{`Bot ${bot?.bot_id}`}</h2>
                         <div onClick={() => closeWindow()} className='closeButton'>⨯</div>
                     </div>
-                    <h3 className='name'>Click on the map to create goals</h3>
+                    {clickOnMap}
                     <div className='botDetailsToolbar'>
                         <Button
                             className={disableButton(commands.stop, missionState).isDisabled ? 'inactive button-jcc' : ' button-jcc stopMission'} 

--- a/src/web/command_control/client/components/EditModeToggle.tsx
+++ b/src/web/command_control/client/components/EditModeToggle.tsx
@@ -3,12 +3,11 @@ import Switch from '@mui/material/Switch';
 import { FormGroup, FormControlLabel } from '@mui/material';
 import { amber } from '@mui/material/colors';
 import { alpha, styled } from '@mui/material/styles';
-import { RunInterface } from "./CommandControl";
+import { MissionInterface, RunInterface } from "./CommandControl";
 
 interface Props {
-    checked: (run: RunInterface) => boolean,
-    onClick: (run: RunInterface) => void,
-    disabled?: (run: RunInterface) => boolean,
+    onClick: (evt: React.ChangeEvent, run: RunInterface,) => void,
+    mission: MissionInterface
     run: RunInterface
     label: string,
     title: string
@@ -36,9 +35,8 @@ export default function EditModeToggle(props: Props) {
             <FormControlLabel 
                 control={
                     <AmberSwitch 
-                        checked={props.checked(props.run)} 
-                        disabled={props.disabled ? props.disabled(props.run) : false} 
-                        onClick={() => props.onClick(props.run)}
+                        checked={props.mission.runIdInEditMode === props.run?.id} 
+                        onChange={(evt: React.ChangeEvent) => props.onClick(evt, props.run)}
                     />
                 }
                 label={props.label} 

--- a/src/web/command_control/client/components/GoalSettings.tsx
+++ b/src/web/command_control/client/components/GoalSettings.tsx
@@ -4,7 +4,7 @@ import { Goal } from './shared/JAIAProtobuf';
 import { deepcopy } from './shared/Utilities'
 import { TaskSettingsPanel } from './TaskSettingsPanel';
 import { Map } from 'ol';
-import { MissionInterface, PanelType, RunInterface } from './CommandControl';
+import { MissionInterface, PanelType} from './CommandControl';
 import { Icon } from '@mdi/react'
 import { mdiDelete } from '@mdi/js'
 import '../style/components/GoalSettingsPanel.css'
@@ -24,7 +24,6 @@ interface Props {
     onChange: () => void
     setVisiblePanel: (panelType: PanelType) => void
     setMoveWptMode: (canMoveWptMode: boolean, botId: number, goalNum: number) => void
-    canEditRunState: (run: RunInterface) => boolean
 }
 
 interface State {
@@ -94,12 +93,6 @@ export class GoalSettingsPanel extends React.Component {
             if (testRun.assigned === this.props.botId) {
                 run = testRun
             }
-        }
-
-        const canEditRun = run?.canEdit
-
-        if (!canEditRun) {
-            this.doneClicked()
         }
     }
 

--- a/src/web/command_control/client/components/Missions.tsx
+++ b/src/web/command_control/client/components/Missions.tsx
@@ -1,7 +1,3 @@
-/* eslint-disable jsx-a11y/label-has-for */
-/* eslint-disable jsx-a11y/label-has-associated-control */
-/* eslint-disable react/sort-comp */
-/* eslint-disable no-unused-vars */
 import { Goal, GeographicCoordinate, Command, CommandType, MissionStart, MovementType} from './shared/JAIAProtobuf'
 import { MissionInterface, RunInterface } from './CommandControl';
 import { deepcopy } from './shared/Utilities';
@@ -61,7 +57,8 @@ export class Missions {
                 name: 'Mission 1',
                 runs: {},
                 runIdIncrement: 1,
-                botsAssignedToRuns: {}
+                botsAssignedToRuns: {},
+                runIdInEditMode: ''
             }
 		}
 
@@ -108,30 +105,29 @@ export class Missions {
         return isRunNumberLessThanMaxRuns
     }
 
-    static addRunWithWaypoints(botId: number, locations: GeographicCoordinate[], mission: MissionInterface, setEditModeToggle: (runNumber: number, isOn: boolean) => void) {
-        let incr = mission.runIdIncrement + 1;
+    static addRunWithWaypoints(botId: number, locations: GeographicCoordinate[], mission: MissionInterface, unAssignedMission?: boolean) {
         let botsAssignedToRuns = mission?.botsAssignedToRuns;
 
         if (!Missions.isValidRunNumber(mission)) { return }
         
-        if(botsAssignedToRuns[botId] != null)
-        {
+        if (botsAssignedToRuns[botId] != null) {
             mission.runs[botsAssignedToRuns[botId]].assigned = -1;
             mission.runs[botsAssignedToRuns[botId]].command.bot_id = -1;
             delete botsAssignedToRuns[botId];
         }
 
+        let incr = mission.runIdIncrement
         mission.runs['run-' + String(incr)] = {
             id: 'run-' + String(incr),
             name: 'Run ' + String(incr),
             assigned: botId,
             command: Missions.commandWithWaypoints(botId, locations),
-            canEdit: true
         }
         mission.runIdIncrement = incr;
+        mission.runIdInEditMode = 'run-' + String(incr);
         botsAssignedToRuns[botId] = 'run-' + String(incr);
 
-        setEditModeToggle(botId, true)
+        mission.runIdIncrement += 1;
 
         return mission;
     }
@@ -154,9 +150,9 @@ export class Missions {
             name: 'Run ' + String(incr),
             assigned: botId,
             command: commandWithGoals(botId, deepcopy(goals)),
-            canEdit: true
         }
         mission.runIdIncrement = incr;
+        mission.runIdInEditMode = 'run-' + String(incr);
         botsAssignedToRuns[botId] = 'run-' + String(incr);
 
         if (setEditModeToggle) {
@@ -186,9 +182,9 @@ export class Missions {
             name: 'Run ' + String(incr),
             assigned: botId,
             command: command,
-            canEdit: true
         }
         mission.runIdIncrement = incr;
+        mission.runIdInEditMode = 'run-' + String(incr);
         botsAssignedToRuns[botId] = 'run-' + String(incr);
 
         return mission;

--- a/src/web/command_control/client/components/Missions.tsx
+++ b/src/web/command_control/client/components/Missions.tsx
@@ -133,7 +133,6 @@ export class Missions {
     }
 
     static addRunWithGoals(botId: number, goals: Goal[], mission: MissionInterface, setEditModeToggle?: (runNumber: number, isOn: boolean) => void) {
-        let incr = mission.runIdIncrement + 1;
         let botsAssignedToRuns = mission?.botsAssignedToRuns;
 
         if (!Missions.isValidRunNumber(mission)) { return }
@@ -145,6 +144,7 @@ export class Missions {
             delete botsAssignedToRuns[botId];
         }
 
+        let incr = mission.runIdIncrement
         mission.runs['run-' + String(incr)] = {
             id: 'run-' + String(incr),
             name: 'Run ' + String(incr),
@@ -155,6 +155,8 @@ export class Missions {
         mission.runIdInEditMode = 'run-' + String(incr);
         botsAssignedToRuns[botId] = 'run-' + String(incr);
 
+        mission.runIdIncrement += 1;
+
         if (setEditModeToggle) {
             setEditModeToggle(botId, true)
         }
@@ -163,7 +165,6 @@ export class Missions {
     }
 
     static addRunWithCommand(botId: number, command: Command, mission: MissionInterface) {
-        let incr = mission.runIdIncrement + 1;
         let botsAssignedToRuns = mission?.botsAssignedToRuns;
 
         if (!Missions.isValidRunNumber(mission)) { return }
@@ -177,6 +178,7 @@ export class Missions {
 
         command.bot_id = botId;
 
+        let incr = mission.runIdIncrement
         mission.runs['run-' + String(incr)] = {
             id: 'run-' + String(incr),
             name: 'Run ' + String(incr),
@@ -186,6 +188,8 @@ export class Missions {
         mission.runIdIncrement = incr;
         mission.runIdInEditMode = 'run-' + String(incr);
         botsAssignedToRuns[botId] = 'run-' + String(incr);
+
+        mission.runIdIncrement += 1;
 
         return mission;
     }

--- a/src/web/command_control/client/components/RunInfoPanel.tsx
+++ b/src/web/command_control/client/components/RunInfoPanel.tsx
@@ -9,16 +9,10 @@ interface Props {
     setVisiblePanel: (panelType: PanelType) => void,
     runNum: number,
     botId: number
-    canDeleteRun: boolean
     deleteRun: (runNum: number) => void
 }
 
 export default function RunInfoPanel(props: Props) {
-    let deleteButton = null
-    if (props.canDeleteRun) {
-        deleteButton = <button className="run-info-btn" onClick={() => handleDeleteRunClick()}>Delete Run</button>
-    }
-
     const handleDeleteRunClick = () => {
         props.deleteRun(props.runNum)
         props.setVisiblePanel(PanelType.NONE)
@@ -41,7 +35,7 @@ export default function RunInfoPanel(props: Props) {
                         <div className="run-info-label">Bot:</div>
                         <div className="run-info-input">{props.botId}</div>
                         <div className="run-info-line-break"></div>
-                        {deleteButton}
+                        <button className="run-info-btn" onClick={() => handleDeleteRunClick()}>Delete Run</button>
                     </div>
                 </div>
             </div>

--- a/src/web/command_control/client/components/mission/MissionControllerPanel.tsx
+++ b/src/web/command_control/client/components/mission/MissionControllerPanel.tsx
@@ -38,7 +38,6 @@ export default class MissionControllerPanel extends React.Component {
     render() {
 		const self = this;
         const emptyMission = Object.keys(this.props.mission.runs).length == 0
-        const botId = this.props.mission.runIdIncrement * -1
 
 		let runPanelComponent =
 			<RunPanel
@@ -49,6 +48,7 @@ export default class MissionControllerPanel extends React.Component {
 				deleteAllRunsInMission={self.props.deleteAllRunsInMission}
 				autoAssignBotsToRuns={self.props.autoAssignBotsToRuns}
 				toggleEditMode={self.props.toggleEditMode}
+                unSelectHubOrBot={self.props.unSelectHubOrBot}
 			/>
 
 		return (
@@ -59,9 +59,8 @@ export default class MissionControllerPanel extends React.Component {
                         className="button-jcc" 
                         id="add-run" 
                         onClick={() => {
-                            // Without unselecting, the run index will be stuck on the previously selected run
                             this.props.unSelectHubOrBot()
-                            Missions.addRunWithWaypoints(botId, [], this.props.mission)
+                            Missions.addRunWithWaypoints(-1, [], this.props.mission)
                             setTimeout(() => {
                                 const runListElement = document.getElementById('runList')
                                 const scrollAmount = runListElement.scrollHeight

--- a/src/web/command_control/client/components/mission/MissionControllerPanel.tsx
+++ b/src/web/command_control/client/components/mission/MissionControllerPanel.tsx
@@ -16,10 +16,8 @@ interface Props {
     saveMissionClick: any,
     deleteAllRunsInMission: any,
     autoAssignBotsToRuns: any,
-    setEditRunMode: (botIds: number[], canEdit: boolean) => void,
-    setEditModeToggle: (runNumber: number, isOn: boolean) => void
-    updateEditModeToggle: (run: RunInterface) => boolean,
-    toggleEditMode: (run: RunInterface) => boolean
+    toggleEditMode: (evt: React.ChangeEvent, run: RunInterface) => boolean
+    unSelectHubOrBot: () => void
 }
 
 export default class MissionControllerPanel extends React.Component {
@@ -40,6 +38,7 @@ export default class MissionControllerPanel extends React.Component {
     render() {
 		const self = this;
         const emptyMission = Object.keys(this.props.mission.runs).length == 0
+        const botId = this.props.mission.runIdIncrement * -1
 
 		let runPanelComponent =
 			<RunPanel
@@ -49,9 +48,6 @@ export default class MissionControllerPanel extends React.Component {
 				saveMissionClick={self.props.saveMissionClick}
 				deleteAllRunsInMission={self.props.deleteAllRunsInMission}
 				autoAssignBotsToRuns={self.props.autoAssignBotsToRuns}
-				setEditRunMode={self.props.setEditRunMode}
-				setEditModeToggle={self.props.setEditModeToggle}
-				updateEditModeToggle={self.props.updateEditModeToggle}
 				toggleEditMode={self.props.toggleEditMode}
 			/>
 
@@ -63,7 +59,9 @@ export default class MissionControllerPanel extends React.Component {
                         className="button-jcc" 
                         id="add-run" 
                         onClick={() => {
-                            Missions.addRunWithWaypoints(-1, [], this.props.mission, this.props.setEditModeToggle);
+                            // Without unselecting, the run index will be stuck on the previously selected run
+                            this.props.unSelectHubOrBot()
+                            Missions.addRunWithWaypoints(botId, [], this.props.mission)
                             setTimeout(() => {
                                 const runListElement = document.getElementById('runList')
                                 const scrollAmount = runListElement.scrollHeight

--- a/src/web/command_control/client/components/mission/RunItem.tsx
+++ b/src/web/command_control/client/components/mission/RunItem.tsx
@@ -25,6 +25,7 @@ interface Props {
     run: RunInterface
     mission: MissionInterface,
     toggleEditMode: (evt: React.ChangeEvent, run: RunInterface) => boolean
+    unSelectHubOrBot: () => void
 }
 
 interface State {
@@ -87,8 +88,16 @@ export default class RunItem extends React.Component {
 
         // Check to see if that run is assigned
         // And if the bot id is not included in the botsNotAssigned array
-        if (this.props.run.assigned > 0 && !this.botsNotAssigned.includes(this.props.run.assigned)) {
+        if (this.props.run.assigned !== -1 && !this.botsNotAssigned.includes(this.props.run.assigned)) {
             assignedLabel = "Bot-" + this.props.run.assigned
+            assignedOption = (
+                <MenuItem 
+                    key={this.props.run.assigned} 
+                    value={this.props.run.assigned}
+                >
+                    {assignedLabel}
+                </MenuItem>
+            )
         }
 
         // Create the Select Object
@@ -99,30 +108,26 @@ export default class RunItem extends React.Component {
                     <Select
                         labelId="bot-assigned-select-label"
                         id="bot-assigned-select"
-                        value={this.props.run.assigned.toString()}
+                        value={this.props.run?.assigned?.toString()}
                         label="Assign"
                         onChange={(evt: SelectChangeEvent) => this.handleBotSelectionChange(evt)}
                     >
 
-                        {
-                            <MenuItem
-                                key={this.props.mission.runIdIncrement * -1}
-                                value={this.props.mission.runIdIncrement * -1}
-                            >
-                                {"Unassigned"}
-                            </MenuItem>
-                        }
+                        <MenuItem 
+                            key={-1} 
+                            value={-1}
+                        >
+                            Unassigned
+                        </MenuItem>
 
                         {
-                            assignedLabel ? 
-                            (
-                                <MenuItem
-                                    key={this.props.run.assigned}
+                            assignedOption ? 
+                                <MenuItem 
+                                    key={this.props.run.assigned} 
                                     value={this.props.run.assigned}
-                                    >
-                                        {assignedLabel}
-                                </MenuItem>
-                            ) : ""
+                                >
+                                    {assignedLabel}
+                                </MenuItem> : ""
                         }
                        
                         {
@@ -146,7 +151,8 @@ export default class RunItem extends React.Component {
                 onClick={(event) => {
                     event.stopPropagation();
                     const goals = deepcopy(this.props.run.command.plan.goal)
-                    Missions.addRunWithGoals(this.props.mission.runIdIncrement * -1, goals, this.props.mission);
+                    this.props.unSelectHubOrBot()
+                    Missions.addRunWithGoals(-1, goals, this.props.mission);
                 }}
             >
                 <Icon path={mdiContentDuplicate} title="Duplicate Run"/>

--- a/src/web/command_control/client/components/mission/RunItem.tsx
+++ b/src/web/command_control/client/components/mission/RunItem.tsx
@@ -24,9 +24,7 @@ interface Props {
     bots: {[key: number]: PortalBotStatus}
     run: RunInterface
     mission: MissionInterface,
-    setEditRunMode: (botIds: number[], canEdit: boolean) => void
-    updateEditModeToggle: (run: RunInterface) => boolean,
-    toggleEditMode: (run: RunInterface) => boolean
+    toggleEditMode: (evt: React.ChangeEvent, run: RunInterface) => boolean
 }
 
 interface State {
@@ -42,9 +40,6 @@ export default class RunItem extends React.Component {
 
     constructor(props: Props) {
         super(props)
-        this.state = {
-          isChecked: this.props.run.canEdit
-        }
     }
 
     componentDidMount() {
@@ -92,16 +87,8 @@ export default class RunItem extends React.Component {
 
         // Check to see if that run is assigned
         // And if the bot id is not included in the botsNotAssigned array
-        if (this.props.run.assigned != -1 && !this.botsNotAssigned.includes(this.props.run.assigned)) {
+        if (this.props.run.assigned > 0 && !this.botsNotAssigned.includes(this.props.run.assigned)) {
             assignedLabel = "Bot-" + this.props.run.assigned
-            assignedOption = (
-                <MenuItem 
-                    key={this.props.run.assigned} 
-                    value={this.props.run.assigned}
-                >
-                    {assignedLabel}
-                </MenuItem>
-            )
         }
 
         // Create the Select Object
@@ -116,21 +103,26 @@ export default class RunItem extends React.Component {
                         label="Assign"
                         onChange={(evt: SelectChangeEvent) => this.handleBotSelectionChange(evt)}
                     >
-                        <MenuItem 
-                            key={-1} 
-                            value={-1}
-                        >
-                            Unassigned
-                        </MenuItem>
 
                         {
-                            assignedOption ? 
-                                <MenuItem 
-                                    key={this.props.run.assigned} 
+                            <MenuItem
+                                key={this.props.mission.runIdIncrement * -1}
+                                value={this.props.mission.runIdIncrement * -1}
+                            >
+                                {"Unassigned"}
+                            </MenuItem>
+                        }
+
+                        {
+                            assignedLabel ? 
+                            (
+                                <MenuItem
+                                    key={this.props.run.assigned}
                                     value={this.props.run.assigned}
-                                >
-                                    {assignedLabel}
-                                </MenuItem> : ""
+                                    >
+                                        {assignedLabel}
+                                </MenuItem>
+                            ) : ""
                         }
                        
                         {
@@ -154,7 +146,7 @@ export default class RunItem extends React.Component {
                 onClick={(event) => {
                     event.stopPropagation();
                     const goals = deepcopy(this.props.run.command.plan.goal)
-                    Missions.addRunWithGoals(-1, goals, this.props.mission);
+                    Missions.addRunWithGoals(this.props.mission.runIdIncrement * -1, goals, this.props.mission);
                 }}
             >
                 <Icon path={mdiContentDuplicate} title="Duplicate Run"/>
@@ -183,8 +175,8 @@ export default class RunItem extends React.Component {
         // Create Edit Mode Toggle
         editModeButton = (
             <EditModeToggle 
-                checked={this.props.updateEditModeToggle}
                 onClick={this.props.toggleEditMode}
+                mission={this.props.mission}
                 run={this.props.run}
                 label="Edit"
                 title="ToggleEditMode"

--- a/src/web/command_control/client/components/mission/RunList.tsx
+++ b/src/web/command_control/client/components/mission/RunList.tsx
@@ -10,10 +10,7 @@ interface Props {
     saveMissionClick: any,
     deleteAllRunsInMission: any,
     autoAssignBotsToRuns: any
-    setEditRunMode: (botIds: number[], canEdit: boolean) => void,
-    setEditModeToggle: (runNumber: number, isOn: boolean) => void
-    updateEditModeToggle: (run: RunInterface) => boolean,
-    toggleEditMode: (run: RunInterface) => boolean
+    toggleEditMode: (evt: React.ChangeEvent, run: RunInterface) => boolean
 }
 
 interface State {
@@ -46,8 +43,6 @@ export default class RunList extends React.Component {
                                 bots={self.props.bots} 
                                 run={value} 
                                 mission={self.props.mission}
-                                setEditRunMode={self.props.setEditRunMode}
-                                updateEditModeToggle={self.props.updateEditModeToggle}
                                 toggleEditMode={self.props.toggleEditMode}
                             />
                         </React.Fragment>

--- a/src/web/command_control/client/components/mission/RunList.tsx
+++ b/src/web/command_control/client/components/mission/RunList.tsx
@@ -11,6 +11,7 @@ interface Props {
     deleteAllRunsInMission: any,
     autoAssignBotsToRuns: any
     toggleEditMode: (evt: React.ChangeEvent, run: RunInterface) => boolean
+    unSelectHubOrBot: () => void
 }
 
 interface State {
@@ -44,6 +45,7 @@ export default class RunList extends React.Component {
                                 run={value} 
                                 mission={self.props.mission}
                                 toggleEditMode={self.props.toggleEditMode}
+                                unSelectHubOrBot={self.props.unSelectHubOrBot}
                             />
                         </React.Fragment>
                     )

--- a/src/web/command_control/client/components/mission/RunPanel.tsx
+++ b/src/web/command_control/client/components/mission/RunPanel.tsx
@@ -10,10 +10,7 @@ interface Props {
     saveMissionClick: any,
     deleteAllRunsInMission: any,
     autoAssignBotsToRuns: any,
-    setEditRunMode: (botIds: number[], canEdit: boolean) => void,
-    setEditModeToggle: (runNumber: number, isOn: boolean) => void
-    updateEditModeToggle: (run: RunInterface) => boolean,
-    toggleEditMode: (run: RunInterface) => boolean
+    toggleEditMode: (evt: React.ChangeEvent, run: RunInterface) => boolean
 }
 
 
@@ -43,9 +40,6 @@ export default class RunPanel extends React.Component {
 				    saveMissionClick={self.props.saveMissionClick}
                     deleteAllRunsInMission={self.props.deleteAllRunsInMission}
                     autoAssignBotsToRuns={self.props.autoAssignBotsToRuns}
-                    setEditRunMode={self.props.setEditRunMode}
-                    setEditModeToggle={self.props.setEditModeToggle}
-                    updateEditModeToggle={self.props.updateEditModeToggle}
                     toggleEditMode={self.props.toggleEditMode}
                 />}
             </React.Fragment>

--- a/src/web/command_control/client/components/mission/RunPanel.tsx
+++ b/src/web/command_control/client/components/mission/RunPanel.tsx
@@ -11,6 +11,7 @@ interface Props {
     deleteAllRunsInMission: any,
     autoAssignBotsToRuns: any,
     toggleEditMode: (evt: React.ChangeEvent, run: RunInterface) => boolean
+    unSelectHubOrBot: () => void
 }
 
 
@@ -41,6 +42,7 @@ export default class RunPanel extends React.Component {
                     deleteAllRunsInMission={self.props.deleteAllRunsInMission}
                     autoAssignBotsToRuns={self.props.autoAssignBotsToRuns}
                     toggleEditMode={self.props.toggleEditMode}
+                    unSelectHubOrBot={self.props.unSelectHubOrBot}
                 />}
             </React.Fragment>
         );


### PR DESCRIPTION
Replaced old edit mode toggle code with a more concise version that checks to see which run is in edit mode.

For unassigned runs, I used the reverse numbering convention. Negative 'bot ids' represent unassigned runs in this version. They are the multiplicative inverse of the run number.