### PR TITLE
bug/saving-mission-in-browser-does-not-work

### DIFF
--- a/config/templates/bot/jaiabot_fusion.pb.cfg.in
+++ b/config/templates/bot/jaiabot_fusion.pb.cfg.in
@@ -21,7 +21,7 @@ course_over_ground_timeout: 3 # timeout in seconds
 total_imu_issue_checks: 4 # (default=4 checks) checks * imu_detect_period (1 seconds) = time to detect
 
 # When to start detecting imu issues again after detecting one
-imu_detect_timeout: 13 # (default=13 seconds)
+imu_detect_timeout: 14 # (default=14 seconds)
 
 imu_issue_detect_horizontal_pitch_checks: 3 # (default=3 checks)
 imu_issue_detect_horizontal_pitch_min_time: 1 # (default=1 seconds)

--- a/src/bin/fusion/config.proto
+++ b/src/bin/fusion/config.proto
@@ -64,7 +64,7 @@ message Fusion
     optional int32 total_imu_issue_checks = 35 [default = 4];
 
     // When to start detecting imu issues again after detecting one
-    optional int32 imu_detect_timeout = 36 [default = 13]; 
+    optional int32 imu_detect_timeout = 36 [default = 14]; 
 
     // Rate in milliseconds
     optional int32 bot_status_period_ms = 37 [default = 1000]; 

--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -910,6 +910,8 @@ void jaiabot::apps::Fusion::detect_imu_issue()
     if (!is_bot_horizontal_)
     {
         glog.is_debug2() && glog << "detect_imu_issue() Exit bot is not horizontal" << endl;
+        // Reset increment
+        imu_issue_crs_hdg_incr_ = 0;
         return;
     }
 
@@ -918,6 +920,8 @@ void jaiabot::apps::Fusion::detect_imu_issue()
     {
         glog.is_debug2() && glog << "detect_imu_issue() Exit bot has a desired speed of zero"
                                  << endl;
+        // Reset increment
+        imu_issue_crs_hdg_incr_ = 0;
         return;
     }
 
@@ -928,6 +932,8 @@ void jaiabot::apps::Fusion::detect_imu_issue()
     {
         glog.is_debug2() && glog << "detect_imu_issue() Exit bot does not have attitude data"
                                  << endl;
+        // Reset increment
+        imu_issue_crs_hdg_incr_ = 0;
         return;
     }
 
@@ -943,6 +949,8 @@ void jaiabot::apps::Fusion::detect_imu_issue()
                                  << "heading diff is above the max"
                                  << " Desired: " << bot_desired_heading_ << ", heading: " << heading
                                  << endl;
+        // Reset increment
+        imu_issue_crs_hdg_incr_ = 0;
         return;
     }
 
@@ -959,6 +967,8 @@ void jaiabot::apps::Fusion::detect_imu_issue()
         now)
     {
         glog.is_debug2() && glog << "detect_imu_issue() Exit bot's course is not updating" << endl;
+        // Reset increment
+        imu_issue_crs_hdg_incr_ = 0;
         return;
     }
 
@@ -973,6 +983,8 @@ void jaiabot::apps::Fusion::detect_imu_issue()
         glog.is_debug2() && glog << "detect_imu_issue() Exit bot's previous course over ground is "
                                     "the same as the current course"
                                  << endl;
+        // Reset increment
+        imu_issue_crs_hdg_incr_ = 0;
         return;
     }
 

--- a/src/web/command_control/client/components/MissionLibrary.tsx
+++ b/src/web/command_control/client/components/MissionLibrary.tsx
@@ -2,9 +2,9 @@ import { LoadMissions, SaveMissions } from './Settings'
 import { RunLibrary } from './Missions'
 import { MissionInterface } from './CommandControl';
 
-const savedMissionKey = "savedMissions"
+const savedMissionsKey = "savedMissions"
 
-const savedMissions = LoadMissions<RunLibrary>(savedMissionKey)
+const savedMissions = LoadMissions<RunLibrary>(savedMissionsKey)
 
 export class MissionLibraryLocalStorage {
     static missionLibraryLocalStorage: MissionLibraryLocalStorage
@@ -38,7 +38,7 @@ export class MissionLibraryLocalStorage {
         }
 
         savedMissions[key] = JSON.parse(JSON.stringify(mission))
-        SaveMissions(savedMissionKey, savedMissions)
+        SaveMissions(savedMissionsKey, savedMissions)
     }
 
     deleteMission(key: string) {
@@ -47,7 +47,7 @@ export class MissionLibraryLocalStorage {
         }
 
         delete savedMissions[key]
-        SaveMissions(savedMissionKey, savedMissions)
+        SaveMissions(savedMissionsKey, savedMissions)
     }
 
 }

--- a/src/web/command_control/client/components/MissionLibrary.tsx
+++ b/src/web/command_control/client/components/MissionLibrary.tsx
@@ -1,8 +1,10 @@
-import { Load, Save } from './Settings'
-import { Missions, RunLibrary } from './Missions'
+import { LoadMissions, SaveMissions } from './Settings'
+import { RunLibrary } from './Missions'
 import { MissionInterface } from './CommandControl';
 
-const savedMissions = Load<RunLibrary>('savedMissions', Missions.defaultMissions())
+const savedMissionKey = "savedMissions"
+
+const savedMissions = LoadMissions<RunLibrary>(savedMissionKey)
 
 export class MissionLibraryLocalStorage {
     static missionLibraryLocalStorage: MissionLibraryLocalStorage
@@ -18,11 +20,7 @@ export class MissionLibraryLocalStorage {
     }
 
     missionNames() {
-        console.log(savedMissions)
-
-        let savedMissionNames = Object.keys(savedMissions).filter((value) => {
-            return value != '_localStorageKeyFunc'
-        }). sort()
+        let savedMissionNames = Object.keys(savedMissions). sort()
         return savedMissionNames
     }
 
@@ -40,7 +38,7 @@ export class MissionLibraryLocalStorage {
         }
 
         savedMissions[key] = JSON.parse(JSON.stringify(mission))
-        Save(savedMissions)
+        SaveMissions(savedMissionKey, savedMissions)
     }
 
     deleteMission(key: string) {
@@ -49,7 +47,7 @@ export class MissionLibraryLocalStorage {
         }
 
         delete savedMissions[key]
-        Save(savedMissions)
+        SaveMissions(savedMissionKey, savedMissions)
     }
 
 }

--- a/src/web/command_control/client/components/MissionLibrary.tsx
+++ b/src/web/command_control/client/components/MissionLibrary.tsx
@@ -18,6 +18,8 @@ export class MissionLibraryLocalStorage {
     }
 
     missionNames() {
+        console.log(savedMissions)
+
         let savedMissionNames = Object.keys(savedMissions).filter((value) => {
             return value != '_localStorageKeyFunc'
         }). sort()

--- a/src/web/command_control/client/components/Settings.tsx
+++ b/src/web/command_control/client/components/Settings.tsx
@@ -55,12 +55,23 @@ export function Load<T>(key: string, defaultValue: T) {
     return value
 }
 
+export function LoadMissions<T>(key: string) {
+    const s = localStorage.getItem(key)
+
+    const storedValue: T = JSON.parse(s)
+
+    return storedValue
+}
+
 
 export function Save(value: any) {
     const key = value._localStorageKeyFunc()
     localStorage.setItem(key, JSON.stringify(value))
 }
 
+export function SaveMissions(key: string, value: any) {
+    localStorage.setItem(key, JSON.stringify(value))
+}
 
 export interface MapSettings {
     visibleLayers: string[]


### PR DESCRIPTION
Missions did not save correctly. They were not saving in local storage because of how the update method was handling them. I created a separate save and load function for missions because I believe we handle them differently. 