### PR TITLE
bug/ansible-mount-not-working

### DIFF
--- a/config/ansible/upgrade-all.yml
+++ b/config/ansible/upgrade-all.yml
@@ -6,10 +6,7 @@
 
   tasks:
     - name: Remount firmware read-write
-      mount:
-        path: /boot/firmware
-        opts: "rw"
-        state: remounted
+      shell: "mount -o remount,rw /boot/firmware"
 
     # Can hopefully be removed when we switch to EFI boot
     # For now we get an error with update-grub on amd64 images due to overlay root
@@ -27,10 +24,7 @@
     - include_tasks: tasks/get-version.yml
 
     - name: Remount firmware read-only
-      mount:
-        path: /boot/firmware
-        opts: "ro"
-        state: remounted
+      shell: "mount -o remount,ro /boot/firmware"
 
     # Do not include as it takes a long time if NTP isn't sync'd
     #- include_tasks: tasks/restart-jaiabot.yml


### PR DESCRIPTION
Changed from using the built in mount that ansible provides to a shell command to remount /boot/firmware.

The built in mount command was not remounting the /boot/firmware partition so it was failing to upgrade when new firmware was available.