### PR TITLE
bug/task-packet-date-selection-does-not-reset-when-toggled

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -2129,6 +2129,7 @@ export default class CommandControl extends React.Component {
 			}).catch((err) => {
 				console.error('Task Packets Retrieval Error:', err)
 			})
+			// Set "Keep End Date Current" checkbox to checked
 			taskPacketsTimeline.keepEndDateCurrent = true
 		}
 

--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -2129,6 +2129,7 @@ export default class CommandControl extends React.Component {
 			}).catch((err) => {
 				console.error('Task Packets Retrieval Error:', err)
 			})
+			taskPacketsTimeline.keepEndDateCurrent = true
 		}
 
 		taskPacketsTimeline.isEditing = !this.state.taskPacketsTimeline.isEditing

--- a/src/web/command_control/client/components/EditModeToggle.tsx
+++ b/src/web/command_control/client/components/EditModeToggle.tsx
@@ -8,7 +8,7 @@ import { alpha, styled } from '@mui/material/styles'
 import { FormGroup, FormControlLabel } from '@mui/material'
 
 interface Props {
-    onClick: (evt: React.ChangeEvent, run: RunInterface,) => void,
+    onClick: (evt: React.ChangeEvent, run: RunInterface) => void,
     runIdInEditMode: string
     run: RunInterface
     label: string,

--- a/src/web/command_control/client/components/WptToggle.tsx
+++ b/src/web/command_control/client/components/WptToggle.tsx
@@ -1,8 +1,8 @@
 import React from "react"
-import Switch from '@mui/material/Switch';
-import { FormGroup, FormControlLabel } from '@mui/material';
-import { amber } from '@mui/material/colors';
-import { alpha, styled } from '@mui/material/styles';
+import Switch from '@mui/material/Switch'
+import { FormGroup, FormControlLabel } from '@mui/material'
+import { amber } from '@mui/material/colors'
+import { alpha, styled } from '@mui/material/styles'
 
 interface Props {
     checked: () => boolean,
@@ -26,7 +26,7 @@ const AmberSwitch = styled(Switch)(({ theme }) => ({
     '& .MuiSwitch-switchBase.Mui-checked.Mui-disabled': {
         color: amber[300],
     }        
-}));
+}))
 
 export default function WptToggle(props: Props) {
     return (

--- a/src/web/command_control/client/components/WptToggle.tsx
+++ b/src/web/command_control/client/components/WptToggle.tsx
@@ -12,23 +12,23 @@ interface Props {
     title?: string
 }
 
-export default function WptToggle(props: Props) {
-    // MUI Styling: mui.com/material-ui/react-switch
-    const AmberSwitch = styled(Switch)(({ theme }) => ({
-        '& .MuiSwitch-switchBase.Mui-checked': {
-            color: amber[600],
-            '&:hover': {
-            backgroundColor: alpha(amber[600], theme.palette.action.hoverOpacity),
-            },
+// MUI Styling: mui.com/material-ui/react-switch
+const AmberSwitch = styled(Switch)(({ theme }) => ({
+    '& .MuiSwitch-switchBase.Mui-checked': {
+        color: amber[600],
+        '&:hover': {
+        backgroundColor: alpha(amber[600], theme.palette.action.hoverOpacity),
         },
-        '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-            backgroundColor: amber[600],
-        },
-        '& .MuiSwitch-switchBase.Mui-checked.Mui-disabled': {
-            color: amber[300],
-        }        
-    }));
+    },
+    '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+        backgroundColor: amber[600],
+    },
+    '& .MuiSwitch-switchBase.Mui-checked.Mui-disabled': {
+        color: amber[300],
+    }        
+}));
 
+export default function WptToggle(props: Props) {
     return (
         <FormGroup>
             <FormControlLabel 


### PR DESCRIPTION
# bug/task-packet-date-selection-does-not-reset-when-toggled

### Description:
When you toggle off Edit Dates, the "Keep end date current" check box is not reset to the default of being turned on which prevents you from getting new task packets

### Approach:
* "Keep end date current" should be in state and it should be changed if the user toggles the Edit Dates view off

#### Important Variables & Functions:
`props.taskPacketsTimeline.keepEndDateCurrent`
`props.handleTaskPacketEditDatesToggle()`

### Tests
ED = Edit Dates
accord = accordion
* Open ED accord, turn off checkbox, close ED accord, reopen it...checkbox should be on
    * PASS
* Open ED accord, turn off checkbox, change end date, close ED accord, open it...date should reset to now and box should be checked
    * PASS
* Open ED accord, turn off checkbox, change start date, close ED accord, open ED accord...should keep the start date the user set
    * PASS
* Open ED accord, turn off checkbox, change start and end date, close ED accord, open ED accord...should keep the start date the user set and end date current
    * PASS