### PR TITLE
Bug/task constant heading input

### DIFF
--- a/src/web/command_control/client/components/TaskSettingsPanel.tsx
+++ b/src/web/command_control/client/components/TaskSettingsPanel.tsx
@@ -67,8 +67,13 @@ function TaskOptionsPanel(props: Props) {
     function onChangeConstantHeadingParameter(evt: React.ChangeEvent<HTMLInputElement>) {
         const target = evt.target
         const key = target.name as (keyof ConstantHeadingParameters)
-        const value = fmod(Number(target.value ?? ''), 360)
 
+        let value = Number(target.value)
+
+        if (key == 'constant_heading') {
+            value = fmod(value, 360)
+        }
+ 
         var newTask = deepcopy(task)
         newTask.constant_heading[key] = value
 

--- a/src/web/command_control/client/components/TaskSettingsPanel.tsx
+++ b/src/web/command_control/client/components/TaskSettingsPanel.tsx
@@ -12,7 +12,7 @@ import { Point } from 'ol/geom';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 
 // For keeping heading angles in the [0, 360] range
-function fmod(a: number, b: number) { 
+function fmod(a: number, b: number) {
     return Number((a - (Math.floor(a / b) * b)).toPrecision(8))
 }
 
@@ -65,9 +65,9 @@ function TaskOptionsPanel(props: Props) {
     }
 
     function onChangeConstantHeadingParameter(evt: React.ChangeEvent<HTMLInputElement>) {
-        const target = evt.target as any
+        const target = evt.target
         const key = target.name as (keyof ConstantHeadingParameters)
-        const value = Number(target.value)
+        const value = fmod(Number(target.value ?? ''), 360)
 
         var newTask = deepcopy(task)
         newTask.constant_heading[key] = value


### PR DESCRIPTION
FYI:  Because the heading field is a React "controlled" field (whose value always comes from the props), and we validate the value in the onChange handler, there isn't a possibility of going outside the [0,359] range and getting the read outline for the field.