### PR TITLE
bug/jcc-stops-updating-when-new-bots-startup

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -88,7 +88,6 @@ const sidebarInitialWidth = 0
 const mapSettings = GlobalSettings.mapSettings
 
 const POD_STATUS_POLL_INTERVAL = 1000
-const POD_STATUS_ERROR_POLL_INTERVAL = 2500
 const METADATA_POLL_INTERVAL = 10_000
 const TASK_PACKET_POLL_INTERVAL = 5000
 const MAX_GOALS = 30

--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -886,7 +886,11 @@ export default class CommandControl extends React.Component {
 	hubConnectionError(errMsg: String) {
 		this.setState({ disconnectionMessage: "Connection Dropped To HUB" })
 		console.error(errMsg)
-		clearInterval(this.podStatusPollId) // Clear regular poll from running alongside error poll
+		
+		// Clear regular poll from running alongside error poll
+		clearInterval(this.podStatusPollId)
+		this.podStatusPollId = null
+
 		if (!this.podStatusErrorPollId) {
 			this.podStatusErrorPollId = setInterval(() => this.pollPodStatus(), POD_STATUS_ERROR_POLL_INTERVAL)
 		}

--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -247,7 +247,6 @@ export default class CommandControl extends React.Component {
 	surveyPolygon: SurveyPolygon
 	surveyExclusions: SurveyExclusions
 	podStatusPollId: NodeJS.Timeout
-	podStatusErrorPollId: NodeJS.Timeout
 	metadataPollId: NodeJS.Timeout
 	flagNumber: number
 
@@ -421,7 +420,6 @@ export default class CommandControl extends React.Component {
 		})
 
 		this.podStatusPollId = null
-		this.podStatusErrorPollId = null
 		this.metadataPollId = null
 		this.taskPackets = []
 		this.taskPacketsCount = 0
@@ -840,18 +838,12 @@ export default class CommandControl extends React.Component {
 				}
 			},
 			(err) => {
-				console.log("Error response")
 				this.hubConnectionError(err.message)
 			}
 		)
-		// Handles inital poll and restart after error
-		if (!this.podStatusPollId && !this.state.disconnectionMessage) {
+		// Starts polling interval
+		if (!this.podStatusPollId) {
 			this.podStatusPollId = setInterval(() => this.pollPodStatus(), POD_STATUS_POLL_INTERVAL)
-		}
-		// Clears poll used during error state
-		if (this.podStatusErrorPollId && !this.state.disconnectionMessage) {
-			clearInterval(this.podStatusErrorPollId)
-			this.podStatusErrorPollId = null
 		}
 	}
 
@@ -886,14 +878,6 @@ export default class CommandControl extends React.Component {
 	hubConnectionError(errMsg: String) {
 		this.setState({ disconnectionMessage: "Connection Dropped To HUB" })
 		console.error(errMsg)
-		
-		// Clear regular poll from running alongside error poll
-		clearInterval(this.podStatusPollId)
-		this.podStatusPollId = null
-
-		if (!this.podStatusErrorPollId) {
-			this.podStatusErrorPollId = setInterval(() => this.pollPodStatus(), POD_STATUS_ERROR_POLL_INTERVAL)
-		}
 	}
 
 	getPodStatus() {


### PR DESCRIPTION
# bug/jcc-stops-updating-when-new-bots-startup

* When a pod status polling error occurs a pod status error polling interval is opened to poll at a slower rate and the normal poll closes. When the polling error is resolved, a new pod status poll should open at the nomral rate and the error poll should close.
* The bug is when the error is resolved, we are not opening a fresh pod status poll.
* For a new pod status poll to open after an error state the following conditional needs to be true: 
    ```
    // Handles inital poll and restart after error
    if (!this.podStatusPollId && !this.state.disconnectionMessage) {
        this.podStatusPollId = setInterval(
        () => this.pollPodStatus(),  POD_STATUS_POLL_INTERVAL)
    }
    ```
* The issue was when the polling error occured, the original interval closed and the error interval opened, however, I forgot to set this.podStatusPollId to null. By forgetting to set this to null, the old id remained in this.podStatusPollId so the above if statement was not being entered after the polling error terminated.

## Solution
* In the error handler, after clearning the orignal interval, set the this.podStatusPollId to null
```
// Clear regular poll from running alongside error poll
clearInterval(this.podStatusPollId)
this.podStatusPollId = null
```
### Updated Solution
* Remove the pod status error handling poll. We decided the complexity of managing two polls is not greater than the benefit of polling at a slower speed during a failed state

 
## Tests
1). Run the JCC and simulation...open the bot details panel to monitor the Status Age. With the Status Age flickering between 0 and 1s kill the server. This will force the pod status poll to close the current interval and open the error interval. After seeing the error state, restart the server. With the bug, the Status Age will freeze, without the bug, the Status Age will return to switching between 0 and 1s
    * PASS
