### PR TITLE
bug/deleting-run-has-lag

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -1244,16 +1244,16 @@ export default class CommandControl extends React.Component {
 	// 
 	async deleteAllRunsInMission(mission: MissionInterface, needConfirmation: boolean, rallyPointRun?: boolean) {
 		return new Promise((resolve, reject) => {
+			let updatedMission = {...mission}
 			const doDelete = () => {
-				const runs = mission.runs
-				for (const run of Object.values(runs)) {
-					const runNumber = Number(run.id.substring(4)) // run.id => run-x
-						delete mission.runs[run.id]
-						delete mission.botsAssignedToRuns[run.assigned]
+				for (const run of Object.values(mission.runs)) {
+					delete updatedMission.runs[run.id]
+					delete updatedMission.botsAssignedToRuns[run.assigned]
 				}
-				mission.runIdIncrement = 1
-				mission.runIdInEditMode = ''
-	
+				updatedMission.runIdIncrement = 1
+				updatedMission.runIdInEditMode = ''
+				this.setRunList(updatedMission)
+
 				resolve(true)			
 			}
 	
@@ -1665,6 +1665,9 @@ export default class CommandControl extends React.Component {
 		} else {
 			run = runs[botsAssignedToRuns[botId]]
 		}
+
+		// Prevent error after operator deletes an unassigned run and then clicks on the map
+		if (!run) { return }
 		
 		if (run.id !== this.getRunList().runIdInEditMode) {
 			warning('Run cannot be modified: toggle Edit in the Mission Panel, Bot Details Panel, or delete the run')

--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -1282,7 +1282,7 @@ export default class CommandControl extends React.Component {
 			console.error('Invalid runId passed to deleteSingleRun\n', err)
 		}
 		
-		const runList = this.pushRunListToUndoStack().getRunList()
+		const runList = {...this.pushRunListToUndoStack().getRunList()}
 		const selectedBotId = this.selectedBotId()
 		const warningString = runId ? `Are you sure you want to delete Run: ${runNumber}` : `Are you sure you want to delete this run for bot: ${selectedBotId}`
 	
@@ -1294,6 +1294,7 @@ export default class CommandControl extends React.Component {
 				this.setVisiblePanel(PanelType.NONE)
 				this.setMoveWptMode(false, `run-${this.state.goalBeingEdited?.runNumber}`, this.state.goalBeingEdited?.goalIndex)
 			}
+			this.setRunList(runList)
 		})
 	}
 

--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -1239,10 +1239,20 @@ export default class CommandControl extends React.Component {
 	// Run Mission (End)
 	// 
 
-	// 
-	// Delete Mission (Start)
-	// 
-	async deleteAllRunsInMission(mission: MissionInterface, needConfirmation: boolean, rallyPointRun?: boolean) {
+
+	/**
+	 * Reset mission planning
+	 * 
+	 * @param {MissionInterface} mission - used to access the mission state
+	 * @param {boolean} needConfirmation - does the deletion require a confirmation by the opertor?
+	 * @param {boolean} rallyPointMission - is the mission a rally point mission?
+	 * @return {Promise<boolean>} - did the deletion occur? If (yes) then (true)
+	 */
+	async deleteAllRunsInMission(
+		mission: MissionInterface,
+		needConfirmation: boolean,
+		rallyPointMission?: boolean
+	) {
 		return new Promise((resolve, reject) => {
 			let updatedMission = {...mission}
 			const doDelete = () => {
@@ -1258,7 +1268,7 @@ export default class CommandControl extends React.Component {
 			}
 	
 			if (needConfirmation) {
-				const warningString = this.generateDeleteAllRunsWarnStr(rallyPointRun)
+				const warningString = this.generateDeleteAllRunsWarnStr(rallyPointMission)
 				CustomAlert.confirm(warningString, 'Delete All Runs', doDelete, () => { resolve(false) })
 			}
 			else {
@@ -1636,6 +1646,12 @@ export default class CommandControl extends React.Component {
 		this.addWaypointAt(getGeographicCoordinate(coordinate, map))
 	}
 
+	/**
+	 * Add a waypoint to the OpenLayers map for a given tap/click
+	 * 
+	 * @param {GeographicCoordinate} location - where the waypoint should be added
+	 * @returns {void}
+	 */
 	addWaypointAt(location: GeographicCoordinate) {
 		let botId = this.selectedBotId()
 		let runList = this.pushRunListToUndoStack().getRunList()

--- a/src/web/shared/Utilities.tsx
+++ b/src/web/shared/Utilities.tsx
@@ -148,6 +148,17 @@ function handleAccordionDropdownClick(event: Event, targetClassName: string, par
     }, dropdownTimeout)
 }
 
+/**
+ * Scroll a dropdown element into view within its parent element
+ * 
+ * @param {string} parentContainerId - allows us to get dimensions of the parent element
+ * @param dropdownContainer - gives us access to dimensions of the dropdown element
+ * @returns {void}
+ * 
+ * @notes
+ * The dropdown is passed as an HTMLElement to prevent the developer from having to assign ids to
+ * each dropdown element in an accordion
+ */
 export function adjustAccordionScrollPosition(parentContainerId: string, dropdownContainer: HTMLElement) {
     const parentContainer = document.getElementById(parentContainerId)
 
@@ -161,7 +172,8 @@ export function adjustAccordionScrollPosition(parentContainerId: string, dropdow
     if (dropdownContainerSpecs.height > parentContainerSpecs.height) {
         const heightDiff = dropdownContainerSpecs.height - parentContainerSpecs.height
         parentContainer.scrollBy({
-            // Subtracting heightDiff reduces scroll by number of pixels dropdownContainer is larger than botDetailsAccordionContainer
+            // Subtracting heightDiff reduces scroll by number of pixels dropdownContainer is larger
+            // than botDetailsAccordionContainer
             top: dropdownContainerSpecs.bottom - parentContainerSpecs.bottom - heightDiff,
             left: 0
         })

--- a/src/web/shared/Utilities.tsx
+++ b/src/web/shared/Utilities.tsx
@@ -150,6 +150,11 @@ function handleAccordionDropdownClick(event: Event, targetClassName: string, par
 
 export function adjustAccordionScrollPosition(parentContainerId: string, dropdownContainer: HTMLElement) {
     const parentContainer = document.getElementById(parentContainerId)
+
+    if (!parentContainer || !dropdownContainer) {
+        return
+    }
+
     const parentContainerSpecs: DOMRect = parentContainer.getBoundingClientRect()
     const dropdownContainerSpecs: DOMRect = dropdownContainer.getBoundingClientRect()
 


### PR DESCRIPTION
# bug/deleting-run-has-lag

## Problem
* When the operator deletes a run from the Details Panel or using the delete all runs button in the Mission Panel there can be lag in the run(s) disappearing from the map
#### Cause of Problem
* The run(s) is deleted from the runList, but setState is not called after


## Solution
* Call `setRunList` passing the updated runList as the argument. This function calls setState and also updates the runList version which is needed for the undo button

## Tests
3x = repeat 3 times
* Delete a run with no throttle from the Details Panel...does it happen instantly? 3x
    * PASS
* Delete a run with no throttle from the Mission Panel (unassigned)...does it happen instantly? 3x
    * PASS
* Delete a run with no throttle from the Mission Panel (assigned)...does it happen instantly? 3x
    * PASS
* Delete 3 runs with no throttle from the Mission Panel using the delete all button...does it happen instantly?
    * FAIL
    * The delete all runs button was also not updating state immediately after. I added the code to make it do so and it passed.
    * PASS
* Delete a run from the Details Panel with 4x throttle...does it happen instantly? 3x
    * PASS
* Delete 3 runs individually from the Mission Panel with 4x throttle...does it happen instantly? 3x
    * PASS
* Delete 3 runs from the Mission Panel with 4x throttle using the delete all button...does it happen instantly? 3x
    * PASS
* Repeat the tests 1 and 3 on a different bot
    * PASS
* Undo a deletion from Details Panel, Mission Panel (individual run deletion and all runs deleletion)
    * PASS


#### Errors Encountered
* `Uncaught TypeError: Cannot read properties of null (reading 'getBoundingClientRect')`
    * Resolved with:
        ```
        if (!parentContainer || !dropdownContainer) {
            return
        }
        ```
* `Uncaught TypeError: Cannot read properties of undefined (reading 'id')
    at CommandControl.addWaypointAt (CommandControl.tsx:1669:11)`
    * Resolved with:
        * `if (!run) { return }`
