### PR TITLE
bug/omp-switching-dive-to-none-breaks

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -1618,7 +1618,7 @@ export default class CommandControl extends React.Component {
 			if (this.state.missionParams.missionType === 'lines' && this.state.mode === Mode.MISSION_PLANNING) {
 				// Add the mission planning feature
 				let mpFeature = this.state.missionPlanningFeature;
-				mpFeature.setStyle(surveyStyle(mpFeature, this.state.missionBaseGoal.task.type))
+				mpFeature.setStyle(surveyStyle(mpFeature, this.state.missionBaseGoal.task?.type))
 				missionPlanningFeaturesList.push(mpFeature)
 			}
 		}


### PR DESCRIPTION
# bug/omp-switching-dive-to-none-breaks
When an operator creates a line tool mission with a Task, and then decides to create another line tool mission with a Task of NONE, the UI crashes on the second click to create the waypoints

### Error
The UI crashes becasue `task` turns to `null` when the operator selects NONE, and when this code executes, an error is thrown saying `task` does not have any properties
```
updateMissionPlanningLayer() {
    // Code above
    let mpFeature = this.state.missionPlanningFeature;
    mpFeature.setStyle(
        surveyStyle(mpFeature, this.state.missionBaseGoal.task.type)
    )
    // Code below
}
```
### Solution
Check that `task` has the property `type` by adding a question mark before we attempt to access `type`
```
updateMissionPlanningLayer() {
    // Code above
    let mpFeature = this.state.missionPlanningFeature;
    mpFeature.setStyle(
        surveyStyle(mpFeature, this.state.missionBaseGoal.task?.type)
    )
    // Code below
}
```

### Tests
* Create a line tool mission with the Task of DIVE. Then create a line tool mission with the task of NONE. Does the UI crash?
    * PASS
* Create a line tool mission with the Task of DRIFT. Then create a line tool mission with the task of NONE. Does the UI crash?
    * PASS
*  Create a line tool mission with the Task of STATION KEEP. Then create a line tool mission with the task of NONE. Does the UI crash?
    * PASS
* Create a line tool mission with the Task of CONSTANT HEADING. Then create a line tool mission with the task of NONE. Does the UI crash?
    * PASS
* Create a line tool mission with the Task of NONE. Then create a line tool mission with the task of DIVE. Finally create a line tool mission with the task of NONE. Does the UI crash?]
    * PASS
* Create a line tool mission with the Task of DIVE. Then create a line tool mission with the task of NONE for differnt rally points. Does the UI crash?
    * PASS
