### PR TITLE
feature/update-slip-radius-for-wpt-with-no-task

### DIFF
--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -94,3 +94,7 @@ imu_restart_seconds: 10 # (default = 10)
 
 # If using wifi we need to subscribe to the hub on start, since the hub doesn't know what bots are running
 $subscribe_to_hub_on_start
+
+# Waypoint Transit Behavior Updates
+waypoint_with_no_task_slip_radius: 15 # (default = 15)
+waypoint_with_task_slip_radius: 5 # (default = 5)

--- a/src/bin/mission_manager/config.proto
+++ b/src/bin/mission_manager/config.proto
@@ -197,4 +197,10 @@ message MissionManager
     // timeout for when to stop logging if in failed state
     optional int32 failed_startup_log_timeout = 85
         [default = 300, (dccl.field).units = { base_dimensions: "T" }];
+
+    // used to update transitting to waypoint to allow more overshoot
+    optional int32 waypoint_with_no_task_slip_radius = 86 [default = 15];
+
+    // used to update transitting to waypoint to allow less overshoot
+    optional int32 waypoint_with_task_slip_radius = 87 [default = 5];
 }

--- a/src/lib/messages/mission.proto
+++ b/src/lib/messages/mission.proto
@@ -280,6 +280,8 @@ message IvPBehaviorUpdate
         optional double speed = 4 [
             (dccl.field).units = { base_dimensions: "LT^-1" }
         ];  // meters/second
+
+        optional int32 slip_radius = 5;
     }
 
     message StationkeepUpdate

--- a/src/lib/moos_gateway/jaiabot_gateway_plugin.cpp
+++ b/src/lib/moos_gateway/jaiabot_gateway_plugin.cpp
@@ -51,7 +51,8 @@ void jaiabot::moos::IvPHelmTranslation::publish_bhv_update(
             {
                 std::stringstream update_ss;
                 update_ss << "point=" << update.transit().x() << "," << update.transit().y()
-                          << "#speed=" << update.transit().speed();
+                          << "#speed=" << update.transit().speed()
+                          << "#nm_radius=" << update.transit().slip_radius();
                 moos().comms().Notify("JAIABOT_TRANSIT_UPDATES", update_ss.str());
             }
 

--- a/src/lib/moos_gateway/jaiabot_gateway_plugin.cpp
+++ b/src/lib/moos_gateway/jaiabot_gateway_plugin.cpp
@@ -52,7 +52,7 @@ void jaiabot::moos::IvPHelmTranslation::publish_bhv_update(
                 std::stringstream update_ss;
                 update_ss << "point=" << update.transit().x() << "," << update.transit().y()
                           << "#speed=" << update.transit().speed()
-                          << "#nm_radius=" << update.transit().slip_radius();
+                          << "#slip_radius=" << update.transit().slip_radius();
                 moos().comms().Notify("JAIABOT_TRANSIT_UPDATES", update_ss.str());
             }
 


### PR DESCRIPTION
Added slip radius updates based on if a waypoint has a task or not