### PR TITLE
bug/undo-not-working-if-wpt-panel-is-open

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -1728,7 +1728,6 @@ export default class CommandControl extends React.Component {
 			// Clicked on goal / waypoint
 			const goal = feature.get('goal')
 			if (goal) {
-				this.pushRunListToUndoStack()
 				const goalBeingEdited = {
 					goal: goal,
 					goalIndex: feature.get('goalIndex'),
@@ -2829,6 +2828,11 @@ export default class CommandControl extends React.Component {
 			const runList = this.state.undoRunListStack.pop()
 			this.setRunList(runList)
 			this.setState({goalBeingEdited: null})
+			
+			// If the reversion makes the open panel irrelevant, close it
+			if (this.state.visiblePanel === PanelType.GOAL_SETTINGS) {
+				this.setState({ visiblePanel: PanelType.NONE })
+			}
 		})
 	}
 


### PR DESCRIPTION
# bug/undo-not-working-if-wpt-panel-is-open

## Problem
Clicking/tapping the undo button when the GoalSettings panel is open does not revert the UI to the previous change

## Cause
When an operator would click on a waypoint, the function `this.pushRunListToUndoStack()` fired. As a result, the undo button needed to be clicked twice to revert to the previous change.

## Solution
* Remove the function call `this.pushRunListToUndoStack()`
* Close the GoalSettings panel since the data no longer exists

## Tests
* Create a one waypoint run, click on the waypoint, then undo
    * PASS
* Create a two waypoint run, click on the first waypoint, then undo
    * PASS
* Create a two waypoint run, click on the second waypoint, then undo
    * PASS
* Create a three waypoint run, click on the middle waypoint, then undo
    * PASS
* Create a three waypoint run, click on the middle waypoint, close the panel, then click undo
    * PASS
* Create a run with one bot, create a run with a second bot, click on a a waypoint of the unselected bot, click undo. Does it undo the most recent change?
    * PASS
* Create a run without assignment, select a waypoint, undo
    * PASS