### PR TITLE
bug/handle-task-packet-retrieval-errors

### DIFF
--- a/src/python/pyjaia/pyjaia/drift_interpolation.py
+++ b/src/python/pyjaia/pyjaia/drift_interpolation.py
@@ -175,10 +175,15 @@ def taskPacketsToDrifts(taskPackets: List[Dict]):
         if drift is not None:
             location = drift['start_location']
             location = LatLon(lat=location['lat'], lon=location['lon'])
-
-            estimated_drift = drift['estimated_drift']
-            drift = Drift(location=location, speed=estimated_drift['speed'], heading=estimated_drift['heading'] or 0.0)
-            drifts.append(drift)
+            
+            estimated_drift = drift.get('estimated_drift', None)
+            if estimated_drift is not None:
+                speed = estimated_drift.get('speed', 0.0)
+                heading = estimated_drift.get('heading', 0.0)
+                drift = Drift(
+                    location=location, speed=speed, heading=heading
+                )
+                drifts.append(drift)
 
     return drifts
 

--- a/src/web/command_control/client/components/TaskPackets.tsx
+++ b/src/web/command_control/client/components/TaskPackets.tsx
@@ -283,17 +283,25 @@ export class TaskData {
     }
 
     /**
-     * Updates the interpolated drift layer by accessing the API
+     * Updates the interpolated drift layer through the Jaia API
+     * 
+     * @returns {void}
+     * 
+     * @notes
      * To Do: Figure out how to make multiple Drift Maps based on time/location
      */
     _updateInterpolatedDrifts() {
         jaiaAPI.getDriftMap()
         .then(features => {
-            const tFeatures = features.map(feature => {
-                feature.setGeometry(feature.getGeometry().transform('EPSG:4326', this.map.getView().getProjection()))
-                return feature
-            })
-            this.driftMapLayer.setSource(new VectorSource({ features: tFeatures }))
+            if (Array.isArray(features)) {
+                const tFeatures = features.map(feature => {
+                    feature.setGeometry(feature.getGeometry().transform('EPSG:4326', this.map.getView().getProjection()))
+                    return feature
+                })
+                this.driftMapLayer.setSource(new VectorSource({ features: tFeatures }))
+            } else {
+                console.error('_updateInterpolatedDrifts response void')
+            }
         }).catch(error => {
             console.error(error)
         })

--- a/src/web/command_control/common/JaiaAPI.ts
+++ b/src/web/command_control/common/JaiaAPI.ts
@@ -5,6 +5,7 @@ require('isomorphic-fetch');
 import { GeoJSON } from 'ol/format';
 import { Command, Engineering, CommandForHub, TaskPacket } from '../../shared/JAIAProtobuf';
 import { randomBase57, convertHTMLStrDateToISO } from '../client/components/shared/Utilities';
+import { Geometry } from 'ol/geom';
 
 export class JaiaAPI {
   clientId: string
@@ -121,9 +122,11 @@ export class JaiaAPI {
 
   /**
    * Gets a GeoJSON object with interpolated drift features
-   * @date 10/5/2023 - 5:22:32 AM
+   * 
+   * @param {string} startDate (optional) Set a lower bound on drift packets used for interpolation
+   * @param {string} endDate (optional) Set an upper bound of drift packets used for interpolation
    *
-   * @returns {*} A GeoJSON feature set containing interpolated drift features
+   * @returns {Feature<Geometry>[] | void} A GeoJSON feature set containing interpolated drift features
    */
   getDriftMap(startDate?: string, endDate?: string) {
     if (startDate && endDate) {
@@ -133,6 +136,8 @@ export class JaiaAPI {
         this.get(`jaia/drift-map?startDate=${startDateStr}&endDate=${endDateStr}`).then((geoJSON) => {
           const features = new GeoJSON().readFeatures(geoJSON)
           return features
+        }).catch((err) => {
+          logResReqError('getDriftMap', err)
         })
       )
     } else {
@@ -141,6 +146,8 @@ export class JaiaAPI {
         this.get(`jaia/drift-map`).then((geoJSON) => {
           const features = new GeoJSON().readFeatures(geoJSON)
           return features
+        }).catch((err) => {
+          logResReqError('getDriftMap', err)
         })
       )
     } 
@@ -171,6 +178,18 @@ export class JaiaAPI {
   postMissionFilesCreate(descriptor: any) {
     return this.post('missionfiles/create', descriptor)
   }
+}
+
+/**
+ * Combine console.error and console.log into one function to reduce code repetition
+ * 
+ * @param {string} functionName Used as location input to the error msg to help debug
+ * @param {Error} error Prints the error object to make all debug data visible
+ * @returns {void}
+ */
+function logResReqError(functionName: string, error: Error) {
+  console.error(`${functionName}:`, error)
+  console.log(`${functionName}:`, error)
 }
 
 export const jaiaAPI = new JaiaAPI(randomBase57(22), '/', false)


### PR DESCRIPTION
## Objective:
* Validate the keys of the drift packet dictionaries before directly accessing them in the creation of the drift map
## Tests: 
1) 1 bot, 3 waypoints, all drifts
* **Pre-changes:** server crashes due to key error when creating the drift map
* **Post-changes:** no crash and no errors thrown or logged; TaskPackets display as expected

2) 2 bots, 5 waypoint line tool mission with all dives and an ending drift task
* **Post-changes:** no crash and no errors thrown or logged; TaskPackets display as expected

