### PR TITLE
task/remove-hover-over-for-custom-buttons

### DIFF
--- a/src/web/shared/CustomAlert.css
+++ b/src/web/shared/CustomAlert.css
@@ -48,11 +48,3 @@ div.button {
     margin: 0pt 20pt 0pt 20pt;
     user-select: none;
 }
-
-div.button:hover {
-    background-color: darkgray;
-}
-
-div.button:active {
-    background-color: #707070;
-}


### PR DESCRIPTION
On the tablet, the hover color change would not revert to its original color after a hover. This pull request removes visual effects from the buttons located in the notification popups.