### PR TITLE
bug/select-logs-panel-needs-to-be-bigger-for-tablet

### DIFF
--- a/src/web/jdv/client/src/index.css
+++ b/src/web/jdv/client/src/index.css
@@ -97,9 +97,9 @@ button {
 
 .dialog {
     position: fixed;
-    left: 25%;
+    left: 10%;
     top: 10%;
-    right: 25%;
+    right: 10%;
     z-index: 10000;
 
     background-color: whitesmoke;


### PR DESCRIPTION
Fix width of the LogSelector to have 10% margins,to look good on a tablet (1024x768)