### PR TITLE
bug/permissions-on-python-files-not-kept

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -23,3 +23,5 @@ add_custom_target(pyjaia_messages
   ALL
   DEPENDS ${pyjaia_outdir}/dccl/option_extensions_pb2.py jaiabot_messages
   )
+
+install(DIRECTORY ${project_SHARE_DIR}/jaiabot/python DESTINATION share/jaiabot USE_SOURCE_PERMISSIONS)


### PR DESCRIPTION
This line was removed accidentally, adding USE_SOURCE_PERMISSIONS back to python directory CMakelist.txt