### PR TITLE
bug/jdv-not-showing-logs-fleet-1

### DIFF
--- a/src/web/jdv/server/h5_tools.py
+++ b/src/web/jdv/server/h5_tools.py
@@ -9,7 +9,13 @@ UINT32_MAX = (2 << 31) - 1
 
 
 def h5_get_files(filenames):
-    return [h5py.File(fn) for fn in filenames]
+    h5Files: h5py.File = []
+    for fn in filenames:
+        try:
+            h5Files.append(h5py.File(fn))
+        except OSError:
+            continue
+    return h5Files
 
 
 def h5_get_string(string_dataset: h5py.Dataset, length_dataset: h5py.Dataset, index: int):

--- a/src/web/jdv/server/jaia_h5.py
+++ b/src/web/jdv/server/jaia_h5.py
@@ -69,7 +69,7 @@ class JaiaH5FileSet:
         try:
             h5File = self.h5Files[0]
         except IndexError:
-            None
+            return None
 
         # Get duration of the first log, if the h5 file exists
         try:
@@ -90,8 +90,8 @@ class JaiaH5FileSet:
                 if h5Path.is_file():
                     try:
                         h5Files.append(h5py.File(h5FileName))
-                    except BlockingIOError as e:
-                        logging.warning(f'While trying to open {h5FileName}, exception occured: {e}')
+                    except (BlockingIOError, OSError) as e:
+                        logging.debug(f'While trying to open {h5FileName}, exception occured: {e}')
                     continue
 
                 # h5 file doesn't exist
@@ -118,7 +118,11 @@ class JaiaH5FileSet:
                     raise e
 
                 # Add the generated or existing h5 file
-                h5Files.append(h5py.File(h5FileName))
+                try:
+                    h5Files.append(h5py.File(h5FileName))
+                except (OSError) as e:
+                    logging.debug(f'{e}: while opening {h5FileName}')
+                    continue
 
         self.h5Files = h5Files
 

--- a/src/web/jdv/server/jaialog_store.py
+++ b/src/web/jdv/server/jaialog_store.py
@@ -203,7 +203,15 @@ class JaialogStore:
     
 
     def openLogs(self, logNames: List[str]):
-        return [self.openLog(logName) for logName in logNames]
+        logs: [h5py.File] = []
+        for logName in logNames:
+            try:
+                logs.append(self.openLog(logName))
+            except OSError:
+                # Corrupt hdf5 file?
+                continue
+        
+        return logs
 
 
     def convertIfNeeded(self, log_names: List[str]):


### PR DESCRIPTION
Fixed exceptions when corrupted hdf5 files are present in the log directory