### PR TITLE
task/data-offload-taskpacket-and-goby-file

### DIFF
--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -61,7 +61,7 @@ data_offload_command: "jaiabot-dataoffload.sh $log_dir"  #  (required)
 log_dir: "$log_dir" # (required)
 hub_start_ip: 10 # (required)
 class_b_network: "10.23" # (required)
-data_offload_exclude: "" # (optional)
+# data_offload_exclude: GOBY # (optional)
 
 # Can enable one or more test modes to override normal operational settings
 #test_mode: ENGINEERING_TEST__ALWAYS_LOG_EVEN_WHEN_IDLE

--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -61,7 +61,7 @@ data_offload_command: "jaiabot-dataoffload.sh $log_dir"  #  (required)
 log_dir: "$log_dir" # (required)
 hub_start_ip: 10 # (required)
 class_b_network: "10.23" # (required)
-data_offload_only_task_packet_file: false # (optional)
+data_offload_exclude: "" # (optional)
 
 # Can enable one or more test modes to override normal operational settings
 #test_mode: ENGINEERING_TEST__ALWAYS_LOG_EVEN_WHEN_IDLE

--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -61,7 +61,8 @@ data_offload_command: "jaiabot-dataoffload.sh $log_dir"  #  (required)
 log_dir: "$log_dir" # (required)
 hub_start_ip: 10 # (required)
 class_b_network: "10.23" # (required)
-# data_offload_exclude: GOBY # (optional)
+# data_offload_exclude options: (NONE, GOBY, TASKPACKET)
+data_offload_exclude: NONE # (optional)
 
 # Can enable one or more test modes to override normal operational settings
 #test_mode: ENGINEERING_TEST__ALWAYS_LOG_EVEN_WHEN_IDLE

--- a/src/bin/mission_manager/config.proto
+++ b/src/bin/mission_manager/config.proto
@@ -167,10 +167,12 @@ message MissionManager
     // e.g. /var/log/jaiabot/bot/*/
     required string log_dir = 71;
 
-    // Follows the rsync --exclude structure
-    // Currently we allow a single file type to be excluded
-    // Example: data_offload_exclude = "*.goby"
-    optional string data_offload_exclude = 72 [default = ""];
+    enum DownloadFileTypes
+    {
+        GOBY = 1;
+        TASKPACKET = 2;
+    }
+    optional DownloadFileTypes data_offload_exclude = 72;
 
     required int32 hub_start_ip = 73 [default = 10];
 

--- a/src/bin/mission_manager/config.proto
+++ b/src/bin/mission_manager/config.proto
@@ -169,8 +169,9 @@ message MissionManager
 
     enum DownloadFileTypes
     {
-        GOBY = 1;
-        TASKPACKET = 2;
+        NONE = 1;
+        GOBY = 2;
+        TASKPACKET = 3;
     }
     optional DownloadFileTypes data_offload_exclude = 72;
 

--- a/src/bin/mission_manager/config.proto
+++ b/src/bin/mission_manager/config.proto
@@ -167,9 +167,10 @@ message MissionManager
     // e.g. /var/log/jaiabot/bot/*/
     required string log_dir = 71;
 
-    // Set to true if we want to not send goby files to hub during offload,
-    // We instead would send a taskpacket file
-    optional bool data_offload_only_task_packet_file = 72 [default = false];
+    // Follows the rsync --exclude structure
+    // Currently we allow a single file type to be excluded
+    // Example: data_offload_exclude = "*.goby"
+    optional string data_offload_exclude = 72 [default = ""];
 
     required int32 hub_start_ip = 73 [default = 10];
 

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -114,15 +114,6 @@ jaiabot::statechart::predeployment::StartingUp::StartingUp(typename StateBase::m
     int timeout_seconds = cfg().startup_timeout_with_units<goby::time::SITime>().value();
     goby::time::SteadyClock::duration timeout_duration = std::chrono::seconds(timeout_seconds);
     timeout_stop_ = timeout_start + timeout_duration;
-
-    if (cfg().data_offload_only_task_packet_file())
-    {
-        glog.is_debug1() && glog << "Create a task packet file and only offload that file"
-                                 << "to hub (ignore sending goby files)" << std::endl;
-
-        // Extra exclusions for rsync
-        this->machine().set_data_offload_exclude(" '*.goby'");
-    }
 }
 
 jaiabot::statechart::predeployment::StartingUp::~StartingUp() {}
@@ -332,7 +323,7 @@ jaiabot::statechart::inmission::underway::Task::~Task()
     if (task_packet_.type() == protobuf::MissionTask::DIVE ||
         task_packet_.type() == protobuf::MissionTask::SURFACE_DRIFT)
     {
-        if (cfg().data_offload_only_task_packet_file())
+        if (cfg().data_offload_exclude() != "*.taskpacket")
         {
             // Convert to json string
             std::string json_string;
@@ -1408,7 +1399,7 @@ jaiabot::statechart::postdeployment::DataProcessing::DataProcessing(
     typename StateBase::my_context c)
     : StateBase(c)
 {
-    if (cfg().data_offload_only_task_packet_file())
+    if (cfg().data_offload_exclude() != "*.taskpacket")
     {
         // Reset if recovered
         // If bot is activated again and more task packets

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -119,10 +119,10 @@ jaiabot::statechart::predeployment::StartingUp::StartingUp(typename StateBase::m
     switch (cfg().data_offload_exclude())
     {
         case config::MissionManager::GOBY:
-            this->machine().set_data_offload_exclude("*.goby");
+            this->machine().set_data_offload_exclude(" '*.goby'");
             break;
         case config::MissionManager::TASKPACKET:
-            this->machine().set_data_offload_exclude("*.taskpacket");
+            this->machine().set_data_offload_exclude(" '*.taskpacket'");
             break;
         default: this->machine().set_data_offload_exclude(""); break;
     }

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -124,6 +124,7 @@ jaiabot::statechart::predeployment::StartingUp::StartingUp(typename StateBase::m
         case config::MissionManager::TASKPACKET:
             this->machine().set_data_offload_exclude(" '*.taskpacket'");
             break;
+        case config::MissionManager::NONE: this->machine().set_data_offload_exclude(""); break;
         default: this->machine().set_data_offload_exclude(""); break;
     }
 }

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -114,6 +114,18 @@ jaiabot::statechart::predeployment::StartingUp::StartingUp(typename StateBase::m
     int timeout_seconds = cfg().startup_timeout_with_units<goby::time::SITime>().value();
     goby::time::SteadyClock::duration timeout_duration = std::chrono::seconds(timeout_seconds);
     timeout_stop_ = timeout_start + timeout_duration;
+
+    // update which files are excluded from data offload
+    switch (cfg().data_offload_exclude())
+    {
+        case config::MissionManager::GOBY:
+            this->machine().set_data_offload_exclude("*.goby");
+            break;
+        case config::MissionManager::TASKPACKET:
+            this->machine().set_data_offload_exclude("*.taskpacket");
+            break;
+        default: this->machine().set_data_offload_exclude(""); break;
+    }
 }
 
 jaiabot::statechart::predeployment::StartingUp::~StartingUp() {}
@@ -323,7 +335,7 @@ jaiabot::statechart::inmission::underway::Task::~Task()
     if (task_packet_.type() == protobuf::MissionTask::DIVE ||
         task_packet_.type() == protobuf::MissionTask::SURFACE_DRIFT)
     {
-        if (cfg().data_offload_exclude() != "*.taskpacket")
+        if (cfg().data_offload_exclude() != config::MissionManager::TASKPACKET)
         {
             // Convert to json string
             std::string json_string;
@@ -1399,7 +1411,7 @@ jaiabot::statechart::postdeployment::DataProcessing::DataProcessing(
     typename StateBase::my_context c)
     : StateBase(c)
 {
-    if (cfg().data_offload_exclude() != "*.taskpacket")
+    if (cfg().data_offload_exclude() != config::MissionManager::TASKPACKET)
     {
         // Reset if recovered
         // If bot is activated again and more task packets

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -554,7 +554,7 @@ struct MissionManagerStateMachine
     std::string task_packet_file_name_{""};
     std::string data_time_string_{""};
     int32_t hub_id_{0};
-    std::string data_offload_exclude_{cfg().data_offload_exclude()};
+    std::string data_offload_exclude_{""};
 };
 
 struct PreDeployment

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -554,7 +554,7 @@ struct MissionManagerStateMachine
     std::string task_packet_file_name_{""};
     std::string data_time_string_{""};
     int32_t hub_id_{0};
-    std::string data_offload_exclude_{""};
+    std::string data_offload_exclude_{cfg().data_offload_exclude()};
 };
 
 struct PreDeployment


### PR DESCRIPTION
# task/data-offload-taskpacket-and-goby-file

## Notes:
* A temporary solution due to the re-working of the download process happening in the coming months
    * Only one file type can be excluded at the moment: 
    ```
    enum DownloadFileTypes
    {
        NONE = 1;
        GOBY = 2;
        TASKPACKET = 3;
    }
    ```
    
## Tests
### Flat Fleet
* Set `data_offload_exclude` to NONE
    * Should see a .taskpacket file after the bot performs a task and a data download occurs
    * Should see a .goby file after the data download completes
        * **PASS**
* Set `data_offload_exclude` to GOBY
    * Should not see a .goby file after the data download completes (should see a .taskpacket file)
        * **PASS**
* Set `data_offload_exclude` to TASKPACKET
    * Should not see a .taskpacket file after the bot performs a task and a data download occurs (should also see a .goby file)
        * **PASS**
* Set`data_offload_exclude` to a invalid enum value:
    * Should not crash the program...should see a .error file downloaded to the hub
        * **PASS**