### PR TITLE
task/change-reverse-start-bound-when-diving-to-match-dive-throttle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,12 +172,14 @@ filter-template-master-only: &filter-template-master-only
     branches:
       only:
         - "1.y"
+        - "task/change-reverse-start-bound-when-diving-to-match-dive-throttle"  
 
 filter-template-non-master: &filter-template-non-master
   filters:
     branches:
       ignore:
         - "1.y"
+        - "task/change-reverse-start-bound-when-diving-to-match-dive-throttle"
         
 ## Begin actual config
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,14 +172,12 @@ filter-template-master-only: &filter-template-master-only
     branches:
       only:
         - "1.y"
-        - "task/change-reverse-start-bound-when-diving-to-match-dive-throttle"  
 
 filter-template-non-master: &filter-template-non-master
   filters:
     branches:
       ignore:
         - "1.y"
-        - "task/change-reverse-start-bound-when-diving-to-match-dive-throttle"
         
 ## Begin actual config
 version: 2

--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -70,6 +70,7 @@ Path(log_file_dir).mkdir(parents=True, exist_ok=True)
 debug_log_file_dir=log_file_dir 
 templates_dir=common.jaia_templates_dir
 
+# Milliseconds
 bot_status_period=1000
 
 node_id=common.bot.bot_index_to_node_id(bot_index)

--- a/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
+++ b/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
@@ -71,9 +71,9 @@ int motor_max_forward = 1900;
 int motor_max_reverse = 1100;
 
 // Motor Steps
-constexpr int motor_max_step_forward_faster = 3;
+constexpr int motor_max_step_forward_faster = 12;
 constexpr int motor_max_step_forward_slower = 12;
-constexpr int motor_max_step_reverse_faster = 3;
+constexpr int motor_max_step_reverse_faster = 12;
 constexpr int motor_max_step_reverse_slower = 12;
 
 // The thermocouple

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -724,6 +724,11 @@ void jaiabot::statechart::inmission::underway::task::dive::PoweredDescent::depth
     if (is_bot_diving_ || context<Dive>().has_bot_performed_a_hold() || cfg().is_sim())
     {
         setpoint_msg.set_dive_depth_with_units(context<Dive>().goal_depth());
+        setpoint_msg.set_is_init_dive_constant_throttle(false);
+    }
+    else
+    {
+        setpoint_msg.set_is_init_dive_constant_throttle(true);
     }
 
     interprocess().publish<jaiabot::groups::desired_setpoints>(setpoint_msg);

--- a/src/lib/messages/high_control.proto
+++ b/src/lib/messages/high_control.proto
@@ -69,5 +69,5 @@ message DesiredSetpoints
 
     optional bool is_helm_constant_course = 2 [default = false];
 
-    optional bool is_init_dive_constant_throttle = 3 [default = false];
+    optional bool is_init_dive_constant_throttle = 3;
 }

--- a/src/lib/messages/high_control.proto
+++ b/src/lib/messages/high_control.proto
@@ -68,4 +68,6 @@ message DesiredSetpoints
     };
 
     optional bool is_helm_constant_course = 2 [default = false];
+
+    optional bool is_init_dive_constant_throttle = 3 [default = false];
 }


### PR DESCRIPTION
ISSUE:

With the new fleet we have the occasional miss dive.

We need to get passed a ESC threshold that is causing a stall out.

When we begin our dive we will use the dive throttle configuration in the bounds file without ramping to that speed.

We have found this to be successful on the initial dive.

We then change the settings to use the ramping of the motor again after the initial dive state. 
