### PR TITLE
bug/mui-material-update-bug

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -9,7 +9,7 @@
         "@mdi/react": "^1.6.1",
         "@mui/icons-material": "^5.10.9",
         "@mui/joy": "^5.0.0-alpha.89",
-        "@mui/material": "^5.14.16",
+        "@mui/material": "5.15.7",
         "buffer": "^6.0.3",
         "es6-promise": "^4.2.8",
         "isomorphic-fetch": "^3.0.0",


### PR DESCRIPTION
Locking mui material node dependency until a fix is released for the new version 5.15.8