### PR TITLE
bug/authentication-required-to-restart-jaiabot-imu-py-service

### DIFF
--- a/src/bin/health/app.cpp
+++ b/src/bin/health/app.cpp
@@ -190,8 +190,15 @@ jaiabot::apps::Health::Health()
             {
                 case protobuf::IMUIssue::STOP_BOT: break;
                 case protobuf::IMUIssue::RESTART_IMU_PY:
-                    glog.is_debug2() && glog << "IMU ERROR: RESTART IMU PY. " << std::endl;
-                    restart_imu_py();
+                    if (!cfg().is_in_sim() || cfg().test_hardware_in_sim())
+                    {
+                        glog.is_debug2() && glog << "IMU ERROR: RESTART IMU PY. " << std::endl;
+                        restart_imu_py();
+                    }
+                    else
+                    {
+                        glog.is_debug2() && glog << "IMU ERROR: IGNORING IN SIM" << std::endl;
+                    }
                     break;
                 case protobuf::IMUIssue::REBOOT_BOT: break;
                 case protobuf::IMUIssue::USE_COG: break;
@@ -199,14 +206,29 @@ jaiabot::apps::Health::Health()
                 case protobuf::IMUIssue::REPORT_IMU: break;
                 case protobuf::IMUIssue::RESTART_BOT: break;
                 case protobuf::IMUIssue::REBOOT_BNO085_IMU:
-                    glog.is_debug2() && glog << "IMU ERROR: REBOOT IMU" << std::endl;
-                    reboot_bno085_imu();
+                    if (!cfg().is_in_sim() || cfg().test_hardware_in_sim())
+                    {
+                        glog.is_debug2() && glog << "IMU ERROR: REBOOT IMU" << std::endl;
+                        reboot_bno085_imu();
+                    }
+                    else
+                    {
+                        glog.is_debug2() && glog << "IMU ERROR: IGNORING IN SIM" << std::endl;
+                    }
                     break;
                 case protobuf::IMUIssue::REBOOT_BNO085_IMU_AND_RESTART_IMU_PY:
-                    glog.is_debug2() && glog << "IMU ERROR: REBOOT IMU and RESTART IMU PY. "
-                                             << std::endl;
-                    reboot_bno085_imu();
-                    restart_imu_py();
+                    if (!cfg().is_in_sim() || cfg().test_hardware_in_sim())
+                    {
+                        glog.is_debug2() && glog << "IMU ERROR: REBOOT IMU and RESTART IMU PY. "
+                                                 << std::endl;
+                        reboot_bno085_imu();
+                        restart_imu_py();
+                    }
+                    else
+                    {
+                        glog.is_debug2() && glog << "IMU ERROR: IGNORING IN SIM" << std::endl;
+                    }
+
                     break;
                 default:
                     //TODO Handle Default Case


### PR DESCRIPTION
In response to https://jaia-innovation.atlassian.net/jira/software/projects/JAIAB/boards/2?selectedIssue=JAIAB-856

This change simply ignores any IMU Issues when running in Simulation.  I tested this with 4 bots at warp 15.  Even though the systems resources were pegged at 100% and the machine was very sluggish there were no blocking pop-ups and the simulation ran for the most part.  Because there were still gaps in reported health from the bots they would turn yellow or red at times.  I ran a mission with a few dives and station keeping and most of the tuns at least 2 of the bots could complete the mission.  I think this is worth putting in place as it prevents the system from getting locked by stacked pop up dialogs.  