### PR TITLE
bug/playall-not-working-after-reassigning

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -2411,7 +2411,18 @@ export default class CommandControl extends React.Component {
 		return this.state.rcModeStatus[botId]
 	}
 
+	/**
+	 * This handles setting the RC mode so that it ends up in a clean state
+	 * 
+	 * @param {number} botId The id used to map the RC mode to a specific bot 
+	 * @param {boolean} rcMode Whether or not the bot is in RC
+	 * @returns {void} 
+	 */
 	setRcMode(botId: number, rcMode: boolean) {
+		if (botId === -1) {
+			return
+		}
+
 		// Clear interval before we set rc mode
 		this.clearRemoteControlInterval()
 


### PR DESCRIPTION
## Summary:
This pull request fixes the setRcMode function so that it handles botIds that are equal to -1. -1 is used to identify runs that are not assigned. If you attempted to click the playall button with an unassigned run preceding assigned runs then it would not work as expected.

## Details:

Function: setRcMode(botId: number, rcMode: boolean)
Fixed setRcMode error when botId==-1

## Testing:

1. Create two runs 
2. Assign a bot to one of the runs 
3. Click play all button
4. Bot should execute the assigned run