### PR TITLE
task/change-style-of-panel-headings

### DIFF
--- a/src/web/command_control/client/components/Details.tsx
+++ b/src/web/command_control/client/components/Details.tsx
@@ -1179,150 +1179,148 @@ export function HubDetailsComponent(props: HubDetailsProps) {
 
     return (
         <div id='hubDetailsBox'>
+            <div className='titleBar'>
+                <h2 className='name'>{`Hub ${hub?.hub_id}`}</h2>
+                <div onClick={() => closeWindow()} className='closeButton'>⨯</div>
+            </div>
             <div id='hubDetailsAccordionContainer' className='accordionParentContainer'>
-                <div className='HorizontalFlexbox'>
-                    <h2 className='name'>{`Hub ${hub?.hub_id}`}</h2>
-                    <div onClick={() => closeWindow()} className='closeButton'>⨯</div>
-                </div>
-                <div id='hubDetailsAccordionContainer'>
-                    <ThemeProvider theme={makeAccordionTheme()}>
-                        <Accordion 
-                            expanded={isExpanded.quickLook} 
-                            onChange={(event, expanded) => {setDetailsExpanded('quickLook', expanded)}}
-                            className='accordionContainer'
+                <ThemeProvider theme={makeAccordionTheme()}>
+                    <Accordion 
+                        expanded={isExpanded.quickLook} 
+                        onChange={(event, expanded) => {setDetailsExpanded('quickLook', expanded)}}
+                        className='accordionContainer'
+                    >
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            aria-controls='panel1a-content'
+                            id='panel1a-header'
                         >
-                            <AccordionSummary
-                                expandIcon={<ExpandMoreIcon />}
-                                aria-controls='panel1a-content'
-                                id='panel1a-header'
-                            >
-                                <Typography>Quick Look</Typography>
-                            </AccordionSummary>
-                            <AccordionDetails>
-                                <table>
-                                    <tbody>
-                                        {healthRow(hub, false)}
-                                        <tr>
-                                            <td>Latitude</td>
-                                            <td>{formatLatitude(hub.location?.lat)}</td>
-                                        </tr>
-                                        <tr>
-                                            <td>Longitude</td>
-                                            <td>{formatLongitude(hub.location?.lon)}</td>
-                                        </tr>
-                                        <tr className={statusAgeClassName}>
-                                            <td>Status Age</td>
-                                            <td>{statusAge.toFixed(0)} s</td>
-                                        </tr>
-                                        <tr>
-                                            <td>CPU Load Average (1 min)</td>
-                                            <td>{loadAverageOneMin}</td>
-                                        </tr>
-                                        <tr>
-                                            <td>CPU Load Average (5 min)</td>
-                                            <td>{loadAverageFiveMin}</td>
-                                        </tr>
-                                        <tr>
-                                            <td>CPU Load Average (15 min)</td>
-                                            <td>{loadAverageFifteenMin}</td>
-                                        </tr>
-                                        <tr>
-                                            <td>Wi-Fi Link Quality</td>
-                                            <td>{linkQualityPercentage + " %"}</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </AccordionDetails>
-                        </Accordion>
-                    </ThemeProvider>
+                            <Typography>Quick Look</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <table>
+                                <tbody>
+                                    {healthRow(hub, false)}
+                                    <tr>
+                                        <td>Latitude</td>
+                                        <td>{formatLatitude(hub.location?.lat)}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Longitude</td>
+                                        <td>{formatLongitude(hub.location?.lon)}</td>
+                                    </tr>
+                                    <tr className={statusAgeClassName}>
+                                        <td>Status Age</td>
+                                        <td>{statusAge.toFixed(0)} s</td>
+                                    </tr>
+                                    <tr>
+                                        <td>CPU Load Average (1 min)</td>
+                                        <td>{loadAverageOneMin}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>CPU Load Average (5 min)</td>
+                                        <td>{loadAverageFiveMin}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>CPU Load Average (15 min)</td>
+                                        <td>{loadAverageFifteenMin}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Wi-Fi Link Quality</td>
+                                        <td>{linkQualityPercentage + " %"}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </AccordionDetails>
+                    </Accordion>
+                </ThemeProvider>
 
-                    <ThemeProvider theme={makeAccordionTheme()}>
-                        <Accordion 
-                            expanded={isExpanded.commands} 
-                            onChange={(event, expanded) => {setDetailsExpanded('commands', expanded)}}
-                            className='accordionContainer'
+                <ThemeProvider theme={makeAccordionTheme()}>
+                    <Accordion 
+                        expanded={isExpanded.commands} 
+                        onChange={(event, expanded) => {setDetailsExpanded('commands', expanded)}}
+                        className='accordionContainer'
+                    >
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            aria-controls='panel1a-content'
+                            id='panel1a-header'
                         >
-                            <AccordionSummary
-                                expandIcon={<ExpandMoreIcon />}
-                                aria-controls='panel1a-content'
-                                id='panel1a-header'
-                            >
-                                <Typography>Commands</Typography>
-                            </AccordionSummary>
-                            <AccordionDetails>
-                                <Button className={' button-jcc'} 
-                                        onClick={() => { issueCommandForHub(api, hub.hub_id, commandsForHub.shutdown) }}>
-                                    <Icon path={mdiPower} title='Shutdown'/>
-                                </Button>
-                                <Button className={' button-jcc'} 
-                                        onClick={() => { issueCommandForHub(api, hub.hub_id, commandsForHub.reboot) }}>
-                                    <Icon path={mdiRestartAlert} title='Reboot'/>
-                                </Button>
-                                <Button className={' button-jcc'}  
-                                        onClick={() => { issueCommandForHub(api, hub.hub_id, commandsForHub.restartServices) }}>
-                                    <Icon path={mdiRestart} title='Restart Services'/>
-                                </Button>
-                            </AccordionDetails>
-                        </Accordion>
-                    </ThemeProvider>
+                            <Typography>Commands</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <Button className={' button-jcc'} 
+                                    onClick={() => { issueCommandForHub(api, hub.hub_id, commandsForHub.shutdown) }}>
+                                <Icon path={mdiPower} title='Shutdown'/>
+                            </Button>
+                            <Button className={' button-jcc'} 
+                                    onClick={() => { issueCommandForHub(api, hub.hub_id, commandsForHub.reboot) }}>
+                                <Icon path={mdiRestartAlert} title='Reboot'/>
+                            </Button>
+                            <Button className={' button-jcc'}  
+                                    onClick={() => { issueCommandForHub(api, hub.hub_id, commandsForHub.restartServices) }}>
+                                <Icon path={mdiRestart} title='Restart Services'/>
+                            </Button>
+                        </AccordionDetails>
+                    </Accordion>
+                </ThemeProvider>
 
-                    <ThemeProvider theme={makeAccordionTheme()}>
-                        <Accordion 
-                            expanded={isExpanded.links} 
-                            onChange={(event, expanded) => {setDetailsExpanded('links', expanded)}}
-                            className='accordionContainer'
+                <ThemeProvider theme={makeAccordionTheme()}>
+                    <Accordion 
+                        expanded={isExpanded.links} 
+                        onChange={(event, expanded) => {setDetailsExpanded('links', expanded)}}
+                        className='accordionContainer'
+                    >
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            aria-controls='panel1a-content'
+                            id='panel1a-header'
                         >
-                            <AccordionSummary
-                                expandIcon={<ExpandMoreIcon />}
-                                aria-controls='panel1a-content'
-                                id='panel1a-header'
+                            <Typography>Links</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <Button
+                                className={'button-jcc'} 
+                                onClick={() => {							
+                                    const hubId = 10 + hub?.hub_id
+                                    const fleetId = getFleetId()
+
+                                    if (fleetId != undefined
+                                        && !Number.isNaN(hubId)) {
+                                        // 40010 is the default port number set in jaiabot/src/web/jdv/server/jaiabot_data_vision.py
+                                        const url = `http://10.23.${fleetId}.${hubId}:40010`
+                                        window.open(url, '_blank')}}
+                                    }  
                             >
-                                <Typography>Links</Typography>
-                            </AccordionSummary>
-                            <AccordionDetails>
-                                <Button
-                                    className={'button-jcc'} 
-                                    onClick={() => {							
+                                <Icon path={mdiChartLine} title='JDV'/>
+                            </Button>
+                            <Button className="button-jcc" onClick={() => {
+                                const fleetId = getFleetId()
+
+                                if (fleetId != undefined) {
+                                    const url = `http://10.23.${fleetId}.1`
+                                    window.open(url, '_blank')}}
+                                }
+                            >
+                                <Icon path={mdiWifiCog} title="Router"></Icon>
+                            </Button>
+                            <Button className="button-jcc" onClick={() => 
+                                    {
                                         const hubId = 10 + hub?.hub_id
                                         const fleetId = getFleetId()
 
-                                        if (fleetId != undefined
-                                            && !Number.isNaN(hubId)) {
-                                            // 40010 is the default port number set in jaiabot/src/web/jdv/server/jaiabot_data_vision.py
-                                            const url = `http://10.23.${fleetId}.${hubId}:40010`
-                                            window.open(url, '_blank')}}
-                                        }  
-                                >
-                                    <Icon path={mdiChartLine} title='JDV'/>
-                                </Button>
-                                <Button className="button-jcc" onClick={() => {
-                                    const fleetId = getFleetId()
-
-                                    if (fleetId != undefined) {
-                                        const url = `http://10.23.${fleetId}.1`
-                                        window.open(url, '_blank')}}
-                                    }
-                                >
-                                    <Icon path={mdiWifiCog} title="Router"></Icon>
-                                </Button>
-                                <Button className="button-jcc" onClick={() => 
-                                        {
-                                            const hubId = 10 + hub?.hub_id
-                                            const fleetId = getFleetId()
-
-                                            if (fleetId != undefined) {
-                                                const url = `http://10.23.${fleetId}.${hubId}:9091`
-                                                window.open(url, '_blank')
-                                            }
+                                        if (fleetId != undefined) {
+                                            const url = `http://10.23.${fleetId}.${hubId}:9091`
+                                            window.open(url, '_blank')
                                         }
                                     }
-                                >
-                                    <Icon path={mdiWrenchCog} title="Upgrade"></Icon>
-                                </Button>
-                            </AccordionDetails>
-                        </Accordion>
-                    </ThemeProvider>
-                </div>
+                                }
+                            >
+                                <Icon path={mdiWrenchCog} title="Upgrade"></Icon>
+                            </Button>
+                        </AccordionDetails>
+                    </Accordion>
+                </ThemeProvider>
             </div>
         </div>
     )

--- a/src/web/command_control/client/style/CommandControl.less
+++ b/src/web/command_control/client/style/CommandControl.less
@@ -52,7 +52,6 @@ td {
   div,
   label {
     font-family: inherit;
-    letter-spacing: 0;
     line-height: 1;
   }
 
@@ -1349,10 +1348,10 @@ div.closeButton {
   margin: 4pt 8pt 0 8pt;
   padding: 2pt;
   
-  background-color: #FFFFFF;
-
+  color: #FFFFFF;
   font-size: 1.1rem;
   font-weight: bold;
+  letter-spacing: 0.5px;
   text-align: center;
 }
 

--- a/src/web/command_control/client/style/CommandControl.less
+++ b/src/web/command_control/client/style/CommandControl.less
@@ -1348,7 +1348,7 @@ div.closeButton {
   margin: 4pt 8pt 0 8pt;
   padding: 2pt;
   
-  color: #FFFFFF;
+  color: @cc-text-color-light;
   font-size: 1.1rem;
   font-weight: bold;
   letter-spacing: 0.25px;

--- a/src/web/command_control/client/style/CommandControl.less
+++ b/src/web/command_control/client/style/CommandControl.less
@@ -1351,7 +1351,7 @@ div.closeButton {
   color: #FFFFFF;
   font-size: 1.1rem;
   font-weight: bold;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.25px;
   text-align: center;
 }
 

--- a/src/web/command_control/client/style/components/Details.less
+++ b/src/web/command_control/client/style/components/Details.less
@@ -1,8 +1,9 @@
-.botDetailsHeading {
+.botDetailsHeading, #hubDetailsBox {
     .titleBar {
         display: flex;
         flex-direction: row;
         align-items: center;
+        justify-content: space-between;
         margin: 10pt 0pt 10pt 0pt;
 
         .botName {
@@ -19,8 +20,7 @@
         }
 
         .closeButton {
-            margin: 0pt 0pt 0pt 20pt;
+            margin: -2pt 0pt 0pt 20pt;
         }
-        
     }
 }

--- a/src/web/command_control/client/style/util.less
+++ b/src/web/command_control/client/style/util.less
@@ -15,6 +15,7 @@
 // Colors
 @cc-background-color: white;
 @cc-text-color: black;
+@cc-text-color-light: white;
 @cc-accordian-color: #767d7d;
 @cc-accordian-text-color: white;
 @cc-details-text-color: white;


### PR DESCRIPTION
## Summary
Removes the white background from the titles of the JCC panels to create a cleaner, more consistent look and adds a top margin to the Hub Details panel to match the Bot Details. 

## Details
The panelHeading class in `src/web/command_control/client/style/CommandControl.less` controls the style for the panel headings (excluding the Hub and Bot Details). I added a top margin to the Hub Details title to match the spacing in the Bot Details panels. 

## Testing
Clicked through all of the panels to visually inspect the appearance of the titles on desktop and tablet screen-sizes.

## Notes
All of the changes to `src/web/command_control/client/components/Details.tsx` come from removing a duplicate div to correctly set the margin-top. Removing the duplicate div requires a layer of indentation to be removed as well which is why git detected so many changes in that file.