### PR TITLE
task/remove-unused-omp-elements

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -269,7 +269,7 @@ export default class CommandControl extends React.Component {
 				'numGoals': (MAX_GOALS - 2),
 				'spacing': 30,
 				'orientation': 0,
-				'rallySpacing': 1,
+				'rallySpacing': 0,
 				'spArea': 0,
 				'spPerimeter': 0,
 				'spRallyStartDist': 0,

--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -269,7 +269,6 @@ export default class CommandControl extends React.Component {
 				'numGoals': (MAX_GOALS - 2),
 				'spacing': 30,
 				'orientation': 0,
-				'rallySpacing': 0,
 				'spArea': 0,
 				'spPerimeter': 0,
 				'spRallyStartDist': 0,

--- a/src/web/command_control/client/components/MissionSettings.tsx
+++ b/src/web/command_control/client/components/MissionSettings.tsx
@@ -112,22 +112,8 @@ export class MissionSettingsPanel extends React.Component {
 				<div className="panel-heading">Mission Settings</div>
                 
                 <div className="mission-settings-panel-container">
-
-                    <div className="mission-settings-input-label">Mission Edit Mode:</div>
-                    <FormControl sx={{ minWidth: 120 }} size="small">
-                        <Select onChange={(evt: SelectChangeEvent) => this.changeMissionEditMode(evt.target.value)}  value={missionType ?? "editing"}>
-                            <MenuItem value={"lines"}>Lines</MenuItem>
-                        </Select>
-                    </FormControl>
-
                     <div className="mission-settings-input-label">Mission Spacing:</div>
                     <div className="mission-settings-input-row"><input type="number" name="spacing" className="mission-settings-num-input" defaultValue={this.state.missionParams.spacing} onChange={this.changeMissionParameter.bind(this)} /> m</div>
-
-                    <div className="mission-settings-input-label">Rally Point Spacing:</div>
-                    <div className="mission-settings-input-row"><input type="number" name="rally_spacing" className="mission-settings-num-input" defaultValue={this.state.missionParams.rallySpacing} onChange={this.changeMissionParameter.bind(this)} /> m</div>
-
-                    <div className="mission-settings-input-label">Mission Orientation:</div>
-                    <div className="mission-settings-input-row"><input id='missionOrientation' name="orientation" className="mission-settings-num-input" readOnly={true} defaultValue={this.state.missionParams.orientation} onChange={this.changeMissionParameter.bind(this)} /> deg</div>
 
                     <div className="mission-settings-input-label">Start Rally:</div>
                     <FormControl sx={{ minWidth: 120 }} size="small">

--- a/src/web/command_control/client/components/MissionSettings.tsx
+++ b/src/web/command_control/client/components/MissionSettings.tsx
@@ -22,7 +22,6 @@ export interface MissionParams {
 	numGoals: number,
 	spacing: number,
 	orientation: number,
-	rallySpacing: number,
 	spArea: number,
 	spPerimeter: number,
 	spRallyStartDist: number,

--- a/src/web/command_control/client/components/SurveyMission.ts
+++ b/src/web/command_control/client/components/SurveyMission.ts
@@ -75,53 +75,6 @@ export function getSurveyMissionPlans(botIdList: number[], rallyStartLocation: G
     let missionPlans: CommandList = {};
     let millisecondsSinceEpoch = new Date().getTime();
 
-    /**
-     * Assign rally point coordinates to each botId in a list
-     * 
-     * @param botIdList List of botIds
-     * @param centerCoordinate Center coordinate of rally points 
-     * @param rotationAngle Angle along which to space rally points for each bot
-     * @param rallySpacing Spacing between rally points (meters)
-     * @returns Mapping from bot_id to rally point coordinates
-     */
-    function findRallySeparation(botIdList: number[], centerCoordinate: GeographicCoordinate, rotationAngle: number, rallySpacing: number) {
-        botIdList = deepcopy(botIdList)
-
-        // Bot rally point separation scheme
-        let rallyPoints: {[key: number]: number[]} = {};
-        let center = [centerCoordinate.lon, centerCoordinate.lat];
-        let radius = rallySpacing/1000;
-        if (botIdList.length >= 3) {
-            // We can use a circle to separate the bots
-            let options = {steps: botIdList.length};
-            let circle = turf.circle(center, radius, options);
-            let circleRallyPointsBasic = turf.coordAll(turf.cleanCoords(turf.multiPoint(circle.geometry.coordinates[0])));
-            circleRallyPointsBasic.forEach(p => {
-                rallyPoints[Number(botIdList.pop())] = p
-            })
-        } else {
-            // Alternative to using a circle for bot separation
-            let rhumbDestinationPoints: number[][][] = [];
-            let nextRadius = 0;
-            botIdList.forEach(bot => {
-                rhumbDestinationPoints.push(turf.coordAll(turf.rhumbDestination(turf.point(center), nextRadius, rotationAngle-90)));
-                nextRadius = nextRadius + radius;
-            })
-            rhumbDestinationPoints.forEach(p => {
-                rallyPoints[Number(botIdList.pop())] = p[0]
-            })
-        }
-        return rallyPoints
-    }
-
-    // Bot rally point separation scheme
-    let rallyStartPoints = findRallySeparation(botIdList, rallyStartLocation, missionParams.orientation, missionParams.rallySpacing);
-    // console.log('rallyStartPoints');
-    // console.log(rallyStartPoints);
-    let rallyFinishPoints = findRallySeparation(botIdList, rallyEndLocation, missionParams.orientation, missionParams.rallySpacing);
-    // console.log('rallyFinishPoints');
-    // console.log(rallyFinishPoints);
-
     let mpg = missionPlanningGrid;
     let mpgKeys = Object.keys(mpg);
     mpgKeys.forEach(key => {
@@ -134,8 +87,8 @@ export function getSurveyMissionPlans(botIdList: number[], rallyStartLocation: G
         // Rally Point Goals
         let botGoal: Goal = {
             "location": {
-                "lat": rallyStartPoints[botId][1],
-                "lon": rallyStartPoints[botId][0]
+                "lat": rallyStartLocation.lat,
+                "lon": rallyStartLocation.lon
             },
             "task": {"type": TaskType.NONE}
         }
@@ -164,8 +117,8 @@ export function getSurveyMissionPlans(botIdList: number[], rallyStartLocation: G
         // Home Goals
         botGoal = {
             "location": {
-                "lat": rallyFinishPoints[botId][1],
-                "lon": rallyFinishPoints[botId][0]
+                "lat": rallyEndLocation.lat,
+                "lon": rallyEndLocation.lon
             },
             "task": {
                 type: TaskType.NONE


### PR DESCRIPTION
## Summary
* Removes unused or broken elements in the Optimize Mission Planning panel in preparation for the USMC training.

## Details
* **Elements removed:**
    * Mission Edit Mode
    * Rally Point Spacing (default == 1)
    * Mission Orientation

## Testing
* Ran a two bot, ten total waypoint survey mission with six dives and two end drifts. The TaskPackets, depth contours, and drift map came through the simulator nicely. 
![Screenshot (35)](https://github.com/jaiarobotics/jaiabot/assets/109538793/ee0301bd-3287-4db0-8033-1239d7db521b)
  