### PR TITLE
feature/update-mission-proto-to-include-srp-fields

### DIFF
--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -454,6 +454,12 @@ void jaiabot::apps::HubManager::handle_command(const jaiabot::protobuf::Command&
                 command_fragment.mutable_plan()->set_repeats(command.plan().repeats());
             }
 
+            if (command.plan().has_bottom_depth_safety_params() && fragment_index == 0)
+            {
+                *command_fragment.mutable_plan()->mutable_bottom_depth_safety_params() =
+                    command.plan().bottom_depth_safety_params();
+            }
+
             command_fragment.mutable_plan()->set_fragment_index(fragment_index);
 
             command_fragment.mutable_plan()->set_expected_fragments(command_fragments_expected);

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -454,12 +454,6 @@ void jaiabot::apps::HubManager::handle_command(const jaiabot::protobuf::Command&
                 command_fragment.mutable_plan()->set_repeats(command.plan().repeats());
             }
 
-            if (command.plan().has_bottom_depth_safety_params() && fragment_index == 0)
-            {
-                *command_fragment.mutable_plan()->mutable_bottom_depth_safety_params() =
-                    command.plan().bottom_depth_safety_params();
-            }
-
             command_fragment.mutable_plan()->set_fragment_index(fragment_index);
 
             command_fragment.mutable_plan()->set_expected_fragments(command_fragments_expected);

--- a/src/lib/messages/engineering.proto
+++ b/src/lib/messages/engineering.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 
 import "dccl/option_extensions.proto";
 import "jaiabot/messages/bounds.proto";
+import "jaiabot/messages/mission.proto";
 
 package jaiabot.protobuf;
 
@@ -98,53 +99,6 @@ message RFDisableOptions
 {
     optional bool rf_disable = 1 [default = false];
     optional int32 rf_disable_timeout_mins = 2 [default = 10, (dccl.field) = { min: 1 max: 255 }];
-}
-
-message BottomDepthSafetyParams
-{
-    option (dccl.msg) = {
-        unit_system: "si"
-    };
-    
-    optional double constant_heading = 1 [
-        default = 0,
-        (dccl.field) = {
-            min: 0
-            max: 360
-            precision: 0
-            units { derived_dimensions: "plane_angle" system: "angle::degree" }
-        }
-    ];
-
-    optional int32 constant_heading_time = 2 [
-        default = 0,
-        (dccl.field) = {
-            min: 0
-            max: 360
-            precision: 0
-            units { base_dimensions: "T" }
-        }
-    ];
-
-    optional double constant_heading_speed = 3 [
-        default = 2,
-        (dccl.field) = {
-            min: 0,
-            max: 3.0,
-            precision: 1,
-            units { base_dimensions: "LT^-1" }
-        }
-    ];
-
-    optional double safety_depth = 4 [
-        default = -1,
-        (dccl.field) = {
-            min: -1,
-            max: 60,
-            precision: 1,
-            units { base_dimensions: "LT^-1" }
-        }
-    ];
 }
 
 message IMUCalibration

--- a/src/lib/messages/mission.proto
+++ b/src/lib/messages/mission.proto
@@ -80,6 +80,53 @@ message Speeds
     ];
 }
 
+message BottomDepthSafetyParams
+{
+    option (dccl.msg) = {
+        unit_system: "si"
+    };
+    
+    required double constant_heading = 1 [
+        default = 0,
+        (dccl.field) = {
+            min: 0
+            max: 360
+            precision: 0
+            units { derived_dimensions: "plane_angle" system: "angle::degree" }
+        }
+    ];
+
+    required int32 constant_heading_time = 2 [
+        default = 0,
+        (dccl.field) = {
+            min: 0
+            max: 360
+            precision: 0
+            units { base_dimensions: "T" }
+        }
+    ];
+
+    required double constant_heading_speed = 3 [
+        default = 2,
+        (dccl.field) = {
+            min: 0,
+            max: 3.0,
+            precision: 1,
+            units { base_dimensions: "LT^-1" }
+        }
+    ];
+
+    required double safety_depth = 4 [
+        default = -1,
+        (dccl.field) = {
+            min: -1,
+            max: 60,
+            precision: 1,
+            units { base_dimensions: "LT^-1" }
+        }
+    ];
+}
+
 message MissionReport
 {
     option (dccl.msg) = {
@@ -258,9 +305,10 @@ message MissionPlan
     optional Recovery recovery = 4;
 
     optional Speeds speeds = 5;
-    optional uint32 fragment_index = 6 [(dccl.field) = { min: 0 max: 2 }];
-    optional uint32 expected_fragments = 7 [(dccl.field) = { min: 1 max: 3 }];
-    optional uint32 repeats = 8 [default = 1, (dccl.field) = {min: 1 max: 100 }];
+    optional BottomDepthSafetyParams bottom_depth_safety_params = 6;
+    optional uint32 fragment_index = 7 [(dccl.field) = { min: 0 max: 2 }];
+    optional uint32 expected_fragments = 8 [(dccl.field) = { min: 1 max: 3 }];
+    optional uint32 repeats = 9 [default = 1, (dccl.field) = {min: 1 max: 100 }];
 }
 
 message IvPBehaviorUpdate


### PR DESCRIPTION
## Summary
* Moves the BottomDepthSafetyParams message definition from engineering.proto to mission.proto in preparation of setting those values in the Optimize Mission Planning panel.

## Details
* Move the BottomDepthSafetyParams message to mission.proto
* Imports mission.proto into engineering.proto to prevent the engineering app from breaking
* Adds the bottom depth safety parameters check for the first fragment of the command message sent over the radio

## Testing
* Forced the SRP into action in sim by setting the seafloor depth to 5m, the dive depth to 7m, and safety depth to 10m (added the buffers to account for dive variability and the egg box shaped seafloor). After the dive, the bot entered its constant heading state as part of the SRP protocol.  