### PR TITLE
feature/first-wpt-task-option-omp

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -142,6 +142,7 @@ interface State {
 	missionPlanningLines?: any,
 	missionPlanningFeature?: OlFeature<Geometry>,
 	missionBaseGoal: Goal,
+	missionStartTask: MissionTask,
 	missionEndTask: MissionTask,
 
 	runList: MissionInterface,
@@ -275,7 +276,8 @@ export default class CommandControl extends React.Component {
 			missionPlanningLines: null,
 			missionPlanningFeature: null,
 			missionBaseGoal: { task: { type: TaskType.NONE } },
-			missionEndTask: {type: TaskType.NONE},
+			missionStartTask: { type: TaskType.NONE },
+			missionEndTask: { type: TaskType.NONE },
 
 			runList: {
 				id: 'mission-1',
@@ -518,7 +520,10 @@ export default class CommandControl extends React.Component {
 
 		// Update the mission planning layer whenever relevant state changes
 		const botsChanged = (prevState.podStatus.bots.length !== this.state.podStatus.bots.length)
-		if (stateHasChanged(['missionPlanningLines', 'missionPlanningFeature', 'missionParams', 'mode', 'missionBaseGoal', 'missionPlanningGrid', 'missionEndTask'], false) || botsChanged) {
+		if (stateHasChanged(
+			['missionPlanningLines', 'missionPlanningFeature', 'missionParams', 'mode', 'missionPlanningGrid', 'missionBaseGoal', 'missionStartTask', 'missionEndTask'],
+			 false) || botsChanged
+		) {
 			this.updateMissionPlanningLayer()
 		}
 
@@ -1586,11 +1591,18 @@ export default class CommandControl extends React.Component {
 
 		// Place all the mission planning features in this for the missionLayer
 		const missionPlanningFeaturesList: OlFeature[] = []
-		const { missionParams, missionPlanningGrid, missionBaseGoal, missionEndTask } = this.state
+		const { missionPlanningGrid, missionBaseGoal, missionStartTask, missionEndTask } = this.state
 
 
 		if (missionPlanningGrid) {
-			this.missionPlans = getSurveyMissionPlans(this.getBotIdList(), this.state.startRally?.get('location'), this.state.endRally?.get('location'), missionParams, missionPlanningGrid, missionEndTask, missionBaseGoal)
+			this.missionPlans = getSurveyMissionPlans(
+				this.state.startRally?.get('location'),
+				this.state.endRally?.get('location'), 
+				missionPlanningGrid,
+				missionBaseGoal,
+				missionStartTask, 
+				missionEndTask
+			)
 			const planningGridFeatures = featuresFromMissionPlanningGrid(missionPlanningGrid, missionBaseGoal)
 			missionPlanningFeaturesList.push(...planningGridFeatures)
 		}
@@ -3109,6 +3121,7 @@ export default class CommandControl extends React.Component {
 					missionParams={this.state.missionParams}
 					missionPlanningGrid={this.state.missionPlanningGrid}
 					missionBaseGoal={this.state.missionBaseGoal}
+					missionStartTask={this.state.missionStartTask}
 					missionEndTask={this.state.missionEndTask}
 					rallyFeatures={layers.rallyPointLayer.getSource().getFeatures()}
 					startRally={this.state.startRally}
@@ -3126,15 +3139,22 @@ export default class CommandControl extends React.Component {
 						this.missionPlans = null
 						this.setState({missionBaseGoal: this.state.missionBaseGoal}) // Trigger re-render
 					}}
-					onMissionApply={(missionSettings: MissionSettings, startRally: OlFeature, endRally: OlFeature) => {
-						this.setState({ missionEndTask: missionSettings.endTask, startRally, endRally })
+					onMissionApply={(startRally: OlFeature, endRally: OlFeature, startTask: MissionTask, endTask: MissionTask) => {
+						this.setState({ startRally, endRally, missionStartTask: startTask, missionEndTask: endTask, })
 
 						if (this.state.missionParams.missionType === 'lines') {
-							const { missionParams, missionPlanningGrid, missionBaseGoal } = this.state
+							const { missionPlanningGrid, missionBaseGoal, missionStartTask, missionEndTask } = this.state
 							const rallyStartLocation = startRally.get('location')
 							const rallyEndLocation = endRally.get('location')
 
-							this.missionPlans = getSurveyMissionPlans(this.getBotIdList(), rallyStartLocation, rallyEndLocation, missionParams, missionPlanningGrid, missionSettings.endTask, missionBaseGoal)
+							this.missionPlans = getSurveyMissionPlans(
+								rallyStartLocation,
+								rallyEndLocation,
+								missionPlanningGrid,
+								missionBaseGoal,
+								missionStartTask,
+								missionEndTask
+							)
 
 							const runList = this.getRunList()
 							this.deleteAllRunsInMission(runList, false).then((confirmed: boolean) => {

--- a/src/web/command_control/client/components/MissionSettings.tsx
+++ b/src/web/command_control/client/components/MissionSettings.tsx
@@ -36,6 +36,7 @@ interface Props {
     missionParams: MissionParams
     missionPlanningGrid: {[key: string]: number[][]}
     missionBaseGoal: Goal,
+    missionStartTask: MissionTask
     missionEndTask: MissionTask,
     rallyFeatures: Feature<Geometry>[]
     startRally: Feature<Geometry>,
@@ -44,7 +45,7 @@ interface Props {
     botList?: {[key: string]: BotStatus}
 
     onClose: () => void
-    onMissionApply: (missionSettings: MissionSettings, startRally: Feature<Geometry>, endRally: Feature<Geometry>) => void
+    onMissionApply: (startRally: Feature<Geometry>, endRally: Feature<Geometry>, missionStartTask: MissionTask, missionEndTask: MissionTask) => void
     onMissionChangeEditMode: () => void
     onTaskTypeChange: () => void
     setSelectedRallyPoint: (rallyPoint: Feature<Geometry>, isStart: boolean) => void
@@ -56,7 +57,9 @@ interface Props {
 interface State {
     missionParams: MissionParams
     missionBaseGoal: Goal,
-    missionEndTask: MissionTask // This is the final task for bots to do at the last line waypoint (station keep OR constant heading back to shore)
+    missionStartTask: MissionTask,
+    // This is the final task for bots to do at the last line waypoint
+    missionEndTask: MissionTask
     botList?: {[key: string]: BotStatus}
 }
 
@@ -75,6 +78,7 @@ export class MissionSettingsPanel extends React.Component {
         this.state = {
             missionParams: props.missionParams,
             missionBaseGoal: props.missionBaseGoal,
+            missionStartTask: props.missionStartTask,
             missionEndTask: props.missionEndTask,
             botList: props.botList
         }
@@ -167,6 +171,18 @@ export class MissionSettingsPanel extends React.Component {
                                 missionBaseGoal.task = task
                                 this.setState({ missionBaseGoal })
                             }}
+                        />
+                    </div>
+
+                    <div className="mission-settings-task-container">
+                        <div className="mission-settings-tasks-title">Start Task:</div>
+                        <TaskSettingsPanel 
+                            title="Start Task" 
+                            map={map} 
+                            location={this.props.startRally?.get('location')}
+                            isEditMode={true}
+                            task={this.state.missionStartTask} 
+                            onChange={(missionStartTask) => { this.setState({ missionStartTask })}} 
                         />
                     </div>
 
@@ -288,7 +304,7 @@ export class MissionSettingsPanel extends React.Component {
             endTask: this.state.missionEndTask
         }
 
-        this.props.onMissionApply?.(missionSettings, this.props.startRally, this.props.endRally)
+        this.props.onMissionApply?.(this.props.startRally, this.props.endRally, this.state.missionStartTask, this.state.missionEndTask)
     }
 
     changeMissionBotSelection() {

--- a/src/web/command_control/client/components/PIDGainsPanel.tsx
+++ b/src/web/command_control/client/components/PIDGainsPanel.tsx
@@ -351,82 +351,26 @@ export class PIDGainsPanel extends React.Component {
                             <tbody>
                                 <tr>
                                     <td key="safety_depth_label">Current Depth Safety (m)</td>
-                                    <td key="safety_depth">
+                                    <td key="safety_depth" style={{maxWidth: "80px"}} >
                                         {engineering?.bottom_depth_safety_params?.safety_depth  ?? "-"}
                                     </td>
                                 </tr>
                                 <tr>
                                     <td key="current_bottom_depth_safety_heading_label">Current Depth Safety Heading (deg)</td>
-                                    <td key="current_bottom_depth_safety_heading">
+                                    <td key="current_bottom_depth_safety_heading" style={{maxWidth: "80px"}} >
                                         {engineering?.bottom_depth_safety_params?.constant_heading  ?? "-"}
                                     </td>
                                 </tr>
                                 <tr>
                                     <td key="current_bottom_depth_safety_time_label">Current Depth Safety Time (s)</td>
-                                    <td key="current_bottom_depth_safety_time">
+                                    <td key="current_bottom_depth_safety_time" style={{maxWidth: "80px"}} >
                                         {engineering?.bottom_depth_safety_params?.constant_heading_time  ?? "-"}
                                     </td>
                                 </tr>
                                 <tr>
                                     <td key="current_bottom_depth_safety_speed_label">Current Depth Safety Speed</td>
-                                    <td key="current_bottom_depth_safety_speed">
+                                    <td key="current_bottom_depth_safety_speed" style={{maxWidth: "80px"}} >
                                         {engineering?.bottom_depth_safety_params?.constant_heading_speed  ?? "-"}
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td key="safety_depth_label">Update Depth Safety (m)</td>
-                                    <td>
-                                        <input style={{maxWidth: "80px"}} 
-                                            type="number" 
-                                            id="safety_depth_input" 
-                                            name="safety_depth_input" 
-                                            defaultValue={engineering?.bottom_depth_safety_params?.safety_depth ?? "-"} 
-                                            min="-1"
-                                            max="60"
-                                            step="any"
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td key="bottom_depth_safety_heading_label">Update Depth Safety Heading (deg)</td>
-                                    <td>
-                                        <input style={{maxWidth: "80px"}} 
-                                            type="number" 
-                                            id="bottom_depth_safety_heading_input" 
-                                            name="bottom_depth_safety_heading_input" 
-                                            defaultValue={engineering?.bottom_depth_safety_params?.constant_heading ?? "-"} 
-                                            min="0"
-                                            max="360"
-                                            step="1"
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td key="bottom_depth_safety_time_label">Update Depth Safety Time (s)</td>
-                                    <td>
-                                        <input style={{maxWidth: "80px"}} 
-                                            type="number" 
-                                            id="bottom_depth_safety_time_input" 
-                                            name="bottom_depth_safety_time_input" 
-                                            defaultValue={engineering?.bottom_depth_safety_params?.constant_heading_time ?? "-"} 
-                                            min="0"
-                                            max="360"
-                                            step="1"
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td key="bottom_depth_safety_speed_label">Update Depth Safety Speed</td>
-                                    <td>
-                                        <input style={{maxWidth: "80px"}} 
-                                            type="number" 
-                                            id="bottom_depth_safety_speed_input" 
-                                            name="bottom_depth_safety_speed_input" 
-                                            defaultValue={engineering?.bottom_depth_safety_params?.constant_heading_speed ?? "-"} 
-                                            min="0"
-                                            max="3"
-                                            step="any"
-                                        />
                                     </td>
                                 </tr>
                             </tbody>

--- a/src/web/command_control/client/components/SurveyMission.ts
+++ b/src/web/command_control/client/components/SurveyMission.ts
@@ -60,17 +60,21 @@ export function featuresFromMissionPlanningGrid(missionPlanningGrid: {[key: stri
 /**
  * Gets a mission plan from the set of survey mission parameters
  * 
- * @param botIdList 
  * @param rallyStartLocation 
  * @param rallyEndLocation 
- * @param missionParams 
  * @param missionPlanningGrid 
  * @param missionEndTask 
  * @param missionBaseGoal 
  * @returns A CommandList (dictionary mapping botIds to Commands)
  */
-export function getSurveyMissionPlans(botIdList: number[], rallyStartLocation: GeographicCoordinate, rallyEndLocation: GeographicCoordinate, 
-    missionParams: MissionParams, missionPlanningGrid: {[key: string]: number[][]}, missionEndTask: MissionTask, missionBaseGoal: Goal) {
+export function getSurveyMissionPlans(
+    rallyStartLocation: GeographicCoordinate, 
+    rallyEndLocation: GeographicCoordinate, 
+    missionPlanningGrid: {[key: string]: number[][]},
+    missionBaseGoal: Goal,
+    missionStartTask: MissionTask,
+    missionEndTask: MissionTask,
+) {
     
     let missionPlans: CommandList = {};
     let millisecondsSinceEpoch = new Date().getTime();
@@ -90,7 +94,7 @@ export function getSurveyMissionPlans(botIdList: number[], rallyStartLocation: G
                 "lat": rallyStartLocation.lat,
                 "lon": rallyStartLocation.lon
             },
-            "task": {"type": TaskType.NONE}
+            "task": missionStartTask
         }
         botGoals.push(botGoal)
 

--- a/src/web/command_control/client/style/CommandControl.less
+++ b/src/web/command_control/client/style/CommandControl.less
@@ -747,7 +747,7 @@ td {
 
     #engineering_safety_table {
       td {
-        text-align: right;
+        text-align: left;
         font-size: 16px;
       }
     }


### PR DESCRIPTION
## Summary
* Allows an operator to set a start task when using the optimize mission planning tool. This start task takes place at the location of the start rally point.

## Details
* The implementation mostly mimics the structure of the end task option. The difference comes from setting the start task to occur at the start rally as opposed to the beginning of the survey line. (For comparison, the end task occurs at the last waypoint in the survey line rather than the end rally).

## Testing
* Planned a survey line with various start tasks (with and without a start rally point selected to check the error handling) and I did not produce any errors.
* Ran two survey missions with 2 bots. The first mission began with a constant heading and the second began with a dive. In both missions, the bots performed the expected steps.