### PR TITLE
task/handle-retrofit-imu-reset

### DIFF
--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -55,6 +55,7 @@ parser.add_argument('--led_type', choices=['hub_led', 'none'], help='If set, con
 parser.add_argument('--user_role', choices=['user', 'advanced', 'developer'], help='Role for user in pre-launch UI')
 parser.add_argument('--electronics_stack', choices=['0', '1', '2'], help='If set, configure services for electronics stack')
 parser.add_argument('--imu_type', choices=['bno055', 'bno085', 'none'], help='If set, configure services for imu type')
+parser.add_argument('--imu_install_type', choices=['embedded', 'retrofit', 'none'], help='If set, configure services for imu install type')
 parser.add_argument('--arduino_type', choices=['spi', 'usb', 'none'], help='If set, configure services for arduino type')
 
 args=parser.parse_args()
@@ -67,6 +68,11 @@ class ARDUINO_TYPE(Enum):
 class IMU_TYPE(Enum):
     BNO055 = 'bno055'
     BNO085 = 'bno085'
+    NONE = 'none'
+
+class IMU_INSTALL_TYPE(Enum):
+    EMBEDDED = 'embedded'
+    RETROFIT = 'retrofit'
     NONE = 'none'
 
 class LED_TYPE(Enum):
@@ -99,6 +105,13 @@ elif args.imu_type == 'bno085':
     jaia_imu_type = IMU_TYPE.BNO085
 else:
     jaia_imu_type = IMU_TYPE.NONE
+
+if args.imu_install_type == 'embedded':
+    jaia_imu_install_type = IMU_INSTALL_TYPE.EMBEDDED
+elif args.imu_install_type == 'retrofit':
+    jaia_imu_install_type = IMU_INSTALL_TYPE.RETROFIT
+else:
+    jaia_imu_install_type = IMU_TYPE.NONE
 
 if args.led_type == 'hub_led':
     jaia_led_type = LED_TYPE.HUB_LED
@@ -160,6 +173,7 @@ subprocess.run('bash -ic "' +
                f'export jaia_user_role={args.user_role}; ' +
                'export jaia_electronics_stack=' + str(jaia_electronics_stack.value) + '; ' +
                'export jaia_imu_type=' + str(jaia_imu_type.value) + '; ' +
+               'export jaia_imu_install_type=' + str(jaia_imu_install_type.value) + '; ' +
                'export jaia_arduino_type=' + str(jaia_arduino_type.value) + '; ' +
                'source ' + args.gen_dir + '/../preseed.goby; env | egrep \'^jaia|^LD_LIBRARY_PATH\' > /tmp/runtime.env; cp --backup=numbered /tmp/runtime.env ' + args.env_file + '; rm /tmp/runtime.env"',
                check=True, shell=True)
@@ -492,7 +506,7 @@ jaia_firmware = [
      'description': 'BNO085 script to reboot imu',
      'template': 'bno085-reset-gpio-pin.service.in',
      'subdir': 'adafruit_BNO085',
-     'args': '',
+     'args': '--install_type=' + jaia_imu_install_type.value,
      'runs_on': Type.BOT,
      'runs_when': Mode.RUNTIME,
      'imu_type': IMU_TYPE.BNO085,

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -106,12 +106,13 @@ elif args.imu_type == 'bno085':
 else:
     jaia_imu_type = IMU_TYPE.NONE
 
+
+jaia_imu_install_type = IMU_TYPE.NONE
+
 if args.imu_install_type == 'embedded':
     jaia_imu_install_type = IMU_INSTALL_TYPE.EMBEDDED
 elif args.imu_install_type == 'retrofit':
     jaia_imu_install_type = IMU_INSTALL_TYPE.RETROFIT
-else:
-    jaia_imu_install_type = IMU_TYPE.NONE
 
 if args.led_type == 'hub_led':
     jaia_led_type = LED_TYPE.HUB_LED

--- a/src/doc/markdown/page70_hardware.md
+++ b/src/doc/markdown/page70_hardware.md
@@ -62,7 +62,8 @@
 | Pin    | Description | Notes            |
 | --:    | ---         | ---              |
 | GPIO6  | Arduino Reset   |           |
-| GPIO10 | IMU  Reset   |                  |
+| GPIO10 | IMU Embedded Reset   |                  |
+| GPIO23 | IMU Retrofit Reset   |                  |
 | GPIO26 | XBee Reset  |                  |
 
 ## Logic Board Lights

--- a/src/python/adafruit_BNO085/jaia_firm_bno085_reset_gpio_pin.py
+++ b/src/python/adafruit_BNO085/jaia_firm_bno085_reset_gpio_pin.py
@@ -1,8 +1,19 @@
 import RPi.GPIO as GPIO
 import time
+from enum import Enum
+import argparse
 
-# BNO085 IMU reset pin
-bno085_pin = 10
+parser = argparse.ArgumentParser(description='Turn on/off bno085 imu', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('--imu_install_type', choices=['embedded', 'retrofit', 'none'], help='If set, configure services for imu install type')
+args=parser.parse_args()
+
+# Set BNO085 IMU reset pin
+if args.imu_install_type == 'embedded':
+    bno085_pin = 10
+elif args.imu_install_type == 'retrofit':
+    bno085_pin = 23
+else:
+    bno085_pin = 10
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(bno085_pin, GPIO.OUT)  

--- a/src/python/adafruit_BNO085/jaia_firm_bno085_reset_gpio_pin.py
+++ b/src/python/adafruit_BNO085/jaia_firm_bno085_reset_gpio_pin.py
@@ -7,13 +7,11 @@ parser = argparse.ArgumentParser(description='Turn on/off bno085 imu', formatter
 parser.add_argument('--imu_install_type', choices=['embedded', 'retrofit', 'none'], help='If set, configure services for imu install type')
 args=parser.parse_args()
 
-# Set BNO085 IMU reset pin
-if args.imu_install_type == 'embedded':
-    bno085_pin = 10
-elif args.imu_install_type == 'retrofit':
+# Set BNO085 IMU reset pin to embedded
+bno085_pin = 10
+
+if args.imu_install_type == 'retrofit':
     bno085_pin = 23
-else:
-    bno085_pin = 10
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(bno085_pin, GPIO.OUT)  


### PR DESCRIPTION
# Summary
Adding configuration for imu installation type
# Details
The approach for the imu installation type is similar to the imu type configuration 
# Testing
The GPIO pin for both the retrofit and the embedded IMU has been tested
# Notes
Please merge this pull request in first: https://github.com/jaiarobotics/jaiabot-debian/pull/53
