### PR TITLE
task/handle-data-offload-options

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -55,15 +55,10 @@ elif jaia_arduino_type == 'usb':
 else:
     jaia_arduino_dev_location="/dev/ttyAMA1"
 
+jaia_data_offload_ignore_type="NONE"
+
 if "jaia_data_offload_ignore_type" in os.environ:
     jaia_data_offload_ignore_type=os.environ['jaia_data_offload_ignore_type']
-
-if jaia_data_offload_ignore_type == "goby":
-    jaia_data_offload_ignore_type="GOBY"
-elif jaia_data_offload_ignore_type == 'taskpacket':
-    jaia_data_offload_ignore_type="TASKPACKET"
-else:
-    jaia_data_offload_ignore_type="NONE"
 
 try:
     bot_index=int(os.environ['jaia_bot_index'])

--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -55,6 +55,16 @@ elif jaia_arduino_type == 'usb':
 else:
     jaia_arduino_dev_location="/dev/ttyAMA1"
 
+if "jaia_data_offload_ignore_type" in os.environ:
+    jaia_data_offload_ignore_type=os.environ['jaia_data_offload_ignore_type']
+
+if jaia_data_offload_ignore_type == "goby":
+    jaia_data_offload_ignore_type="GOBY"
+elif jaia_data_offload_ignore_type == 'taskpacket':
+    jaia_data_offload_ignore_type="TASKPACKET"
+else:
+    jaia_data_offload_ignore_type="NONE"
+
 try:
     bot_index=int(os.environ['jaia_bot_index'])
 except:
@@ -238,7 +248,8 @@ elif common.app == 'jaiabot_mission_manager':
                                      mission_manager_in_simulation=is_simulation(),
                                      subscribe_to_hub_on_start=subscribe_to_hub_on_start,
                                      total_after_dive_gps_fix_checks=total_after_dive_gps_fix_checks,
-                                     fleet_id=fleet_index))
+                                     fleet_id=fleet_index,
+                                     jaia_data_offload_ignore_type=jaia_data_offload_ignore_type))
 elif common.app == 'jaiabot_engineering':
     print(config.template_substitute(templates_dir+'/bot/jaiabot_engineering.pb.cfg.in',
                                      app_block=app_common,

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -56,6 +56,7 @@ parser.add_argument('--user_role', choices=['user', 'advanced', 'developer'], he
 parser.add_argument('--electronics_stack', choices=['0', '1', '2'], help='If set, configure services for electronics stack')
 parser.add_argument('--imu_type', choices=['bno055', 'bno085', 'none'], help='If set, configure services for imu type')
 parser.add_argument('--arduino_type', choices=['spi', 'usb', 'none'], help='If set, configure services for arduino type')
+parser.add_argument('--data_offload_ignore_type', choices=['goby', 'taskpacket', 'none'], help='If set, configure services for arduino type')
 
 args=parser.parse_args()
 
@@ -83,6 +84,11 @@ class ELECTRONICS_STACK(Enum):
     STACK_1 = '1'
     STACK_2 = '2'
     STACK_3 = '2'
+
+class DATA_OFFLOAD_IGNORE_TYPE(Enum):
+    GOBY = 'goby'
+    TASKPACKET = 'taskpacket'
+    NONE = 'none'
 
 # Set the arduino type based on the argument
 # Used to set the serial port device
@@ -119,6 +125,13 @@ elif args.electronics_stack == '2':
 else:
     jaia_electronics_stack = ELECTRONICS_STACK.STACK_0
     jaia_gps_type = GPS_TYPE.I2C
+
+if args.data_offload_ignore_type == 'goby':
+    jaia_data_offload_ignore_type = DATA_OFFLOAD_IGNORE_TYPE.GOBY
+elif args.data_offload_ignore_type == 'taskpacket':
+    jaia_data_offload_ignore_type = DATA_OFFLOAD_IGNORE_TYPE.TASKPACKET
+else:
+    jaia_data_offload_ignore_type = DATA_OFFLOAD_IGNORE_TYPE.NONE
 
 # make the output directories, if they don't exist
 os.makedirs(os.path.dirname(args.env_file), exist_ok=True)
@@ -161,6 +174,7 @@ subprocess.run('bash -ic "' +
                'export jaia_electronics_stack=' + str(jaia_electronics_stack.value) + '; ' +
                'export jaia_imu_type=' + str(jaia_imu_type.value) + '; ' +
                'export jaia_arduino_type=' + str(jaia_arduino_type.value) + '; ' +
+               'export jaia_data_offload_ignore_type=' + str(jaia_data_offload_ignore_type.value) + '; ' +
                'source ' + args.gen_dir + '/../preseed.goby; env | egrep \'^jaia|^LD_LIBRARY_PATH\' > /tmp/runtime.env; cp --backup=numbered /tmp/runtime.env ' + args.env_file + '; rm /tmp/runtime.env"',
                check=True, shell=True)
 

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -86,9 +86,9 @@ class ELECTRONICS_STACK(Enum):
     STACK_3 = '2'
 
 class DATA_OFFLOAD_IGNORE_TYPE(Enum):
-    GOBY = 'goby'
-    TASKPACKET = 'taskpacket'
-    NONE = 'none'
+    GOBY = 'GOBY'
+    TASKPACKET = 'TASKPACKET'
+    NONE = 'NONE'
 
 # Set the arduino type based on the argument
 # Used to set the serial port device
@@ -126,12 +126,13 @@ else:
     jaia_electronics_stack = ELECTRONICS_STACK.STACK_0
     jaia_gps_type = GPS_TYPE.I2C
 
+
+jaia_data_offload_ignore_type = DATA_OFFLOAD_IGNORE_TYPE.NONE
+
 if args.data_offload_ignore_type == 'goby':
     jaia_data_offload_ignore_type = DATA_OFFLOAD_IGNORE_TYPE.GOBY
 elif args.data_offload_ignore_type == 'taskpacket':
     jaia_data_offload_ignore_type = DATA_OFFLOAD_IGNORE_TYPE.TASKPACKET
-else:
-    jaia_data_offload_ignore_type = DATA_OFFLOAD_IGNORE_TYPE.NONE
 
 # make the output directories, if they don't exist
 os.makedirs(os.path.dirname(args.env_file), exist_ok=True)

--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -62,7 +62,7 @@ log_dir: "$log_dir" # (required)
 hub_start_ip: 10 # (required)
 class_b_network: "10.23" # (required)
 # data_offload_exclude options: (NONE, GOBY, TASKPACKET)
-data_offload_exclude: NONE # (optional)
+data_offload_exclude: $jaia_data_offload_ignore_type # (optional)
 
 # Can enable one or more test modes to override normal operational settings
 #test_mode: ENGINEERING_TEST__ALWAYS_LOG_EVEN_WHEN_IDLE


### PR DESCRIPTION
# Summary
Adding config for data offload type

# Details
The approach for the data offload type is similar to the imu type configuration

# Testing

This will need to be tested on a bot after merging in. 

# Notes
Please merge this pull request in first: https://github.com/jaiarobotics/jaiabot-debian/pull/54