### PR TITLE
bug/omp-spacing-input-render-and-validation

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -3022,9 +3022,21 @@ export default class CommandControl extends React.Component {
 	//
 	//
 	/**
+	 * Triggers a state update for changes made to the MissionParams
+	 * 
+	 * @param {MissionParams} params Contains the params edited by the operator
+	 * @returns {void} 
+	 */
+	setMissionParams(params: MissionParams) {
+		let updatedParams = {...params}
+		this.setState({ missionParams: updatedParams })
+	}
+
+	/**
 	 * Triggers a state update for changes made to the BottomDepthSafetyParams
 	 * 
-	 * @param {BottomDepthSafetyParams} params Contain the params edited by the operator
+	 * @param {BottomDepthSafetyParams} params Contains the params edited by the operator
+	 * @returns {void}
 	 * 
 	 * @notes
 	 * Keeping the BottomDepthSafetyParams in CommandControl state allows the data to persist
@@ -3179,6 +3191,7 @@ export default class CommandControl extends React.Component {
 				<MissionSettingsPanel
 					map={map}
 					missionParams={this.state.missionParams}
+					setMissionParams={this.setMissionParams.bind(this)}
 					missionPlanningGrid={this.state.missionPlanningGrid}
 					missionBaseGoal={this.state.missionBaseGoal}
 					missionStartTask={this.state.missionStartTask}

--- a/src/web/command_control/client/components/MissionSettings.tsx
+++ b/src/web/command_control/client/components/MissionSettings.tsx
@@ -36,6 +36,7 @@ export interface MissionParams {
 interface Props {
     map: Map
     missionParams: MissionParams
+    setMissionParams: (missionParams: MissionParams) => void
     missionPlanningGrid: {[key: string]: number[][]}
     missionBaseGoal: Goal,
     missionStartTask: MissionTask
@@ -371,15 +372,20 @@ export class MissionSettingsPanel extends React.Component {
     }
 
     /**
-     * Prevents negative values or 0 from being used in data processing
+     * Prevents negative values from being entered by operator
      * 
      * @param {number} value Input value to be checked
      * @returns {number} The value passed or DEFAULT_VALUE
+     * 
+     * @notes
+     * Zero cannot be used in the creation of a survey mission but if 0 cannot display
+     * in the input box it makes it difficult to enter values that don't start with 1.
+     * To balance user experience and the survey mission calculations, there is a final
+     * input check to catch zeros just before the preview is created. (SurveyLines.ts) 
      */
     validateNumInput(value: number) {
-        // Values less than 1 throw errors in the creation of survey missions
-        const DEFAULT_VALUE = 1
-        if (value < DEFAULT_VALUE) {
+        const DEFAULT_VALUE = 0
+        if (value < DEFAULT_VALUE || Number.isNaN(value)) {
             return DEFAULT_VALUE
         }
         return value
@@ -394,7 +400,9 @@ export class MissionSettingsPanel extends React.Component {
     changePointSpacing(evt: Event) {
         const element = evt.target as HTMLInputElement
         const value = this.validateNumInput(Number(element.value))
-        this.props.missionParams.pointSpacing = value
+        let missionParams = {...this.props.missionParams}
+        missionParams.pointSpacing = value
+        this.props.setMissionParams(missionParams)
     }
     
     /**
@@ -406,7 +414,9 @@ export class MissionSettingsPanel extends React.Component {
     changeLineSpacing(evt: Event) {
         const element = evt.target as HTMLInputElement
         const value = this.validateNumInput(Number(element.value))
-        this.props.missionParams.lineSpacing = value
+        let missionParams = {...this.props.missionParams}
+        missionParams.lineSpacing = value
+        this.props.setMissionParams(missionParams)
     }
 
     handleRallyFeatureSelection(evt: SelectChangeEvent, isStart: boolean) {

--- a/src/web/command_control/client/components/SurveyLines.ts
+++ b/src/web/command_control/client/components/SurveyLines.ts
@@ -127,6 +127,8 @@ export class SurveyLines {
                     const geom1 = evt2.target;
                     let { missionParams, surveyExclusionCoords, startRally, endRally } = commandControl.state;
                     let stringCoords = geom1.getGeometry().getCoordinates()
+
+                    this.validateSurveySpacingInputs()
         
                     if (stringCoords[0].length >= 2 && startRally && endRally) {
                         let coords = stringCoords.slice(-2);
@@ -252,5 +254,24 @@ export class SurveyLines {
                 OlUnobserveByKey(this.listener);
             }
         )
+    }
+
+    /**
+     * Converts zeros passed as spacing values to ones to prevent the preview from breaking
+     * 
+     * @returns {void}
+     * 
+     * @notes
+     * We know this code needs a refactor as it violates React best practices. This is a
+     * temporary solution to meet an urgent business requirement. 
+     */
+    validateSurveySpacingInputs() {
+        if (this.commandControl.state.missionParams.pointSpacing === 0) {
+            this.commandControl.state.missionParams.pointSpacing = 1
+        }
+
+        if (this.commandControl.state.missionParams.lineSpacing === 0) {
+            this.commandControl.state.missionParams.lineSpacing = 1
+        }
     }
 }


### PR DESCRIPTION
## Summary
* Increases the speed of input updates and allows 0 to displayed to make it easier for operators to enter values that do not start with the minimum value of 1.

## Details
* Passes a state setter through props and creates a copy of the missionParams to trigger a new state update when the input changes
* Adds a final input validation for the mission spacing values right before the preview is created to check for 0s. If a value equals 0, it is set to 1.

## Testing
* Quickly typed values into the mission spacing input boxes
* Typed in characters to make sure they default to 0
* Adjusted the point and line spacing values and watched them grow and shrink in the preview as expected
* Set the point and line spacing to 0 and saw no console errors and watched the preview use the default value of 1
* Played a mission when both the point and line spacing were set to 0