### PR TITLE
bug/rc-dive

### DIFF
--- a/src/web/command_control/client/components/CommandControl.tsx
+++ b/src/web/command_control/client/components/CommandControl.tsx
@@ -3275,6 +3275,7 @@ export default class CommandControl extends React.Component {
 					remoteControlValues={this.state.remoteControlValues}
 					rcDiveParameters={this.state.rcDives[this.selectedBotId()]}
 					createInterval={this.createRemoteControlInterval.bind(this)}
+					deleteInterval={this.clearRemoteControlInterval.bind(this)}
 					weAreInControl={this.weAreInControl.bind(this)}
 					weHaveInterval={this.weHaveRemoteControlInterval.bind(this)}
 					setRCDiveParameters={this.setRCDiveParams.bind(this)}

--- a/src/web/command_control/client/components/RCControllerPanel.tsx
+++ b/src/web/command_control/client/components/RCControllerPanel.tsx
@@ -23,6 +23,7 @@ interface Props {
 	remoteControlValues: Engineering,
 	rcDiveParameters: { [diveParam: string]: string },
 	createInterval: () => void,
+	deleteInterval: () => void,
 	weAreInControl: () => boolean,
 	weHaveInterval: () => boolean,
 	setRCDiveParameters: (diveParams: {[param: string]: string} ) => void,
@@ -330,9 +331,17 @@ export default class RCControllerPanel extends React.Component {
 		this.props.setRCDiveParameters(diveParams)
 	}
 
+	/**
+	 * Clears the interval to send RC commands and sends a dive task
+	 * 
+	 * returns {void}
+	 */
 	handleDiveButtonClick() {
 		const diveParametersNum: { [diveParam: string]: number } = {}
 		const driftParametersNum: { [driftParam: string]: number } = {}
+
+		// delete interval so the bot does not receive engineering commands
+		this.props.deleteInterval()
 
 		for (const key of Object.keys(this.props.rcDiveParameters)) {
 			if (key === 'driftTime') {


### PR DESCRIPTION
## Summary
Removing interval for RC when the dive button is clicked

## Details
In RC mode if the operator was driving a bot and then proceeded to send the RC dive command the bot would get interrupted 2 times a second while comms were still good. To resolve this we removed the interval to send the RC commands when the dive command is clicked.

## Testing
1. To test start a simulation with 1 bot running at 1 warp
2. Open liaison: http://localhost:30002/?_=/scope
3. Watch engineering command messages and low control messages
4. Open JCC
5. Split the screen to watch both JCC and liaison
6. Put bot in RC mode and send a rudder command
7. You will see engineering messages being sent periodically
8. Then click on the dive button in the RC dive mode
9. These engineering messages should stop coming in


