### PR TITLE
bug/imu-install-type-for-resetting

### DIFF
--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -522,7 +522,7 @@ jaia_firmware = [
      'description': 'BNO085 script to reboot imu',
      'template': 'bno085-reset-gpio-pin.service.in',
      'subdir': 'adafruit_BNO085',
-     'args': '--install_type=' + jaia_imu_install_type.value,
+     'args': '--imu_install_type=' + jaia_imu_install_type.value,
      'runs_on': Type.BOT,
      'runs_when': Mode.RUNTIME,
      'imu_type': IMU_TYPE.BNO085,


### PR DESCRIPTION
## Summary
Changed argument name in system.py to match the argument in the jaia firm to reset the bno085 pin

## Details
While testing on the bench with bot 5 fleet 1 the imu was not reporting data. Checked the jaia firm responsible for restarting the pin and it was throwing an error.

## Testing
Tested the updated argument on bot 5 fleet 1 and the imu successfully restarted and began reporting again.
