### PR TITLE
Task/fix apt cacher

### DIFF
--- a/config/ansible/change-sources.yml
+++ b/config/ansible/change-sources.yml
@@ -77,7 +77,7 @@
       ansible.builtin.lineinfile:
         path: "/etc/hosts"
         regexp: ".*hub{{ hub_id }} *$"
-        line: "10.23.1.{{ (hub_id | int) + 10 }} hub{{ hub_id }}"
+        line: "10.23.{{ jaiabot_embedded_fleet_id }}.{{ (hub_id | int) + 10 }} hub{{ hub_id }}"
       when: mode == "offline" or mode == "online_with_hub_cache"
 
     - name: Set /etc/apt/sources.list.d/jaiabot.list for offline mode

--- a/config/ansible/change-sources.yml
+++ b/config/ansible/change-sources.yml
@@ -39,6 +39,14 @@
       when:
         - mode != "offline"
         - repo != "test"
+    - name: Check if hub_id is defined
+      ansible.builtin.assert:
+        that:
+          - hub_id is defined
+          - hub_id | int | string == hub_id
+        fail_msg: "Hub ID must be defined and must be an integer"
+      when:
+        - mode != "online"
   tasks:
     - include_tasks: tasks/read-debconf.yml
   
@@ -65,11 +73,18 @@
           deb http://packages.jaia.tech/ubuntu/gobysoft/{{ repo }}/{{ internal_version }}/ {{ ansible_distribution_release }}/
       when: mode == "online" or mode == "online_with_hub_cache"
         
+    - name: Set /etc/hosts for hub entry
+      ansible.builtin.lineinfile:
+        path: "/etc/hosts"
+        regexp: ".*hub{{ hub_id }} *$"
+        line: "10.23.1.{{ (hub_id | int) + 10 }} hub{{ hub_id }}"
+      when: mode == "offline" or mode == "online_with_hub_cache"
+
     - name: Set /etc/apt/sources.list.d/jaiabot.list for offline mode
       ansible.builtin.copy:
         dest: "/etc/apt/sources.list.d/jaiabot.list"
         content: |
-          deb [trusted=yes] http://hub0/updates /
+          deb [trusted=yes] http://hub{{ hub_id }}/updates /
       when: mode == "offline"
 
     - name: Set /etc/pip.conf for offline / hub cache mode
@@ -78,8 +93,8 @@
         content: |
           [global]
           no-index = true
-          find-links = http://hub0/updates/
-          trusted-host = hub0
+          find-links = http://hub{{ hub_id }}/updates/
+          trusted-host = hub{{ hub_id }}
       when: mode == "offline" or mode == "online_with_hub_cache"
       
     - name: Set /etc/pip.conf for online mode
@@ -121,5 +136,5 @@
       ansible.builtin.copy:
         dest: "/etc/apt/apt.conf.d/00aptproxy"
         content: |
-          Acquire::http::Proxy "http://hub0:8000";
+          Acquire::http::Proxy "http://hub{{ hub_id }}:8000";
       when: mode == "online_with_hub_cache"

--- a/config/ansible/tasks/read-debconf.yml
+++ b/config/ansible/tasks/read-debconf.yml
@@ -1,5 +1,5 @@
 - name: Capture debconf settings
-  ansible.builtin.shell: debconf-show jaiabot-embedded
+  shell: debconf-show jaiabot-embedded
   register: debconf_raw
   changed_when: False
 

--- a/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
+++ b/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
@@ -44,6 +44,12 @@ add_commander_tab: false
             display_name: "Version Branch"
             value: "1.y"
         }
+        input_var {
+            name: "hub_id"
+            display_name: "Hub ID for offline/hub cache updates"
+            value: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21",  "22", "23", "24", "25", "26", "27", "28", "29", "30"]
+        }
+        
     }
     ansible_playbook {
         file: "check-version.yml" 


### PR DESCRIPTION
Fixes issues arising from https://github.com/jaiarobotics/jaiabot/pull/783:

- Ansible 2.9 (Ubuntu 20.04) does not properly understand "ansible.builtin.shell" (but "shell" works). Revert to using "shell"
- Add support for pulling offline / online with hub cache update from hub ID that is not hub0 (defaults to hub1 in Liaison drop-down menu).

![image](https://github.com/jaiarobotics/jaiabot/assets/732276/e7bcf035-2d86-4d34-880e-4742be1d52ec)

