### PR TITLE
bug/bot-type-should-be-optional-field

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ set(PROJECT_SOVERSION "1")
 
 # increment when DCCL messages change. See also src/lib/messages/CMakeLists.txt
 # start at 1 as 0 would be used prior to introducing this version (goby::middleware::Group::broadcast_group == 0)
-set(PROJECT_INTERVEHICLE_API_VERSION 1)
+set(PROJECT_INTERVEHICLE_API_VERSION 2)
 
 # find Protobuf
 find_package(ProtobufLocal REQUIRED)

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -64,7 +64,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xf62f32809b3cb1fe")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xb0a8dad3780d0a0c")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0x72e30e5222062eee")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0x272a59cf6bc934cd")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x10116fc06c9a8e8b")

--- a/src/lib/messages/jaia_dccl.proto
+++ b/src/lib/messages/jaia_dccl.proto
@@ -139,7 +139,7 @@ message BotStatus
         HYDRO = 1;
         ECHO = 2;
     }
-    required BotType bot_type = 7;
+    optional BotType bot_type = 7;
 
     optional GeographicCoordinate location = 10;
 


### PR DESCRIPTION
### Description
Changing bot type field to be optional.

### Testing

- Start web server
- Start jaia apps (all.launch)
- Bots should show in the JCC
- Test sending commands


