### PR TITLE
bug/missing-dependency-dccl4-apps

### DIFF
--- a/scripts/setup-tools-build-nodocker.sh
+++ b/scripts/setup-tools-build-nodocker.sh
@@ -7,7 +7,7 @@ sudo apt-key adv --recv-key --keyserver hkp://keyserver.ubuntu.com:80 19478082E2
 # Update apt
 sudo apt-get -y update
 # Install the required dependencies
-sudo apt-get -y install libdccl4-dev libgoby3-dev libgoby3-moos-dev libgoby3-gui-dev gpsd libnanopb-dev nanopb rsync python3-venv python3-protobuf
+sudo apt-get -y install dccl4-apps libdccl4-dev libgoby3-dev libgoby3-moos-dev libgoby3-gui-dev gpsd libnanopb-dev nanopb rsync python3-venv python3-protobuf
 # Install the build tools necessary
 sudo apt-get -y install cmake g++ npm clang-format clang graphviz
 # Install packages to allow apt to use a repository over HTTPS:


### PR DESCRIPTION
### Description
Added dccl apps to setup-tools-build-nodocker.sh. Needed to run dccl and get the hash of the different dccl messages we send.

### Testing
- Run setup-tools-build.sh
- Run the ./build.sh
- Verify the package installed: `dpkg-query -W <package name>`