### PR TITLE
feature/add-web-endpoints-for-hub-status-and-bot-status

### DIFF
--- a/src/web/server/app.py
+++ b/src/web/server/app.py
@@ -69,6 +69,14 @@ def JSONResponse(obj: any=None, string: str=None):
 def getStatus():
     return JSONResponse(jaia_interface.get_status())
 
+@app.route('/jaia/status-bots', methods=['GET'])
+def getStatusBots():
+    return JSONResponse(jaia_interface.get_status_bots())
+
+@app.route('/jaia/status-hubs', methods=['GET'])
+def getStatusHubs():
+    return JSONResponse(jaia_interface.get_status_hubs())
+
 @app.route('/jaia/metadata', methods=['GET'])
 def getMetadata():
     return JSONResponse(jaia_interface.get_Metadata())

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -415,6 +415,20 @@ class Interface:
             pass
 
         return status
+    
+    def get_status_bots(self):
+        """Gets the status for all bots connected to the hub
+        Returns:
+            {[bot_id: int]: BotStatus}: The status for all connected bots
+        """
+        return self.bots
+    
+    def get_status_hubs(self):
+        """Gets the status for all online hubs
+        Returns:
+            {[hub_id: int]: HubStatus}: The status for all online hubs
+        """
+        return self.hubs
 
     def post_engineering_command(self, command, clientId):
         cmd = google.protobuf.json_format.ParseDict(command, Engineering())


### PR DESCRIPTION
### Description
Add separate endpoints to get hub and bot statuses
### Testing
1. Launch the simulation
2. Launch the server
3. Ping the endpoint (localhost:40001/jaia/status-bots)
    1. You should see the statuses for the bots in sim
4. Ping the endpoint (localhost:40001/jaia/status-hubs)
    1. You should see the status for the hub in sim
### Suggestions
Open to suggestions regarding endpoint names and wording of the function comments