### PR TITLE
bug/jdv-not-loading-logs

### DIFF
--- a/src/web/jdv/server/jaia_h5.py
+++ b/src/web/jdv/server/jaia_h5.py
@@ -50,7 +50,7 @@ def get_title_from_path(path: str):
 
 # This lock is locked whenever a thread is checking to open an h5 file, potentially doing some goby -> h5 conversions
 # It is used because we don't want multiple python "threads" (they're not really threads but behave that way) to 
-# run goby_log_tool on the same log at the same time.
+# run goby log convert on the same log at the same time.
 conversionLock = Lock()
 
 
@@ -106,7 +106,7 @@ class JaiaH5FileSet:
                 gobyPath = h5Path.with_suffix('.goby')
                 if gobyPath.is_file():
                     # convert goby file to h5 file
-                    cmd = f'nice -n 10 goby_log_tool --input_file {gobyPath} --output_file {h5Path} --format HDF5'
+                    cmd = f'nice -n 10 goby log convert --input_file {gobyPath} --output_file {h5Path} --format HDF5'
                     logging.info(cmd)
                     os.system(cmd)
                 else:
@@ -175,7 +175,6 @@ class JaiaH5FileSet:
         return results
 
     def map(self):
-        BotStatus_bot_id_path = '/jaiabot::bot_status;0/jaiabot.protobuf.BotStatus/bot_id'
         NodeStatus_lat_path = 'goby::middleware::frontseat::node_status/goby.middleware.frontseat.protobuf.NodeStatus/global_fix/lat'
         NodeStatus_lon_path = 'goby::middleware::frontseat::node_status/goby.middleware.frontseat.protobuf.NodeStatus/global_fix/lon'
         NodeStatus_heading_path = 'goby::middleware::frontseat::node_status/goby.middleware.frontseat.protobuf.NodeStatus/pose/heading'
@@ -186,7 +185,11 @@ class JaiaH5FileSet:
         desired_heading_series = Series()
 
         for log in self.h5Files:
-            bot_id_string = str(log[BotStatus_bot_id_path][0])
+            # Get Bot id from the filename
+            bot_id_pattern = re.compile(r'bot(\d+)')
+            bot_id = re.findall(bot_id_pattern, log.filename)
+            bot_id_string = str(bot_id[0])
+
             lat_series = Series(log=log, path=NodeStatus_lat_path, invalid_values=[0])
             lon_series = Series(log=log, path=NodeStatus_lon_path, invalid_values=[0])
             heading_series = Series(log=log, path=NodeStatus_heading_path)

--- a/src/web/jdv/server/log_conversion.py
+++ b/src/web/jdv/server/log_conversion.py
@@ -49,7 +49,7 @@ class LogConversionManager:
                     logging.error(f'File not found: {goby_path}')
                     continue
 
-                cmd = f'goby_log_tool --input_file {goby_path} --output_file {temp_path} --format HDF5'
+                cmd = f'nice -n 10 goby log convert --input_file {goby_path} --output_file {temp_path} --format HDF5'
                 logging.info(cmd)
                 system(cmd)
                 system(f'mv {temp_path} {h5_path}')


### PR DESCRIPTION
### Description
The group id for bot status is now the api version number. Using 0 as a default will not work. This pull request gets bot id from file name. Also updated to use goby log convert instead of goby_log_tool.

### Testing
- Start simulation with 2 bots
- Copy goby files to /var/log/jaiabot/bot_offload directory
- Start jdv
- Select logs to convert
- Select data to view