### PR TITLE
bug/after-performing-a-task-mission-manager-breaks

### DIFF
--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -1,3 +1,4 @@
+#include "jaiabot/intervehicle.h"
 #include <goby/middleware/log/groups.h>
 #include <goby/middleware/protobuf/logger.pb.h>
 
@@ -380,7 +381,8 @@ jaiabot::statechart::inmission::underway::Task::~Task()
         {
             glog.is_debug2() && glog << "(RF Enabled) Publishing task packet intervehicle: "
                                      << task_packet_.DebugString() << std::endl;
-            intervehicle().publish<groups::task_packet>(task_packet_);
+            intervehicle().publish<groups::task_packet>(
+                task_packet_, intervehicle::default_publisher<protobuf::TaskPacket>);
         }
     }
 }


### PR DESCRIPTION
### Description
Need to pass a default publisher to send task packet over intervehicle. The group is inferred from jaiabot::INTERVEHICLE_API_VERSION and possibly the already-set bot_id field we don't need to set anything using the group function. However Goby requires one to exist for using non-broadcast groups, so we define a no-op group_func
### Testing
- Start simulation
- Send a run to a bot with a task
- The bot should still be in good health after the run is completed