### PR TITLE
task/hide-echo-field-if-not-bots-are-echos

### DIFF
--- a/src/web/jcc/client/components/CommandControl.tsx
+++ b/src/web/jcc/client/components/CommandControl.tsx
@@ -39,7 +39,7 @@ import { divePacketIconStyle, driftPacketIconStyle, getRallyStyle } from './shar
 import { createBotCourseOverGroundFeature, createBotHeadingFeature } from './shared/BotFeature'
 import { getSurveyMissionPlans, featuresFromMissionPlanningGrid, surveyStyle } from './SurveyMission'
 import { BotDetailsComponent, HubDetailsComponent, DetailsExpandedState, BotDetailsProps, HubDetailsProps } from './Details'
-import { Goal, TaskType, GeographicCoordinate, CommandType, Command, Engineering, MissionTask, TaskPacket, BottomDepthSafetyParams } from './shared/JAIAProtobuf'
+import { Goal, TaskType, GeographicCoordinate, CommandType, Command, Engineering, MissionTask, TaskPacket, BottomDepthSafetyParams, BotType } from './shared/JAIAProtobuf'
 import { getGeographicCoordinate, deepcopy, equalValues, getMapCoordinate, getHTMLDateString, getHTMLTimeString } from './shared/Utilities'
 
 
@@ -133,6 +133,7 @@ interface State {
 	podStatus: PodStatus
 	podStatusVersion: number
 	botExtents: {[key: number]: number[]},
+	enableEcho: boolean,
 	lastBotCount: number,
 
 	missionParams: MissionParams,
@@ -256,6 +257,7 @@ export default class CommandControl extends React.Component {
 			},
 			podStatusVersion: 0,
 			botExtents: {},
+			enableEcho: false,
 			lastBotCount: 0,
 
 			missionParams: {
@@ -814,6 +816,7 @@ export default class CommandControl extends React.Component {
 
 				this.oldPodStatus = {...this.getPodStatus()}
 				this.setPodStatus(result)
+				this.setPodConfig()
 
 				let messages = result.messages
 
@@ -882,6 +885,15 @@ export default class CommandControl extends React.Component {
 
 	setPodStatus(podStatus: PodStatus) {
 		this.setState({ podStatus, podStatusVersion: this.state.podStatusVersion + 1 })
+	}
+
+	/**
+	 * Saves configurable pod settings in state
+	 * @returns {void}
+	 */
+	setPodConfig() {
+		const enableEcho = this.checkBotTypes(BotType.ECHO)
+		this.setState({ enableEcho })
 	}
 
 	getMetadata() {
@@ -1033,6 +1045,21 @@ export default class CommandControl extends React.Component {
 				onSuccess()
 			})
 		}
+	}
+
+	/**
+	 * Loops through bot status messages searching for a particular bot type
+	 * 
+	 * @param {BotType} type Target bot type
+	 * @returns {boolean} Whether or not the target bot type exists in the pod
+	 */
+	checkBotTypes(type: BotType) {
+		for (let bot of Object.values(this.state.podStatus['bots'])) {
+			if (bot.bot_type !== undefined && bot.bot_type === type) {
+				return true
+			}
+		}
+		return false
 	}
 
 	// 

--- a/src/web/jcc/client/components/CommandControl.tsx
+++ b/src/web/jcc/client/components/CommandControl.tsx
@@ -889,6 +889,7 @@ export default class CommandControl extends React.Component {
 
 	/**
 	 * Saves configurable pod settings in state
+	 * 
 	 * @returns {void}
 	 */
 	setPodConfig() {

--- a/src/web/jcc/client/components/CommandControl.tsx
+++ b/src/web/jcc/client/components/CommandControl.tsx
@@ -3346,6 +3346,7 @@ export default class CommandControl extends React.Component {
 					isSRPEnabled={this.state.isSRPEnabled}
 					setIsSRPEnabled={this.setIsSRPEnabled.bind(this)}
 					botList={bots}
+					enableEcho={this.state.enableEcho}
 					
 					onClose={() => {
 						this.clearMissionPlanningState()
@@ -3673,6 +3674,7 @@ export default class CommandControl extends React.Component {
 						originalGoal={goalBeingEdited.originalGoal}
 						runList={this.getRunList()}
 						runNumber={goalBeingEdited?.runNumber}
+						enableEcho={this.state.enableEcho}
 						setRunList={this.setRunList.bind(this)}
 						onChange={() => {
 							this.setRunList(this.getRunList())

--- a/src/web/jcc/client/components/GoalSettings.tsx
+++ b/src/web/jcc/client/components/GoalSettings.tsx
@@ -27,6 +27,7 @@ interface Props {
     map: Map
     runList: MissionInterface
     runNumber: number
+    enableEcho: boolean
     onChange: () => void
     onDoneClick: () => void
     setVisiblePanel: (panelType: PanelType) => void
@@ -274,6 +275,7 @@ export class GoalSettingsPanel extends React.Component {
                         map={this.props.map}
                         location={goal?.location}
                         isEditMode={isEditMode}
+                        enableEcho={this.props.enableEcho}
                         scrollTaskSettingsIntoView={this.scrollTaskSettingsIntoView.bind(this)}
                         onChange={task => {
                             goal.task = task

--- a/src/web/jcc/client/components/MissionSettings.tsx
+++ b/src/web/jcc/client/components/MissionSettings.tsx
@@ -53,6 +53,7 @@ interface Props {
     isSRPEnabled: boolean
     setIsSRPEnabled: (isSRPEnabled: boolean) => void
     botList?: {[key: string]: BotStatus}
+    enableEcho: boolean
 
     onClose: () => void
     onMissionApply: (startRally: Feature<Geometry>, endRally: Feature<Geometry>, missionStartTask: MissionTask, missionEndTask: MissionTask) => void
@@ -242,6 +243,7 @@ export class MissionSettingsPanel extends React.Component {
                         <TaskSettingsPanel 
                             task={this.state.missionBaseGoal.task} 
                             isEditMode={true}
+                            enableEcho={this.props.enableEcho}
                             onChange={(task) => {
                                 const missionBaseGoal = this.state.missionBaseGoal
                                 missionBaseGoal.task = task
@@ -257,7 +259,8 @@ export class MissionSettingsPanel extends React.Component {
                             map={map} 
                             location={this.props.startRally?.get('location')}
                             isEditMode={true}
-                            task={this.state.missionStartTask} 
+                            task={this.state.missionStartTask}
+                            enableEcho={this.props.enableEcho}
                             onChange={(missionStartTask) => { this.setState({ missionStartTask })}} 
                         />
                     </div>
@@ -269,7 +272,8 @@ export class MissionSettingsPanel extends React.Component {
                             map={map} 
                             location={finalLocation}
                             isEditMode={true}
-                            task={this.state.missionEndTask} 
+                            task={this.state.missionEndTask}
+                            enableEcho={this.props.enableEcho}
                             onChange={(missionEndTask) => { this.setState({ missionEndTask })}} 
                         />
                     </div>

--- a/src/web/jcc/client/components/TaskSettingsPanel.tsx
+++ b/src/web/jcc/client/components/TaskSettingsPanel.tsx
@@ -37,6 +37,7 @@ interface Props {
     task?: MissionTask
     location?: GeographicCoordinate
     isEditMode?: boolean
+    enableEcho: boolean
     scrollTaskSettingsIntoView?: () => void
     onChange?: (task?: MissionTask) => void
     onDoneClick?: (task?: MissionTask) => void
@@ -239,6 +240,31 @@ function TaskOptionsPanel(props: Props) {
         })
     }
 
+    /**
+     * If the pod contains an Echo bot, then a toggle for acoustic functionality will appear in the task settings
+     * 
+     * @returns {ReactComponent} A toggle for controlling the acoustic modem or an empty div for non-Echo pods
+     */
+    function getEchoToggle() {
+        const enableEcho = props.enableEcho
+
+        if (enableEcho) {
+            return (
+                <tr className="task-param-container">
+                    <td className="task-label">Start Echo</td>
+                    <td className="input-row dive-time">
+                        <JaiaToggle 
+                            checked={() => isEchoChecked()}
+                            onClick={() => handleEchoCheck()}
+                            disabled={() => !props?.isEditMode}
+                        />
+                    </td>
+                </tr>
+            )
+        }
+        return <div></div>
+    }
+
      /**
      * Checks to see if what state start_echo is in
      * 
@@ -299,16 +325,7 @@ function TaskOptionsPanel(props: Props) {
                                     <td className="task-label">Drift Time</td>
                                     <td className="input-row dive-time"><input type="number" step="10" min="0" max="3600" className="NumberInput" name="drift_time" value={surface_drift.drift_time} onChange={onChangeDriftParameter} disabled={!props?.isEditMode}/>s</td>
                                 </tr>
-                                <tr className="task-param-container">
-                                    <td className="task-label">Start Echo</td>
-                                    <td className="input-row dive-time">
-                                        <JaiaToggle 
-                                            checked={() => isEchoChecked()}
-                                            onClick={() => handleEchoCheck()}
-                                            disabled={() => !props?.isEditMode}
-                                        />
-                                    </td>
-                                </tr>
+                                {getEchoToggle()}
                             </tbody>
                         </table>
                         :
@@ -330,16 +347,7 @@ function TaskOptionsPanel(props: Props) {
                                     <td className="task-label">Drift Time</td>
                                     <td className="input-row dive-time"><input type="number" step="10" min="0" max="3600" className="NumberInput" name="drift_time" value={surface_drift.drift_time} onChange={onChangeDriftParameter} disabled={!props?.isEditMode} />s</td>
                                 </tr>
-                                <tr className="task-param-container">
-                                    <td className="task-label">Start Echo</td>
-                                    <td className="input-row dive-time">
-                                        <JaiaToggle 
-                                            checked={() => isEchoChecked()}
-                                            onClick={() => handleEchoCheck()}
-                                            disabled={() => !props?.isEditMode}
-                                        />
-                                    </td>
-                                </tr>
+                                {getEchoToggle()}
                             </tbody>
                         </table>
 
@@ -357,16 +365,7 @@ function TaskOptionsPanel(props: Props) {
                                 <td className="task-label">Drift Time</td>
                                 <td className="input-row drift-time"><input type="number" step="1" className="NumberInput" name="drift_time" value={surface_drift.drift_time} onChange={onChangeDriftParameter} disabled={!props?.isEditMode} />s</td>
                             </tr>
-                            <tr className="task-param-container">
-                                <td className="task-label">Start Echo</td>
-                                <td className="input-row dive-time">
-                                    <JaiaToggle 
-                                        checked={() => isEchoChecked()}
-                                        onClick={() => handleEchoCheck()}
-                                        disabled={() => !props?.isEditMode}
-                                    />
-                                </td>
-                            </tr>
+                                {getEchoToggle()}
                         </tbody>
                     </table>
                 </div>

--- a/src/web/shared/JAIAProtobuf.ts
+++ b/src/web/shared/JAIAProtobuf.ts
@@ -758,6 +758,11 @@ export interface DesiredCourse {
     altitude?: number
 }
 
+export enum BotType {
+    HYDRO = "HYDRO",
+    ECHO = "ECHO",
+}
+
 export enum VehicleType {
     UNKNOWN = "UNKNOWN",
     AUV = "AUV",
@@ -985,6 +990,7 @@ export interface BotStatus {
     health_state?: HealthState
     error?: Error[]
     warning?: Warning[]
+    bot_type?: BotType
     location?: GeographicCoordinate
     depth?: number
     attitude?: Attitude


### PR DESCRIPTION
### Summary
Hides the acoustic modem toggle in the JCC if none of the bots in the pod are JaiaBot PAMs

### Description
Loops through the bot types as the bot status messages arrive on the client side. If one of the bot status messages includes the bot type ECHO (in the future we will change this to PAM), then a new state property `enableEcho` is set to true. This is passed down to the panels that render the toggle.

### Testing
Tested in sim with:
2 HYDROs
2 ECHOs
1 HYDRO, 1 ECHO
1 ECHO, 1 HYDRO
For each combination of bots, I created individual runs and verified I could use the toggle on dive and drift tasks. I also created a survey mission to verify the toggle appeared correctly in that panel.