### PR TITLE
bug/imu-detection-reboot

### DIFF
--- a/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
+++ b/config/templates/bot/jaiabot_mission_manager.pb.cfg.in
@@ -90,7 +90,7 @@ include_goal_timeout_states: IN_MISSION__PAUSE__REACQUIRE_GPS
 min_depth_safety: -1 # (default = -1)
 
 # IMU Restart State Timeout
-imu_restart_seconds: 10 # (default = 10)
+imu_restart_seconds: 15 # (default = 15)
 
 # If using wifi we need to subscribe to the hub on start, since the hub doesn't know what bots are running
 $subscribe_to_hub_on_start

--- a/src/bin/drivers/adafruit_BNO055/config.proto
+++ b/src/bin/drivers/adafruit_BNO055/config.proto
@@ -43,6 +43,6 @@ message AdaFruitBNO055Publisher
 
     optional int32 adafruit_bno055_report_timeout_seconds = 10 [default = 30];
     optional bool adafruit_bno055_report_in_simulation = 11 [default = true];
-    optional jaiabot.protobuf.IMUIssue.SolutionType imu_issue_solution = 33 [default = RESTART_IMU_PY];
+    optional jaiabot.protobuf.IMUIssue.SolutionType imu_issue_solution = 12 [default = RESTART_IMU_PY];
     optional int32 imu_trigger_issue_timeout_seconds = 13 [default = 30];
 }

--- a/src/bin/drivers/adafruit_BNO055/config.proto
+++ b/src/bin/drivers/adafruit_BNO055/config.proto
@@ -25,8 +25,10 @@ syntax = "proto2";
 
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "jaiabot/messages/feather.proto";
 import "goby/middleware/protobuf/udp_config.proto";
+
+import "jaiabot/messages/feather.proto";
+import "jaiabot/messages/imu.proto";
 
 package jaiabot.config;
 
@@ -39,6 +41,8 @@ message AdaFruitBNO055Publisher
 
     required goby.middleware.protobuf.UDPPointToPointConfig udp_config = 3;
 
-    optional int32 adafruit_bno055_report_timeout_seconds = 10 [default = 40];
+    optional int32 adafruit_bno055_report_timeout_seconds = 10 [default = 30];
     optional bool adafruit_bno055_report_in_simulation = 11 [default = true];
+    optional jaiabot.protobuf.IMUIssue.SolutionType imu_issue_solution = 33 [default = RESTART_IMU_PY];
+    optional int32 imu_trigger_issue_timeout_seconds = 13 [default = 30];
 }

--- a/src/bin/drivers/adafruit_BNO085/config.proto
+++ b/src/bin/drivers/adafruit_BNO085/config.proto
@@ -43,6 +43,6 @@ message AdaFruitBNO085Publisher
 
     optional int32 adafruit_bno085_report_timeout_seconds = 10 [default = 30];
     optional bool adafruit_bno085_report_in_simulation = 11 [default = true];
-    optional jaiabot.protobuf.IMUIssue.SolutionType imu_issue_solution = 33 [default = REBOOT_BNO085_IMU_AND_RESTART_IMU_PY];
+    optional jaiabot.protobuf.IMUIssue.SolutionType imu_issue_solution = 12 [default = REBOOT_BNO085_IMU_AND_RESTART_IMU_PY];
     optional int32 imu_trigger_issue_timeout_seconds = 13 [default = 30];
 }

--- a/src/bin/drivers/adafruit_BNO085/config.proto
+++ b/src/bin/drivers/adafruit_BNO085/config.proto
@@ -25,8 +25,10 @@ syntax = "proto2";
 
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "jaiabot/messages/feather.proto";
 import "goby/middleware/protobuf/udp_config.proto";
+
+import "jaiabot/messages/feather.proto";
+import "jaiabot/messages/imu.proto";
 
 package jaiabot.config;
 
@@ -39,6 +41,8 @@ message AdaFruitBNO085Publisher
 
     required goby.middleware.protobuf.UDPPointToPointConfig udp_config = 3;
 
-    optional int32 adafruit_bno085_report_timeout_seconds = 10 [default = 40];
+    optional int32 adafruit_bno085_report_timeout_seconds = 10 [default = 30];
     optional bool adafruit_bno085_report_in_simulation = 11 [default = true];
+    optional jaiabot.protobuf.IMUIssue.SolutionType imu_issue_solution = 33 [default = REBOOT_BNO085_IMU_AND_RESTART_IMU_PY];
+    optional int32 imu_trigger_issue_timeout_seconds = 13 [default = 30];
 }

--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -889,23 +889,13 @@ void jaiabot::apps::Fusion::health(goby::middleware::protobuf::ThreadHealth& hea
         {
             // TODO: We should be able to easily configure different error timeouts
             // Temp fix for now
-            if (ep.first == DataType::HEADING && !imu_issue_detected_)
+            if (ep.first == DataType::HEADING)
             {
                 if (!last_data_time_.count(ep.first) ||
                     (last_data_time_[ep.first] +
                          std::chrono::seconds(cfg().heading_timeout_seconds()) <
                      now))
                 {
-                    jaiabot::protobuf::IMUIssue imu_issue;
-                    imu_issue.set_solution(cfg().imu_issue_solution());
-                    interprocess().publish<jaiabot::groups::imu>(imu_issue);
-                    imu_issue_detected_ = true;
-                    last_imu_issue_report_time_ = now;
-
-                    glog.is_debug2() &&
-                        glog << "detect_imu_issue() Post IMU Warning: No heading data "
-                                "indicates imu issue"
-                             << endl;
                     health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
                         ->add_error(ep.second);
                     health.set_state(goby::middleware::protobuf::HEALTH__FAILED);

--- a/src/bin/mission_manager/config.proto
+++ b/src/bin/mission_manager/config.proto
@@ -121,7 +121,7 @@ message MissionManager
     optional RemoteControlSetpointEnd rc_setpoint_end = 50
         [default = RC_SETPOINT_ENDS_IN_STATIONKEEP];
 
-    optional uint32 imu_restart_seconds = 51 [default = 10];
+    optional uint32 imu_restart_seconds = 51 [default = 15];
 
     // Bot not rising timeout in seconds without depth change greater than
     // dive_depth_eps before assuming the bot is stuck and is not rising


### PR DESCRIPTION
## Description
The imu detection entered a loop where it would keep restarting. This left the vehicle unable to drive using the autonomy. Moved the imu publish to restart into the imu drivers instead of fusion. Updated the imu restart state to 15 seconds.

## Testing
* Deployed code to bot 1 fleet 0
* Stopped the python driver for the imu
* Check for the error message in liaison
* Check to see if the error goes away and imu data comes back