### PR TITLE
bug/imu-var-not-initialized

### DIFF
--- a/src/python/pyjaia/pyjaia/waves/acceleration_analyzer.py
+++ b/src/python/pyjaia/pyjaia/waves/acceleration_analyzer.py
@@ -63,10 +63,10 @@ class AccelerationAnalyzer:
         if imuData is None:
             return
         
+        acc = imuData.linear_acceleration
+        
         if self._sampling_for_wave_height:
             utime = datetime.utcnow().timestamp() * 1e6
-            acc = imuData.linear_acceleration
-
             vertical_acceleration = dotProduct(imuData.linear_acceleration, imuData.gravity) / magnitude(imuData.gravity)
             self.vertical_acceleration.append(utime, vertical_acceleration)
 


### PR DESCRIPTION
## Description
Moving initialization of acc var outside of if statement because it would crash the imu driver when the vehicle went to dive.

## Testing
Tested the code on bot 5 fleet 1.