### PR TITLE
bug/data-offload-percent-missing-from-details-panel

### DIFF
--- a/src/web/jcc/client/components/Details.tsx
+++ b/src/web/jcc/client/components/Details.tsx
@@ -682,8 +682,8 @@ export function BotDetailsComponent(props: BotDetailsProps) {
 
     let botOffloadPercentage = ''
 
-    if (bot.data_offload_percentage) {
-        botOffloadPercentage = ' ' + bot.data_offload_percentage + '%'
+    if (bot.bot_id === hub?.bot_offload?.bot_id) {
+        botOffloadPercentage = ' ' + hub.bot_offload?.data_offload_percentage + '%'
     }
 
     // Change message for clicking on map if the bot has a run, but it is not in edit mode


### PR DESCRIPTION
## Summary
I forgot to add update the data offload percentage in the details panel. It now grabs the offload percent from the hub status message.

## Testing
Watched the percentage come through correctly in the details panel while working with Fleet 2 (Bots 1 and 2)