### PR TITLE
bug/install-web-dependencies-clears-pre-commit-hooks

### DIFF
--- a/scripts/git-hooks/init/pre-commit/pre-commit
+++ b/scripts/git-hooks/init/pre-commit/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# clang-format=hooks
+scripts/git-hooks/clang-format-hooks/git-pre-commit-format
+
+# prettier
+scripts/git-hooks/prettier/write.sh
+
+exit 0

--- a/scripts/git-hooks/init/pre-commit/set-pre-commit-hook.sh
+++ b/scripts/git-hooks/init/pre-commit/set-pre-commit-hook.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/bash
+
+cp pre-commit ../../../../.husky/_/pre-commit

--- a/src/web/run.sh
+++ b/src/web/run.sh
@@ -19,6 +19,14 @@ popd > /dev/null
 # Build JCC and JED clients
 # Install pre-requisites
 ./install_dependencies.sh ./
+
+
+# Set up pre-commit hooks
+pushd ${JAIA_DIR}/scripts/git-hooks/init/pre-commit/ > /dev/null
+    ./set-pre-commit-hook.sh
+popd > /dev/null
+
+
 mkdir -p ${BUILD_DIR}
 echo 🟢 Building JCC and JED into ${BUILD_DIR}
 npx webpack --mode production --env OUTPUT_DIR=${BUILD_DIR} --progress


### PR DESCRIPTION
## Summary
* Bug: Installing the dependencies in the run script, cleared the pre-commit hook script.
* Solution: Copy the pre-commit hook script for husky execution after the web dependencies are installed in `run.sh`

## Testing
* Executed the run script with the pre-commit script cleared and watched it copy after the web dependencies were installed