### PR TITLE
Task/post rootfs merge cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,21 +278,7 @@ workflows:
           requires:
             - raspi-image-create-jammy
             - virtualbox-image-create-jammy
-          <<: *filter-template-aws-rootfs-builds
-                
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - /.*/
-    jobs:
-      - raspi-image-create-focal
-      - virtualbox-image-create-focal
-      - raspi-image-create-jammy
-      - virtualbox-image-create-jammy
+          <<: *filter-template-aws-rootfs-builds                
       
 jobs:
 

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -1,10 +1,10 @@
 # JaiaBot rootfs generation.
 
-This repository contains [live-build](https://live-team.pages.debian.net/live-manual/html/live-manual/index.en.html) scripts for generating an Ubuntu root filesystem for booting on the embedded Linux computer (currently Raspberry Pi) or on a VirtualBox virtual machine.
+This folder contains [live-build](https://live-team.pages.debian.net/live-manual/html/live-manual/index.en.html) scripts for generating an Ubuntu root filesystem for booting on the embedded Linux computer (currently Raspberry Pi) or on a VirtualBox virtual machine.
 
 ## CI Built images
 
-As an alternative to cloning this repository and building images yourself, you can download them pre-built on [CircleCI](https://app.circleci.com/pipelines/github/jaiarobotics/jaiabot-rootfs-gen). Browse to the latest build (raspi-image-create for the Raspberry Pi image, or virtualbox-image-create for the VirtualBox image), click "Artifacts", and download the appropriate file (.img.gz or .ova, respectively).
+As an alternative to cloning this repository and building images yourself, you can download them pre-built on [CircleCI](https://app.circleci.com/pipelines/github/jaiarobotics/jaiabot?branch=1.y). Browse to the latest build (raspi-image-create for the Raspberry Pi image, or virtualbox-image-create for the VirtualBox image), click "Artifacts", and download the appropriate file (.img.gz or .ova, respectively).
 
 
 ## Quick usage (build your own)

--- a/src/doc/markdown/page19_repository.md
+++ b/src/doc/markdown/page19_repository.md
@@ -1,20 +1,12 @@
 # JaiaBot Repositories
-The JaiaBot source code lives in the following Git repositories:
-
-* `jaiabot`: Source code (C++ primarily) that is built into compiled code (binaries and libraries)
-* `jaiabot-rootfs-gen`: Root filesystem generation for jaiabot
-* `jaiabot-debian`: Debian packaging files for jaiabot
-
-## jaiabot
-This Git repository is hosted at: <https://github.com/jaiarobotics/jaiabot>
+The JaiaBot source code lives in the `jaiabot` Git repository (<https://github.com/jaiarobotics/jaiabot>).
 
 It consists of source code that is compiled into a variety of binary applications and libraries to be run on the target platforms (vehicles and base station computers). This compilation can be carried out manually by the developers on their computers and automatically be the CircleCI service for the target hardware. See [Building and CI/CD](page20_build.md) for more details.
 
-## jaiabot-rootfs-gen
-This Git repository is hosted at: <https://github.com/jaiarobotics/jaiabot-rootfs-gen>
-
-## jaiabot-debian
-This Git repository is hosted at: <https://github.com/jaiarobotics/jaiabot-debian>
+* `jaiabot`
+  * `src`: Source code (C++ primarily) that is built into compiled code (binaries and libraries)
+  * `rootfs`: Root filesystem generation for jaiabot (prior to 1.12.0 this was the separate `jaiabot-rootfs-gen` repository).
+  * `debian`: Debian packaging files for jaiabot (prior to 1.12.0 this was the separate `jaiabot-debian` repository).
 
 # Release Branches
 

--- a/src/doc/markdown/page25_embedded_setup.md
+++ b/src/doc/markdown/page25_embedded_setup.md
@@ -20,11 +20,11 @@ The RP bootloader on older CM4 boards does not boot from all the USB ports autom
 
 ### Generation of the filesystem image
 
-*Note: this step should only need to be done once per change to jaiabot-rootfs-gen (and then reused for any number of USB thumb drives).*
+*Note: this step should only need to be done once per change to jaiabot/rootfs files (and then reused for any number of USB thumb drives).*
 
-The [jaiabot-rootfs-gen](https://github.com/jaiarobotics/jaiabot-rootfs-gen) project is designed to generate a complete filesystem suitable to boot the RP off a USB thumb drive or other USB disk.
+The jaiabot/rootfs folder is designed to generate a complete filesystem suitable to boot the RP off a USB thumb drive or other USB disk.
 
-To generate the image, follow the steps in https://github.com/jaiarobotics/jaiabot-rootfs-gen/blob/master/README.md
+To generate the image, follow the steps in https://github.com/jaiarobotics/jaiabot/blob/1.y/rootfs/README.md.
 
 The result will be something like `jaiabot_img-1.0.0~alpha1+5+g90e72a3.img`.
 

--- a/src/doc/markdown/page56_cloud.md
+++ b/src/doc/markdown/page56_cloud.md
@@ -57,7 +57,7 @@ The components of the VPC include:
 
 ## Network addresses
 
-The use of the `ip.py` tool (in `jaiabot-rootfs-gen/customization/includes.chroot/etc/jaiabot` or `/etc/jaiabot/ip.py` on the hub/bots) is recommended for determining IP addresses for a given node, id, fleet, etc.
+The use of the `ip.py` tool (in `jaiabot/rootfs/customization/includes.chroot/etc/jaiabot` or `/etc/jaiabot/ip.py` on the hub/bots) is recommended for determining IP addresses for a given node, id, fleet, etc.
 
 The network address assignment for the Jaia Cloud is intended to complement the existing fleet specific [VPN](page55_vpn.md). This means that a given fleet may have up to three VPN subnets assigned:
 


### PR DESCRIPTION
- Remove nightly rootfs builds as this is pointless now that jaiabot-rootfs-gen is part of jaiabot/rootfs.
- Update doc for change from jaiabot-rootfs-gen to jaiabot/rootfs.