### PR TITLE
bug/prettier-working-outside-web

### DIFF
--- a/scripts/git-hooks/prettier/write.sh
+++ b/scripts/git-hooks/prettier/write.sh
@@ -2,6 +2,9 @@
 FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
 [ -z "$FILES" ] && exit 0
 
+INCLUDE="web"
+FILES=$(echo "$FILES" | grep -E "$INCLUDE")
+
 # Prettify all selected files
 prettier_project_path="src/web/node_modules/.bin/prettier"
 prettier_abs_path=${PWD}"/${prettier_project_path}"
@@ -9,6 +12,6 @@ prettier_abs_path=${PWD}"/${prettier_project_path}"
 echo "$FILES" | xargs ${prettier_abs_path} --ignore-unknown --write
 
 # Add back the modified/prettified files to staging
-echo "$FILES" | xargs git add
+echo "$FILES" | xargs git add .
 
 exit 0


### PR DESCRIPTION
## Summary
Prettier runs on changed files detected by git. It ignores files out of its realm (ie `.cpp`, `.py`), but I forgot to consider `.yaml` and `.md` files. This PR prevents prettier from touching files outside of the web dir.

## Testing
* Made changes to the circleci yaml file and to a web file. Committed those changes (using exit code 1 on the pre-commit hook to simulate a commit) and saw no changes made to the yaml file and the correct changes made to the web file.