### PR TITLE
task/clear-deb-test-branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/add-adafruit_bno08x-repo-into-jaiabot-repo-jaia-1270"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds


### PR DESCRIPTION
## Summary
When merging in https://github.com/jaiarobotics/jaiabot/commit/d399f3f8b1ae8aa6f7f3d799429b8360f1bd1f89 I forgot to remove the branch from the circleci build. This pull request removes it.