### PR TITLE
task/jcc-use-minimize-jaia-1280

### DIFF
--- a/src/web/run.sh
+++ b/src/web/run.sh
@@ -27,16 +27,13 @@ pushd ${JAIA_DIR}/scripts/git-hooks/init/pre-commit/ > /dev/null
 popd > /dev/null
 
 
-mkdir -p ${BUILD_DIR}
-echo 🟢 Building JCC and JED into ${BUILD_DIR}
-npx webpack --mode production --env OUTPUT_DIR=${BUILD_DIR} --progress
-
-
 # Start server
+echo 🟢 Starting server
 pushd server > /dev/null
     ./app.py -a ${BUILD_DIR} $1 &
 popd > /dev/null
 
 
 # Watch build JCC and JED clients for development
+echo 🟢 Building the client apps. Please wait until initial build completes before loading JCC or JED in browser.
 npx webpack --mode development --env OUTPUT_DIR=${BUILD_DIR} --watch --progress

--- a/src/web/webpack.config.js
+++ b/src/web/webpack.config.js
@@ -133,6 +133,8 @@ module.exports = (env, argv) => {
         ],
     };
 
+    // This just takes a new empty object {}, and then updates it in place with the baseConfig, then the modeConfig,
+    // then the config for the target app... basically fusing the three configs together.
     return [
         Object.assign({}, baseConfig, modeConfig, jedConfig),
         Object.assign({}, baseConfig, modeConfig, jccConfig),


### PR DESCRIPTION
Do not use devtool: eval-source-map option when building JCC for production, (reduces 35 MB product down to 7 MB!)