### PR TITLE
Parse ntpq for peer status code rather than waiting ntpstat

### DIFF
--- a/config/templates/systemd/jaiabot.service.in
+++ b/config/templates/systemd/jaiabot.service.in
@@ -24,7 +24,7 @@ EnvironmentFile=$env_file
 ExecStartPre=/bin/bash -c "/bin/mkdir -p `$gen log_file`"
 
 # Try for 120 seconds for NTP to synchronize
-ExecStartPre=/bin/bash -c "for i in {1..12}; do ntpstat && break; echo 'Waiting for NTP sync'; sleep 10; done"
+ExecStartPre=/bin/bash -c "for i in {1..12}; do ntpq -pn | egrep '^\*|^o' && break; echo 'Waiting for NTP sync'; sleep 10; done"
 
 ExecStart=/bin/echo "Starting Jaia"
 


### PR DESCRIPTION
This will drive down our time to first bot status from cold power-on substantially. `ntpstat` seems excessively picky about declaring synchronization.

Needs testing on a bot/hub.