### PR TITLE
bug/jdv-map-headings-off

### DIFF
--- a/src/web/jdv/client/src/JaiaMap.ts
+++ b/src/web/jdv/client/src/JaiaMap.ts
@@ -376,7 +376,15 @@ export default class JaiaMap {
 
             // Filter to only keep points within the time range
             var path = [];
+            var startPt = null;
+            var endPt = null;
+
             for (const pt of ptArray) {
+                if (pt[1] == null || pt[2] == null) continue;
+
+                if (startPt == null) startPt = pt;
+                endPt = pt;
+
                 // Contribute to tMin and tMax
                 const t = pt[0];
                 if (this.tMin == null || t < this.tMin) this.tMin = t;
@@ -405,9 +413,8 @@ export default class JaiaMap {
             this.botPathVectorSource.addFeature(pathFeature);
 
             // Add start and end markers
-            if (ptArray.length > 0) {
-                // parameters: {title?, lon, lat, style?, time?, popupHTML?}
-                const startPt = ptArray[0];
+
+            if (startPt) {
                 const startMarker = createMarker2(this.map, {
                     title: "Start",
                     lon: startPt[2],
@@ -416,8 +423,9 @@ export default class JaiaMap {
                     style: Styles.startMarker,
                 });
                 this.botPathVectorSource.addFeature(startMarker);
+            }
 
-                const endPt = ptArray[ptArray.length - 1];
+            if (endPt) {
                 const endMarker = createMarker2(this.map, {
                     title: "End",
                     lon: endPt[2],
@@ -456,7 +464,7 @@ export default class JaiaMap {
 
     updateToTimestamp(timestamp_micros: number) {
         this.timestamp = timestamp_micros;
-        // console.log('updateToTimestamp', timestamp_micros, this.timestamp)
+        // console.log('updateToTimestamp: ', timestamp_micros)
 
         this.updateBotMarkers(timestamp_micros);
         this.updateMissionLayer(timestamp_micros);

--- a/src/web/jdv/server/jaia_h5.py
+++ b/src/web/jdv/server/jaia_h5.py
@@ -191,8 +191,8 @@ class JaiaH5FileSet:
             bot_id = re.findall(bot_id_pattern, log.filename)
             bot_id_string = str(bot_id[0])
 
-            lat_series = Series.loadFromH5File(log=log, path=NodeStatus_lat_path, invalid_values=[0])
-            lon_series = Series.loadFromH5File(log=log, path=NodeStatus_lon_path, invalid_values=[0])
+            lat_series = Series.loadFromH5File(log=log, path=NodeStatus_lat_path)
+            lon_series = Series.loadFromH5File(log=log, path=NodeStatus_lon_path)
             heading_series = Series.loadFromH5File(log=log, path=NodeStatus_heading_path)
             course_over_ground_series = Series.loadFromH5File(log=log, path=NodeStatus_course_over_ground_path)
 
@@ -204,8 +204,8 @@ class JaiaH5FileSet:
                 most_recent_desired_heading = desired_heading_series.getValueAtTime(lat_series.utime[i])
                 thisSeries.append([
                     lat_series.utime[i], 
-                    lat_series.y_values[i], 
-                    lon_series.y_values[i], 
+                    lat_series.y_values[i] or None, 
+                    lon_series.y_values[i] or None, 
                     heading_series.y_values[i], 
                     course_over_ground_series.y_values[i], 
                     most_recent_desired_heading


### PR DESCRIPTION
Do not filter out zeroes from lat/lon series on the backend, so the heading series always has the same length as the lat/lon series.