### PR TITLE
Setup fixes for NVM install directory and submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/python/Adafruit_CircuitPython_BNO08x"]
 	path = src/python/Adafruit_CircuitPython_BNO08x
-	url = git@github.com:jaiarobotics/Adafruit_CircuitPython_BNO08x.git
+	url = https://github.com/jaiarobotics/Adafruit_CircuitPython_BNO08x.git

--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,13 @@ script_dir=$(dirname $0)
 ARCH=$(dpkg --print-architecture)
 
 # Make sure we're using the nvm versions of npm and webpack
-source $HOME/.nvm/nvm.sh
+if [ -z "${XDG_CONFIG_HOME-}" ]; then
+    export NVM_DIR="${HOME}/.nvm"
+else
+    export NVM_DIR="${XDG_CONFIG_HOME}/nvm"
+fi
+
+source ${NVM_DIR}/nvm.sh
 
 set -e -u
 mkdir -p ${script_dir}/build/${ARCH}

--- a/scripts/setup-tools-build-nodocker.sh
+++ b/scripts/setup-tools-build-nodocker.sh
@@ -23,7 +23,13 @@ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.
 curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
 
 export NODE_VERSION=v18.12.1
-export NVM_DIR="$HOME/.nvm"
+
+if [ -z "${XDG_CONFIG_HOME-}" ]; then
+    export NVM_DIR="${HOME}/.nvm"
+else
+    export NVM_DIR="${XDG_CONFIG_HOME}/nvm"
+fi
+
 
 # We have to source the "~/.nvm/nvm.sh" script in order to set the paths to use the
 #   nvm versions of webpack and npm


### PR DESCRIPTION
See #887 for NVM issue.

The new Adafruit submodule will not initialize on systems without an ssh key setup. This is not in the build documentation so it can cause an unexpected error for anyone who has not set one up. Switching this URL to https solves this issue and does not introduce credential issues as the submodule repository is public.