### PR TITLE
task/add-gps-outliers-to-jdv-map

### DIFF
--- a/src/web/jdv/client/src/JaiaMap.ts
+++ b/src/web/jdv/client/src/JaiaMap.ts
@@ -391,8 +391,6 @@ export default class JaiaMap {
             var path = [];
             var startPt = null;
             var endPt = null;
-            var prevPt = null;
-            var coordEpsilon = 0.0001;
 
             for (const pt of ptArray) {
                 const lat = pt[1];
@@ -412,19 +410,10 @@ export default class JaiaMap {
                     break;
                 }
 
-                if (
-                    prevPt &&
-                    (this.checkOutlier(prevPt[1], lat, coordEpsilon) ||
-                        this.checkOutlier(prevPt[2], lon, coordEpsilon))
-                ) {
-                    continue;
-                }
-
                 if (t > timeRange[0]) {
                     path.push(this.fromLonLat([lon, lat])); // API gives lat/lon, OpenLayers uses lon/lat
                 }
 
-                prevPt = pt;
             }
 
             // const pathLineString = new LineString(path)


### PR DESCRIPTION
Removed JDV outlier filter due to spurious filtering and to implement a more informative outlier filter upstream in the data