### PR TITLE
task/report_mid_battery_2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ set(PROJECT_SOVERSION "1")
 
 # increment when DCCL messages change. See also src/lib/messages/CMakeLists.txt
 # start at 1 as 0 would be used prior to introducing this version (goby::middleware::Group::broadcast_group == 0)
-set(PROJECT_INTERVEHICLE_API_VERSION 7)
+set(PROJECT_INTERVEHICLE_API_VERSION 8)
 
 # find Protobuf
 find_package(ProtobufLocal REQUIRED)

--- a/config/templates/bot/jaiabot_simulator.pb.cfg.in
+++ b/config/templates/bot/jaiabot_simulator.pb.cfg.in
@@ -58,6 +58,7 @@ arduino_config {
     voltage_period: 3 # (default = 1)
     voltage_step_decrease: 0.0 # (default = 0.1)
     voltage_start: 24.0 # (default = 24.0)
+    voltage_mid_start: 12.0 # (default = 12.0)
     reset_voltage_level: 15.0 # (default = 15.0)
 } 
 

--- a/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
+++ b/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
@@ -98,6 +98,7 @@ bool target_led_switch_on = false;
 constexpr int VvCurrent = A3;
 constexpr int VccCurrent = A2;
 constexpr int VccVoltage = A0;
+constexpr int VmidVoltage = A6;
 
 jaiabot_protobuf_ArduinoCommand command = jaiabot_protobuf_ArduinoCommand_init_default;
 
@@ -161,6 +162,8 @@ void send_ack(jaiabot_protobuf_ArduinoStatusCode code, uint32_t crc=0, uint32_t 
 
   ack.vccvoltage = analogRead(VccVoltage)*.0306;
   ack.has_vccvoltage = true;
+  ack.vmidvoltage = analogRead(VmidVoltage)*.0306; 
+  ack.has_vmidvoltage = true; 
   ack.vvcurrent = ((analogRead(VvCurrent)*.0049)-5)*-.05;
   ack.has_vvcurrent = true;
 
@@ -208,6 +211,7 @@ void setup()
 
   pinMode(VccCurrent, INPUT);
   pinMode(VccVoltage, INPUT);
+  pinMode(VmidVoltage, INPUT); 
   pinMode(VvCurrent, INPUT);
   pinMode(LED_D1_PIN, OUTPUT);
   

--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -472,6 +472,21 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(5 * si::hertz)
                 latest_bot_status_.set_battery_percent(battery_percentage);
             }
 
+            if (arduino_response.has_vmidvoltage())
+            {
+                latest_bot_status_.set_vmid_voltage(arduino_response.vmidvoltage());
+
+                //TODO ADD FUNCTION / CODE TO REPORT BATTERY PERCENTAGE
+                std::map<float, float> mid_voltage_to_battery_percent_{
+                    {10.5, 0.0},   {11.31, 10}, {11.58, 20.0},
+                    {12.42, 80.0}, {12.5, 90.0}, {12.7, 100.0}}; // map of voltage to battery %
+
+                float mid_battery_percentage = goby::util::linear_interpolate(
+                    arduino_response.vmidvoltage(), mid_voltage_to_battery_percent_);
+
+                // latest_bot_status_.set_battery_percent(battery_percentage);
+            }
+
             if (arduino_response.has_vcccurrent())
             {
                 latest_bot_status_.set_vcc_current(arduino_response.vcccurrent());

--- a/src/bin/simulator/arduino_sim_thread.cpp
+++ b/src/bin/simulator/arduino_sim_thread.cpp
@@ -60,9 +60,6 @@ void jaiabot::apps::ArduinoSimThread::loop()
         if (voltage_start_ < reset_voltage_level_)
         {
             voltage_start_ = cfg().voltage_start();
-        }
-        if (voltage_mid_start_ < 9.0)
-        {
             voltage_mid_start_ = cfg().voltage_mid_start(); 
         }
     }

--- a/src/bin/simulator/arduino_sim_thread.cpp
+++ b/src/bin/simulator/arduino_sim_thread.cpp
@@ -35,6 +35,7 @@ jaiabot::apps::ArduinoSimThread::ArduinoSimThread(const jaiabot::config::Arduino
     voltage_step_decrease_ = cfg.voltage_step_decrease();
     voltage_period_ = cfg.voltage_period();
     voltage_start_ = cfg.voltage_start();
+    voltage_mid_start_ = cfg.voltage_mid_start(); 
     reset_voltage_level_ = cfg.reset_voltage_level();
 }
 
@@ -51,12 +52,18 @@ void jaiabot::apps::ArduinoSimThread::loop()
     if ((voltage_updated_ + std::chrono::seconds(voltage_period_)) < now)
     {
         voltage_start_ = voltage_start_ - voltage_step_decrease_;
+        voltage_mid_start_ = voltage_mid_start_ - voltage_step_decrease_; 
         arduino_response.set_vccvoltage(voltage_start_);
+        arduino_response.set_vmidvoltage(voltage_mid_start_);
         voltage_updated_ = goby::time::SteadyClock::now();
 
         if (voltage_start_ < reset_voltage_level_)
         {
             voltage_start_ = cfg().voltage_start();
+        }
+        if (voltage_mid_start_ < 9.0)
+        {
+            voltage_mid_start_ = cfg().voltage_mid_start(); 
         }
     }
 

--- a/src/bin/simulator/config.proto
+++ b/src/bin/simulator/config.proto
@@ -126,4 +126,5 @@ message ArduinoSimThread
     optional double voltage_step_decrease = 2 [default = 0.1];
     optional double voltage_start = 3 [default = 24.0];
     optional double reset_voltage_level = 4 [default = 15.0];
+    optional double voltage_mid_start = 5 [default = 12.0]; 
 }

--- a/src/bin/simulator/simulator_thread.h
+++ b/src/bin/simulator/simulator_thread.h
@@ -69,6 +69,7 @@ class ArduinoSimThread : public SimulatorThread<jaiabot::config::ArduinoSimThrea
     double voltage_step_decrease_{0.1};
     double voltage_start_{24.0};
     double reset_voltage_level_{15};
+    double voltage_mid_start_{12.0}; 
     goby::time::SteadyClock::time_point voltage_updated_{std::chrono::seconds(0)};
 };
 

--- a/src/doc/markdown/page41_hdf5.md
+++ b/src/doc/markdown/page41_hdf5.md
@@ -130,6 +130,7 @@
   * optional double thermocouple_temperature
   * optional double vv_current
   * optional double vcc_current
+  * optional double vmid_voltage
   * optional double vcc_voltage
   * optional double battery_percent
   * optional IMUData.CalibrationStatus calibration_status
@@ -595,6 +596,7 @@
   * optional float vccvoltage
   * optional float vcccurrent
   * optional float vvcurrent
+  * optional float vmidvoltage
   * optional uint32 crc
   * optional uint32 calculated_crc
   * optional uint32 version

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -64,7 +64,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xd3f1756c210c6df8")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xc30b47a277b57130")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0x72e30e5222062eee")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0x52a2f5523b658a63")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/arduino.proto
+++ b/src/lib/messages/arduino.proto
@@ -47,6 +47,7 @@ message ArduinoResponse
     optional float vcccurrent = 4;
     optional float vvcurrent = 5;
     optional int32 motor = 6;
+    optional float vmidvoltage = 7; 
 
     optional uint32 crc = 50;
     optional uint32 calculated_crc = 51;

--- a/src/lib/messages/jaia_dccl.proto
+++ b/src/lib/messages/jaia_dccl.proto
@@ -275,6 +275,13 @@ message BotStatus
 
     optional int32 wifi_link_quality_percentage = 62
         [(dccl.field) = { min: 0 max: 100 precision: 0 }];
+    
+    optional double vmid_voltage = 63 [(dccl.field) = {
+        min: 0
+        max: 13
+        precision: 2
+        units { derived_dimensions: "electric_potential" system: "si" }
+    }];
 }
 
 message DriftPacket

--- a/src/web/jcc/client/components/Details.tsx
+++ b/src/web/jcc/client/components/Details.tsx
@@ -1423,6 +1423,10 @@ export function BotDetailsComponent(props: BotDetailsProps) {
                                                         <td>{bot.vcc_voltage?.toFixed(prec)} V</td>
                                                     </tr>
                                                     <tr>
+                                                        <td>Vmid Voltage</td>
+                                                        <td>{bot.vmid_voltage?.toFixed(prec)} V</td>
+                                                    </tr>
+                                                    <tr>
                                                         <td>Vcc Current</td>
                                                         <td>{bot.vcc_current?.toFixed(prec)} A</td>
                                                     </tr>

--- a/src/web/jed/updateStatus.js
+++ b/src/web/jed/updateStatus.js
@@ -60,6 +60,7 @@ function updateStatus(status) {
         innerHTML += "<td>" + (bot.salinity?.toFixed(1) || "?") + "</td>";
 
         innerHTML += "<td>" + (bot.vcc_voltage?.toFixed(1) || "?") + "</td>";
+        innerHTML += "<td>" + (bot.vmid_voltage?.toFixed(1) || "?") + "</td>";
         innerHTML += "<td>" + (bot.vcc_current?.toFixed(1) || "?") + "</td>";
         innerHTML += "<td>" + (bot.vv_current?.toFixed(1) || "?") + "</td>";
 

--- a/src/web/shared/JAIAProtobuf.ts
+++ b/src/web/shared/JAIAProtobuf.ts
@@ -1013,6 +1013,7 @@ export interface BotStatus {
     vv_current?: number;
     vcc_current?: number;
     vcc_voltage?: number;
+    vmid_voltage?: number;
     battery_percent?: number;
     calibration_status?: number;
     hdop?: number;

--- a/src/web/utils/protobuf-types.ts
+++ b/src/web/utils/protobuf-types.ts
@@ -999,6 +999,7 @@ export interface BotStatus {
     vv_current?: number;
     vcc_current?: number;
     vcc_voltage?: number;
+    vmid_voltage?: number;
     battery_percent?: number;
     calibration_status?: number;
     hdop?: number;


### PR DESCRIPTION
Reports 'vmid_voltage' data inside the BotStatus message, read from the midpoint of the two batteries onboard a Jaiabot. 