### PR TITLE
tasks / Support updating root yubikeys and security labels on PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,3 +20,13 @@ rootfs:
 github-actions:
   - changed-files:
       - any-glob-to-any-file: '.github/**'
+
+circleci:
+  - changed-files:
+      - any-glob-to-any-file: '.circleci/**'
+
+systemd:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'config/gen/systemd*'
+          - 'config/templates/systemd/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+debian:
+  - 'jaiabot/debian/**'
+
+rootfs:
+  - 'jaiabot/rootfs/**'
+
+actions:
+  - 'jaiabot/.github/workflows/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,6 +17,6 @@ rootfs:
   - changed-files:
       - any-glob-to-any-file: 'jaiabot/rootfs/**'
 
-actions:
+github-actions:
   - changed-files:
       - any-glob-to-any-file: 'jaiabot/.github/workflows/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,4 +19,4 @@ rootfs:
 
 github-actions:
   - changed-files:
-      - any-glob-to-any-file: 'jaiabot/.github/workflows/**'
+      - any-glob-to-any-file: 'jaiabot/.github/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,12 +11,12 @@ task:
 # Labels on changed files
 debian:
   - changed-files:
-      - any-glob-to-any-file: 'jaiabot/debian/**'
+      - any-glob-to-any-file: 'debian/**'
 
 rootfs:
   - changed-files:
-      - any-glob-to-any-file: 'jaiabot/rootfs/**'
+      - any-glob-to-any-file: 'rootfs/**'
 
 github-actions:
   - changed-files:
-      - any-glob-to-any-file: 'jaiabot/.github/**'
+      - any-glob-to-any-file: '.github/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,22 @@
+# Labels on branch name
+feature:
+  - head-branch: ['feature/*', 'feat/*']
+
+bug:
+  - head-branch: 'bug/*'
+
+task:
+  - head-branch: 'task/*'
+
+# Labels on changed files
 debian:
-  - 'jaiabot/debian/**'
+  - changed-files:
+      - any-glob-to-any-file: 'jaiabot/debian/**'
 
 rootfs:
-  - 'jaiabot/rootfs/**'
+  - changed-files:
+      - any-glob-to-any-file: 'jaiabot/rootfs/**'
 
 actions:
-  - 'jaiabot/.github/workflows/**'
+  - changed-files:
+      - any-glob-to-any-file: 'jaiabot/.github/workflows/**'

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,3 +1,0 @@
-feature: ['feature/*', 'feat/*']
-bug: bug/*
-task: task/*

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,18 +1,9 @@
 name: PR Labeler
 on:
-  pull_request:
-    types: [opened]
+- pull_request_target
 
 jobs:
-  name-labeler:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: TimonVS/pr-labeler-action@v3
-        with:
-          configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  file-labeler:
+  labeler:
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,7 +4,7 @@ on:
     types: [opened]
 
 jobs:
-  pr-labeler:
+  name-labeler:
     runs-on: ubuntu-latest
     steps:
       - uses: TimonVS/pr-labeler-action@v3
@@ -12,3 +12,10 @@ jobs:
           configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  file-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Labeler
 on:
-- pull_request_target
+- pull_request
 
 jobs:
   labeler:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Labeler
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   labeler:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,12 @@ if(install_motd)
   install(PROGRAMS ${project_SCRIPTS_DIR}/75-jaiabot-status DESTINATION /etc/update-motd.d/)
 endif()
 
+option(install_ssh_authorized_keys "Install SSH authorized keys to /etc/jaiabot/ssh" ON)
+if(install_ssh_authorized_keys)
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/rootfs/customization/includes.chroot/etc/jaiabot/ssh DESTINATION /etc/jaiabot)
+endif()
+
+
 install(PROGRAMS ${project_SCRIPTS_DIR}/75-jaiabot-status DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jaiabot-status)
 
 # for use by Docker build install

--- a/debian/jaiabot-embedded.install
+++ b/debian/jaiabot-embedded.install
@@ -1,2 +1,2 @@
 /etc/update-motd.d/*
-
+/etc/jaiabot/ssh/*


### PR DESCRIPTION
# Update root yubikeys with software release update

## Overview 

This PR makes updates to so that the root yubikey authorized_keys (/etc/jaiabot/ssh/root_authorized_keys) can be changed with normal updates to jaiabot now, in the event that the root yubikeys are lost, stolen or need to be replaced for other reasons (e.g., newer version of the keys supporting new features).

## Additional PR labeling for verification 

To ensure this is done securely (and improve the likelihood that we will catch malicious code inserted to key parts of the repository), this PR adds additional labels (using .github/workflows/pr-labeler.yml) that are automatically attached to pull requests that modify files that are most likely to cause harm. This will be an extra hint to reviewers to pay attention to ensure these changes are correct (and not malicious):

- **rootfs**: Files in the rootfs generation directory (this can modify that core features of *newly* created fleets). This also includes changes to ssh key access.
- **debian**: Files in the debian directory (this can script changes that occur on each `apt update`)
- **github-actions**: Files in the github-actions (including the action that flags the PRs!).
- **circleci**: Files in .circleci which govern the automatic deployment of code
- **systemd**: Files in the systemd generation which govern how the various services are run.

I merged the existing PR labeling behavior into this, using the official `labeler@v5` (https://github.com/actions/labeler) action.

## Further considerations:

Another tool we can use is CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection