### PR TITLE
bug/jammy-image-does-not-boot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,7 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
     branches:
       only:
         - "1.y"
+        - "bug/jammy-image-does-not-boot"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,6 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
     branches:
       only:
         - "1.y"
-        - "bug/jammy-image-does-not-boot"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds

--- a/rootfs/scripts/create_raspi_base_image.sh
+++ b/rootfs/scripts/create_raspi_base_image.sh
@@ -388,6 +388,12 @@ if [ ! -z "$VIRTUALBOX" ]; then
     echo "Virtualbox OVA created at $OUTPUT_IMAGE_OVA, VDI created at $OUTPUT_IMAGE_VDI, img at $OUTPUT_IMAGE_IMG"
 else
     sudo chroot rootfs apt-get -y install linux-image-raspi
+
+    ## Run flash-kernel manually once as it will not run automatically in CHROOT / EFI
+    # Jammy flash-kernel checks for /sys/firmware/efi and bails
+    sudo umount "$ROOTFS_PARTITION"/sys
+    # Noble flash-kernel added FK_IGNORE_EFI
     sudo chroot rootfs /bin/bash -c "export FK_FORCE=yes; export FK_IGNORE_EFI=yes; flash-kernel"
+    
     echo "Raspberry Pi image created at $OUTPUT_IMAGE_PATH"
 fi

--- a/rootfs/scripts/create_raspi_base_image.sh
+++ b/rootfs/scripts/create_raspi_base_image.sh
@@ -388,5 +388,6 @@ if [ ! -z "$VIRTUALBOX" ]; then
     echo "Virtualbox OVA created at $OUTPUT_IMAGE_OVA, VDI created at $OUTPUT_IMAGE_VDI, img at $OUTPUT_IMAGE_IMG"
 else
     sudo chroot rootfs apt-get -y install linux-image-raspi
+    sudo chroot rootfs /bin/bash -c "export FK_FORCE=yes; export FK_IGNORE_EFI=yes; flash-kernel"
     echo "Raspberry Pi image created at $OUTPUT_IMAGE_PATH"
 fi


### PR DESCRIPTION
The `flash-kernel` script has gotten fancier in Ubuntu 22.04/jammy about detecting if it should run. 

As we are building the image on a EFI system in a chroot, we need a bit more coaxing to get it to run during image creation.

This small change fixes the create_raspi_base_image.sh script so it correctly installs the kernel and thus can be booted on the Raspberry Pi.

Tested on Raspberry Pi 4 hardware.