### PR TITLE
bug/clicking-hub-button-no-gps-jaia-1520

### DIFF
--- a/src/web/containers/HubDetails.tsx
+++ b/src/web/containers/HubDetails.tsx
@@ -38,10 +38,6 @@ export function HubDetails() {
 
     const hubContext = useContext(HubContext);
 
-    if (hubContext === null || !globalContext.showHubDetails) {
-        return <div></div>;
-    }
-
     const [accordionTheme, setAccordionTheme] = useState(
         createTheme({
             transitions: {
@@ -53,6 +49,10 @@ export function HubDetails() {
     useEffect(() => {
         addDropdownListener("accordionContainer", "hubDetailsAccordionContainer", 30);
     }, []);
+
+    if (hubContext === null || !globalContext.showHubDetails) {
+        return <div></div>;
+    }
 
     const firstKey = Number(Object.keys(hubContext.hubStatuses)[0]);
     const hubStatus = hubContext.hubStatuses[firstKey];

--- a/src/web/containers/HubDetails.tsx
+++ b/src/web/containers/HubDetails.tsx
@@ -54,8 +54,8 @@ export function HubDetails() {
         addDropdownListener("accordionContainer", "hubDetailsAccordionContainer", 30);
     }, []);
 
-    const firstKey = Object.keys(hubContext.hubStatus)[0];
-    const hubStatus = hubContext.hubStatus[firstKey];
+    const firstKey = Number(Object.keys(hubContext.hubStatuses)[0]);
+    const hubStatus = hubContext.hubStatuses[firstKey];
 
     /**
      * Dispatches an action to close the HubDetails panel
@@ -95,7 +95,7 @@ export function HubDetails() {
      * @returns {number | string} Load average for the hub or 'N/A' if an issue arises
      */
     function getCPULoadAverage(timeMins: number) {
-        const loads = hubContext.hubStatus?.processor?.loads;
+        const loads = hubStatus?.linux_hardware_status?.processor?.loads;
 
         if (loads === undefined) {
             return "N/A";
@@ -133,9 +133,9 @@ export function HubDetails() {
      * @returns {void}
      */
     function openJDV() {
-        const hubOctal = 10 + hubStatus.hub_id;
-        const fleetOctal = hubStatus.fleet_id;
-        const url = `http://10.23.${fleetOctal}.${hubOctal}:40010`;
+        const hubOctet = 10 + hubStatus.hub_id;
+        const fleetOctet = hubStatus.fleet_id;
+        const url = `http://10.23.${fleetOctet}.${hubOctet}:40010`;
         window.open(url, "_blank");
     }
 
@@ -145,8 +145,8 @@ export function HubDetails() {
      * @returns {void}
      */
     function openRouterPage() {
-        const fleetOctal = hubStatus.fleet_id;
-        const url = `http://10.23.${fleetOctal}.1`;
+        const fleetOctet = hubStatus.fleet_id;
+        const url = `http://10.23.${fleetOctet}.1`;
         window.open(url, "_blank");
     }
 
@@ -156,9 +156,9 @@ export function HubDetails() {
      * @returns {void}
      */
     function openUpgradePage() {
-        const hubOctal = 10 + hubStatus.hub_id;
-        const fleetOctal = hubStatus.fleet_id;
-        const url = `http://10.23.${fleetOctal}.${hubOctal}:9091`;
+        const hubOctet = 10 + hubStatus.hub_id;
+        const fleetOctet = hubStatus.fleet_id;
+        const url = `http://10.23.${fleetOctet}.${hubOctet}:9091`;
         window.open(url, "_blank");
     }
 
@@ -196,11 +196,11 @@ export function HubDetails() {
                                     <HealthStatusLine healthState={hubStatus?.health_state} />
                                     <tr>
                                         <td>Latitude</td>
-                                        <td>{formatLatitude(hubStatus?.location.lat)}</td>
+                                        <td>{formatLatitude(hubStatus?.location?.lat)}</td>
                                     </tr>
                                     <tr>
                                         <td>Longitude</td>
-                                        <td>{formatLongitude(hubStatus?.location.lon)}</td>
+                                        <td>{formatLongitude(hubStatus?.location?.lon)}</td>
                                     </tr>
                                     <tr
                                         className={getStatusAgeClassName(hubStatus.portalStatusAge)}

--- a/src/web/context/HubContext.tsx
+++ b/src/web/context/HubContext.tsx
@@ -9,13 +9,15 @@ import { jaiaAPI } from "../jcc/common/JaiaAPI";
 // Utilities
 import { isError } from "lodash";
 
+type HubStatuses = { [key: number]: PortalHubStatus };
+
 interface HubContextType {
-    hubStatus: PortalHubStatus;
+    hubStatuses: HubStatuses;
 }
 
 interface Action {
     type: string;
-    hubStatus?: PortalHubStatus;
+    hubStatuses?: HubStatuses;
 }
 
 interface HubContextProviderProps {
@@ -24,7 +26,7 @@ interface HubContextProviderProps {
 
 const HUB_POLL_TIME = 1000; // ms
 
-export const HubContext = createContext(null);
+export const HubContext = createContext<HubContextType>(null);
 export const HubDispatchContext = createContext(null);
 
 /**
@@ -38,7 +40,7 @@ function hubReducer(state: HubContextType, action: Action) {
     let mutableState = { ...state };
     switch (action.type) {
         case HubActions.HUB_STATUS_POLLED:
-            return handleHubStatusPolled(mutableState, action.hubStatus);
+            return handleHubStatusPolled(mutableState, action.hubStatuses);
         default:
             return state;
     }
@@ -50,9 +52,9 @@ function hubReducer(state: HubContextType, action: Action) {
  * @param {GlobalContextType} mutableState State object ref for making modifications
  * @returns {GlobalContextType} Updated mutable state object
  */
-function handleHubStatusPolled(mutableState: HubContextType, hubStatus: PortalHubStatus) {
-    if (!hubStatus) throw new Error("Invalid hubStatus");
-    mutableState.hubStatus = hubStatus;
+function handleHubStatusPolled(mutableState: HubContextType, hubStatuses: HubStatuses) {
+    if (!hubStatuses) throw new Error("Invalid hubStatuses");
+    mutableState.hubStatuses = hubStatuses;
     return mutableState;
 }
 
@@ -89,7 +91,7 @@ function pollHubStatus(dispatch: React.Dispatch<Action>) {
         if (!isError(response)) {
             dispatch({
                 type: HubActions.HUB_STATUS_POLLED,
-                hubStatus: response,
+                hubStatuses: response,
             });
         }
     }, HUB_POLL_TIME);

--- a/src/web/jcc/client/components/SetHubLocation.tsx
+++ b/src/web/jcc/client/components/SetHubLocation.tsx
@@ -132,7 +132,7 @@ export default function SetHubLocation(props: Props) {
                     id="set-hub-location-latitude"
                     ref={latitudeInputElementRef}
                     name="latitude"
-                    defaultValue={hubLocation.lat.toFixed(6)}
+                    defaultValue={hubLocation?.lat.toFixed(6)}
                 />
 
                 <div>Longitude</div>
@@ -141,7 +141,7 @@ export default function SetHubLocation(props: Props) {
                     id="set-hub-location-longitude"
                     name="longitude"
                     ref={longitudeInputElementRef}
-                    defaultValue={hubLocation.lon.toFixed(6)}
+                    defaultValue={hubLocation?.lon.toFixed(6)}
                 />
             </div>
 

--- a/src/web/shared/Utilities.tsx
+++ b/src/web/shared/Utilities.tsx
@@ -20,7 +20,7 @@ export function convertMicrosecondsToSeconds(microseconds: number) {
 
 export function formatLatitude(lat: number, prec = 5) {
     if (lat == null) {
-        return "?";
+        return "N/A";
     }
     if (lat > 0) {
         return abs(lat).toFixed(prec) + "° N";
@@ -31,7 +31,7 @@ export function formatLatitude(lat: number, prec = 5) {
 
 export function formatLongitude(lon: number, prec = 5) {
     if (lon == null) {
-        return "?";
+        return "N/A";
     }
     if (lon > 0) {
         return abs(lon).toFixed(prec) + "° E";


### PR DESCRIPTION
-     Add type information to the HubContext variable.
-     Change the type of HubContextType.hubStatuses variable to be a hash of hub_id to PortalHubStatus.
-     Added the optional chaining operator to hubStatus?.location?.lat and lon
-     Change name of HubContextType.hubStatus to hubStatuses to indicate that it's a map onto PortalHubStatus objects.
-     Changed "Octal" to "Octet"
-     Don't return early before all hooks are generated (React doesn't like this and produces a console warning).