### PR TITLE
bug/change-delimiter-for-entering-xbee-command-mode

### DIFF
--- a/src/lib/comms/xbee/xbee.cpp
+++ b/src/lib/comms/xbee/xbee.cpp
@@ -440,14 +440,14 @@ size_t jaiabot::comms::XBeeDevice::bytes_available()
 void jaiabot::comms::XBeeDevice::enter_command_mode()
 {
     std::string buffer;
-    std::string deliminiter = "";
+    std::string delimiter = "B-Bypass";
     int timeout_seconds = 5;
     
     // Triggers menu to appear for bypass
     write("\r");
 
     this->async_read_with_timeout(
-            buffer, deliminiter, timeout_seconds, [this](const std::string& result) {
+            buffer, delimiter, timeout_seconds, [this](const std::string& result) {
                       
                 glog.is_debug1() && glog << group(glog_group) << "Result: " << result 
                                        << "\nResult is empty: " << result.empty()


### PR DESCRIPTION
## Summary
Changes delimiter for entering command mode from "" to "B-Bypass". This will allow the timeout to occur so command mode can be entered for 900 MW radios.

## Testing
Tested using 4 bots from Fleet 1 with multiple iterations of turning the bots and hub off and on.