### PR TITLE
bug/jcc-crashes-hub-services-restart

### DIFF
--- a/src/web/containers/HubDetails.tsx
+++ b/src/web/containers/HubDetails.tsx
@@ -57,6 +57,10 @@ export function HubDetails() {
     const firstKey = Number(Object.keys(hubContext.hubStatuses)[0]);
     const hubStatus = hubContext.hubStatuses[firstKey];
 
+    if (!hubStatus) {
+        return <div></div>;
+    }
+
     /**
      * Dispatches an action to close the HubDetails panel
      *
@@ -123,8 +127,8 @@ export function HubDetails() {
         const isControlTaken = await takeControl(globalContext.clientID);
         if (isControlTaken) {
             globalDispatch({ type: GlobalActions.TAKE_CONTROL_SUCCESS });
+            sendHubCommand(hubStatus.hub_id, command);
         }
-        sendHubCommand(hubStatus.hub_id, command);
     }
 
     /**


### PR DESCRIPTION
## Problem
JCC crashed while the hub services restarted and the hub rebooted via the commands in the Hub Details panel.

## Solution
Return an empty div when the hub status object does not exist. This is the behavior I noticed in previous releases.

## Testing
* Deployed to Fleet 2, Hub 2.
* Restarted the services via the Hub Details panel.  No crash. 
* Rebooted the hub via the Hub Details panel. No crash,

## Notes
Moved the `issueHubCommand` function inside a conditional to take into account whether or not control is taken,