### PR TITLE
bug/update-hub-id-error-handling-jcc

### DIFF
--- a/debian/jaiabot-embedded.postinst
+++ b/debian/jaiabot-embedded.postinst
@@ -174,4 +174,7 @@ echo "jaiabot-embedded version: $(dpkg-query --show --showformat='${Version}' ja
 
 #DEBHELPER#
 
+# Remove Goby intervehicle subscription file from hub to prevent non-connected bots from appearing in JCC
+sudo rm /var/log/jaiabot/hub/goby_intervehicle_subscriptions_hub.pb.txt
+
 exit 0

--- a/debian/jaiabot-embedded.postinst
+++ b/debian/jaiabot-embedded.postinst
@@ -175,6 +175,6 @@ echo "jaiabot-embedded version: $(dpkg-query --show --showformat='${Version}' ja
 #DEBHELPER#
 
 # Remove Goby intervehicle subscription file from hub to prevent non-connected bots from appearing in JCC
-sudo rm /var/log/jaiabot/hub/goby_intervehicle_subscriptions_hub.pb.txt
+rm /var/log/jaiabot/hub/goby_intervehicle_subscriptions_hub.pb.txt
 
 exit 0

--- a/src/web/context/GlobalContext.tsx
+++ b/src/web/context/GlobalContext.tsx
@@ -207,7 +207,7 @@ function handleClickedBotTab(mutableState: GlobalContextType) {
  * @returns {GlobalContextType} Updated mutable state object
  */
 function handleClickedHubMapIcon(mutableState: GlobalContextType, hubID: number) {
-    if (!hubID) throw new Error("Invalid hubID");
+    if (isNaN(hubID)) throw new Error("Invalid hubID");
 
     const isHubSelected =
         mutableState.selectedPodElement !== null &&

--- a/src/web/context/GlobalContext.tsx
+++ b/src/web/context/GlobalContext.tsx
@@ -155,7 +155,7 @@ function handleClosedHubDetails(mutableState: GlobalContextType) {
  * @returns {GlobalContextType} Updated mutable state object
  */
 function handleClickedHubTab(mutableState: GlobalContextType, hubID: number) {
-    if (!hubID) throw new Error("Invalid hubID");
+    if (isNaN(hubID)) throw new Error("Invalid hubID");
 
     const isHubSelected =
         mutableState.selectedPodElement !== null &&


### PR DESCRIPTION
## Summary
An error was thrown for hubs with an ID of 0 as the code intended to catch non-numerical hub IDs. Hub IDs of 0 have been depreciated, but to remain compatible with older hubs, this PR uses `isNaN` to validate the hub ID is a number.

Additionally, this PR removes the `goby_intervehicle_subscriptions_hub.pb.txt` file to prevent disconnected bots from appearing in the JCC.

## Testing
Configured the ghost hub as Fleet 1, Hub 0. No error is thrown when opening the hub details panel now.
Removed `goby_intervehicle_subscriptions_hub.pb.txt` from Fleet 1, Hub 0 and watched it repopulate after a hard reboot.
