### PR TITLE
task/hub-comms-limit-default-on

### DIFF
--- a/src/web/jcc/client/components/Layers.ts
+++ b/src/web/jcc/client/components/Layers.ts
@@ -83,7 +83,7 @@ export class Layers {
             title: "Hub Comms Limit Circles",
         },
         source: new VectorSource(),
-        visible: false,
+        visible: true,
         zIndex: 500,
     });
 


### PR DESCRIPTION
The hub comms limit layer has been updated to be on by default. 

I did not check what happens if the Hub does not have GPS.

We still need to address the potential for the user to what to show these limits even if the hub is not getting GPS but the user knows the hubs location