### PR TITLE
bug/jcc-server-crash-cloudhub/jaia/1702

### DIFF
--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -275,8 +275,12 @@ class Interface:
         logging.debug('🟢 SENDING')
         logging.debug(msg)
         data = msg.SerializeToString()
-        self.sock.sendto(data, self.goby_host)
-        logging.info(f'Sent {len(data)} bytes')
+        try:
+            self.sock.sendto(data, self.goby_host)
+            logging.info(f'Sent {len(data)} bytes')
+        except Exception as e:
+            logging.error(f'Failed to send data: {e}')
+        return False
 
         return True
 

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -280,7 +280,7 @@ class Interface:
             logging.info(f'Sent {len(data)} bytes')
         except Exception as e:
             logging.error(f'Failed to send data: {e}')
-        return False
+            return False
 
         return True
 


### PR DESCRIPTION
After researching this, it looks like this is probably an issue with the peers connecting (or not yet connecting) to the wireguard vpn server.

Do our bots and hubs have the other bots and hubs specified in their wireguard conf files?  This stackoverflow post seems to say that you can get this error if you have a peer with no Endpoint defined, and try to send a packet to that peer:

 https://serverfault.com/questions/1037398/wireguard-destination-address-required-when-trying-to-communicate-from-client

In any case, the temporary fix here seems to be a good one, assuming this was a race condition sort of thing, where the machine running web_portal hadn’t yet established itself when the ping packet was sent from jaia_portal.py.

Indeed, I was able to reproduce this error by adding a [Peer] section to my wg_fleet1.conf file, without an Endpoint, and trying to connect to that:

```
WARNING:root:🏓 Pinging server 172.23.1.12:40000
ERROR:root:Failed to send data: [Errno 89] Destination address required
```

And the temporary fix handled it well as you can see.