### PR TITLE
bug/ip-incorrect-for-jdv-liaison-when-using-vpn-jaia-532

### DIFF
--- a/src/web/containers/HubDetails.tsx
+++ b/src/web/containers/HubDetails.tsx
@@ -32,11 +32,32 @@ import {
     mdiWrenchCog,
 } from "@mdi/js";
 
+/**
+ * Returns the IP prefix (two octets), corresponding to either the LAN or the VPN access.
+ *
+ * @param {string} hostname
+ * @returns {("172.23" | "10.23")} The IP prefix needed to create proper links to JDV, the router, upgrade, etc.
+ */
+function getIPPrefix(hostname: string) {
+    // For the VPN
+    // Return 172.23 for hostnames matching:
+    // * 172.23.x.x
+    // * bXfX
+    //
+    // Return 10.23 for ANYTHING else
+
+    if (hostname.match(/172\.23\.[0-9]+\.[0-9]+/)) return "172.23";
+    if (hostname.match(/h[0-9]+f[0-9]+/)) return "172.23";
+    return "10.23";
+}
+
 export function HubDetails() {
     const globalContext = useContext(GlobalContext);
     const globalDispatch = useContext(GlobalDispatchContext);
 
     const hubContext = useContext(HubContext);
+
+    const IPPrefix = getIPPrefix(location.hostname);
 
     const [accordionTheme, setAccordionTheme] = useState(
         createTheme({
@@ -139,7 +160,7 @@ export function HubDetails() {
     function openJDV() {
         const hubOctet = 10 + hubStatus.hub_id;
         const fleetOctet = hubStatus.fleet_id;
-        const url = `http://10.23.${fleetOctet}.${hubOctet}:40010`;
+        const url = `http://${IPPrefix}.${fleetOctet}.${hubOctet}:40010`;
         window.open(url, "_blank");
     }
 
@@ -150,7 +171,7 @@ export function HubDetails() {
      */
     function openRouterPage() {
         const fleetOctet = hubStatus.fleet_id;
-        const url = `http://10.23.${fleetOctet}.1`;
+        const url = `http://${IPPrefix}.${fleetOctet}.1`;
         window.open(url, "_blank");
     }
 
@@ -162,7 +183,7 @@ export function HubDetails() {
     function openUpgradePage() {
         const hubOctet = 10 + hubStatus.hub_id;
         const fleetOctet = hubStatus.fleet_id;
-        const url = `http://10.23.${fleetOctet}.${hubOctet}:9091`;
+        const url = `http://${IPPrefix}.${fleetOctet}.${hubOctet}:9091`;
         window.open(url, "_blank");
     }
 

--- a/src/web/containers/HubDetails.tsx
+++ b/src/web/containers/HubDetails.tsx
@@ -13,6 +13,7 @@ import {
     formatLongitude,
 } from "../shared/Utilities";
 import { CommandInfo, hubCommands, sendHubCommand, takeControl } from "../utils/commands";
+import { getIPPrefix } from "../shared/IPPrefix";
 
 // Styles
 import Button from "@mui/material/Button";
@@ -31,25 +32,6 @@ import {
     mdiWifiCog,
     mdiWrenchCog,
 } from "@mdi/js";
-
-/**
- * Returns the IP prefix (two octets), corresponding to either the LAN or the VPN access.
- *
- * @param {string} hostname
- * @returns {("172.23" | "10.23")} The IP prefix needed to create proper links to JDV, the router, upgrade, etc.
- */
-function getIPPrefix(hostname: string) {
-    // For the VPN
-    // Return 172.23 for hostnames matching:
-    // * 172.23.x.x
-    // * bXfX
-    //
-    // Return 10.23 for ANYTHING else
-
-    if (hostname.match(/172\.23\.[0-9]+\.[0-9]+/)) return "172.23";
-    if (hostname.match(/h[0-9]+f[0-9]+/)) return "172.23";
-    return "10.23";
-}
 
 export function HubDetails() {
     const globalContext = useContext(GlobalContext);

--- a/src/web/shared/IPPrefix.ts
+++ b/src/web/shared/IPPrefix.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns the IP prefix (two octets), corresponding to either the LAN or the VPN access.
+ *
+ * @param {string} hostname
+ * @returns {("172.23" | "10.23")} The IP prefix needed to create proper links to JDV, the router, upgrade, etc.
+ */
+export function getIPPrefix(hostname: string) {
+    // For the VPN
+    // Return 172.23 for hostnames matching:
+    // * 172.23.x.x
+    // * bXfX
+    //
+    // Return 10.23 for ANYTHING else
+
+    if (hostname.match(/172\.23\.[0-9]+\.[0-9]+/)) return "172.23";
+    if (hostname.match(/h[0-9]+f[0-9]+/)) return "172.23";
+    return "10.23";
+}


### PR DESCRIPTION
The client JS checks the location's hostname and matches it against "hXfX" or "172.23.X.X,"  and if either one matches then it assumes you're on the VPN and uses the "172.23" IP prefix in that case.