### PR TITLE
Remove unused imports in .protos

### DIFF
--- a/src/bin/drivers/adafruit_BNO055/config.proto
+++ b/src/bin/drivers/adafruit_BNO055/config.proto
@@ -27,7 +27,6 @@ import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 import "goby/middleware/protobuf/udp_config.proto";
 
-import "jaiabot/messages/feather.proto";
 import "jaiabot/messages/imu.proto";
 
 package jaiabot.config;

--- a/src/bin/drivers/adafruit_BNO085/config.proto
+++ b/src/bin/drivers/adafruit_BNO085/config.proto
@@ -27,7 +27,6 @@ import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 import "goby/middleware/protobuf/udp_config.proto";
 
-import "jaiabot/messages/feather.proto";
 import "jaiabot/messages/imu.proto";
 
 package jaiabot.config;

--- a/src/bin/drivers/atlas_scientific_ezo_ec/config.proto
+++ b/src/bin/drivers/atlas_scientific_ezo_ec/config.proto
@@ -25,7 +25,6 @@ syntax = "proto2";
 
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "jaiabot/messages/feather.proto";
 import "goby/middleware/protobuf/udp_config.proto";
 
 package jaiabot.config;

--- a/src/bin/drivers/echo/config.proto
+++ b/src/bin/drivers/echo/config.proto
@@ -24,7 +24,6 @@ syntax = "proto2";
 
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "jaiabot/messages/feather.proto";
 import "goby/middleware/protobuf/udp_config.proto";
 import "jaiabot/messages/echo.proto";
 

--- a/src/bin/web_portal/config.proto
+++ b/src/bin/web_portal/config.proto
@@ -25,7 +25,6 @@ syntax = "proto2";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 import "goby/middleware/protobuf/udp_config.proto";
-import "goby/middleware/protobuf/transporter_config.proto";
 
 package jaiabot.config;
 

--- a/src/lib/messages/echo.proto
+++ b/src/lib/messages/echo.proto
@@ -1,7 +1,5 @@
 syntax = "proto2";
 
-import "dccl/option_extensions.proto";
-
 package jaiabot.protobuf;
 
 message EchoCommand

--- a/src/lib/messages/metadata.proto
+++ b/src/lib/messages/metadata.proto
@@ -1,6 +1,5 @@
 syntax = "proto2";
 
-import "dccl/option_extensions.proto";
 import "jaiabot/messages/option_extensions.proto";
 
 package jaiabot.protobuf;

--- a/src/lib/messages/moos.proto
+++ b/src/lib/messages/moos.proto
@@ -1,7 +1,5 @@
 syntax = "proto2";
 
-import "dccl/option_extensions.proto";
-
 package jaiabot.protobuf;
 
 // Protobuf version of CMOOSMsg

--- a/src/lib/moos_gateway/jaiabot_gateway_config.proto
+++ b/src/lib/moos_gateway/jaiabot_gateway_config.proto
@@ -1,7 +1,6 @@
 syntax = "proto2";
 
 import "goby/moos/protobuf/moos_gateway_config.proto";
-import "dccl/option_extensions.proto";
 
 package jaiabot.protobuf;
 


### PR DESCRIPTION
Minor - removes all unused imports in .proto files to reduce compiler warnings.