### PR TITLE
task/update-global-protobuf-extension-number

### DIFF
--- a/src/lib/messages/option_extensions.proto
+++ b/src/lib/messages/option_extensions.proto
@@ -32,17 +32,20 @@ message EnumValueOptions
     optional RestAPI rest_api = 1;
 }
 
+// we can use 1252 for all extensions:
+// https://github.com/protocolbuffers/protobuf/commit/46f7879cae6a986ca0f780811dc8414ae14d18d5
+
 extend .google.protobuf.FieldOptions
 {
-    optional .jaia.FieldOptions field = 1191;
+    optional .jaia.FieldOptions field = 1252;
 }
 
 extend .google.protobuf.MessageOptions
 {
-    optional .jaia.MessageOptions msg = 1191;
+    optional .jaia.MessageOptions msg = 1252;
 }
 
 extend .google.protobuf.EnumValueOptions
 {
-    optional .jaia.EnumValueOptions ev = 1191;
+    optional .jaia.EnumValueOptions ev = 1252;
 }


### PR DESCRIPTION
Google finally accepted my PR that includes our global option extension number (to allow global compatibility with other users of Protobuf option extensions):

https://github.com/protocolbuffers/protobuf/commit/46f7879cae6a986ca0f780811dc8414ae14d18d5

Given their delay they had to update the tag index to 1252, which is our final allocated value. This PR updates the extension IDs to this accepted value.

This change should have no effect on our codebase other than ensuring we are compatible with all potential users of Protobuf.