### PR TITLE
task/install-doxygen-in-setup-tools-script/JAIA-1729

### DIFF
--- a/scripts/setup-tools-build-nodocker.sh
+++ b/scripts/setup-tools-build-nodocker.sh
@@ -15,7 +15,7 @@ sudo apt-get -y update
 # Install the required dependencies
 sudo apt-get -y install dccl4-apps libdccl4-dev libgoby3-dev libgoby3-moos-dev libgoby3-gui-dev gpsd libnanopb-dev nanopb rsync python3-venv python3-protobuf python3-netifaces gdal-bin
 # Install the build tools necessary
-sudo apt-get -y install cmake g++ npm clang-format clang graphviz
+sudo apt-get -y install cmake g++ npm clang-format clang graphviz doxygen
 # Install Arduino command line interface for local compilation of ino files into hex
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sudo BINDIR=/usr/local/bin sh && \
     arduino-cli config init --overwrite && \


### PR DESCRIPTION
## Description
Adding doxygen to setup-tools-build-nodocker script. This is needed to create the documentation.

## Testing
* Run the setup tools script
* Turn on build documentation
* Run the ./build.sh script