### PR TITLE
task/eliminate-leading-zeros-in-task-parameter-inputs-JAIA-1751

### DIFF
--- a/src/web/jcc/client/components/TaskSettingsPanel.tsx
+++ b/src/web/jcc/client/components/TaskSettingsPanel.tsx
@@ -359,7 +359,7 @@ function TaskOptionsPanel(props: Props) {
                                             max="3600"
                                             className="NumberInput"
                                             name="drift_time"
-                                            value={surface_drift.drift_time}
+                                            value={surface_drift.drift_time.toString()}
                                             onChange={onChangeDriftParameter}
                                             disabled={!props?.isEditMode}
                                         />
@@ -382,7 +382,7 @@ function TaskOptionsPanel(props: Props) {
                                             max="60"
                                             className="NumberInput"
                                             name="max_depth"
-                                            value={dive.max_depth}
+                                            value={dive.max_depth.toString()}
                                             onChange={onChangeDiveParameter}
                                             disabled={!props?.isEditMode}
                                         />
@@ -399,7 +399,7 @@ function TaskOptionsPanel(props: Props) {
                                             max="60"
                                             className="NumberInput"
                                             name="depth_interval"
-                                            value={dive.depth_interval}
+                                            value={dive.depth_interval.toString()}
                                             onChange={onChangeDiveParameter}
                                             disabled={!props?.isEditMode}
                                         />
@@ -416,7 +416,7 @@ function TaskOptionsPanel(props: Props) {
                                             max="3600"
                                             className="NumberInput"
                                             name="hold_time"
-                                            value={dive.hold_time}
+                                            value={dive.hold_time.toString()}
                                             onChange={onChangeDiveParameter}
                                             disabled={!props?.isEditMode}
                                         />
@@ -433,7 +433,7 @@ function TaskOptionsPanel(props: Props) {
                                             max="3600"
                                             className="NumberInput"
                                             name="drift_time"
-                                            value={surface_drift.drift_time}
+                                            value={surface_drift.drift_time.toString()}
                                             onChange={onChangeDriftParameter}
                                             disabled={!props?.isEditMode}
                                         />
@@ -461,7 +461,7 @@ function TaskOptionsPanel(props: Props) {
                                         max="3600"
                                         className="NumberInput"
                                         name="station_keep_time"
-                                        value={station_keep?.station_keep_time}
+                                        value={station_keep?.station_keep_time.toString()}
                                         onChange={onChangeStationKeepParameter}
                                         disabled={!props?.isEditMode}
                                     />
@@ -485,7 +485,7 @@ function TaskOptionsPanel(props: Props) {
                                         step="1"
                                         className="NumberInput"
                                         name="drift_time"
-                                        value={surface_drift.drift_time}
+                                        value={surface_drift.drift_time.toString()}
                                         onChange={onChangeDriftParameter}
                                         disabled={!props?.isEditMode}
                                     />


### PR DESCRIPTION
### Before
https://github.com/user-attachments/assets/a5b8c1b7-c59b-4a69-9ad2-679c95635a7f

### After
https://github.com/user-attachments/assets/62d0d4c5-af2d-491f-bbc7-362ad6b7582b

### Testing
Entered a variety of values into all of the task parameter input sections (decimals, negative values, integers, alphabetical characters, and symbols). The default input handling manages the different values as expected. One possible improvement going forward would be to remove the red outline for values that do not match the expected precision defined in the dccl field and provide a more helpful message.