### PR TITLE
bug/git-commits-are-adding-untracked-files/JAIA-1761

### DIFF
--- a/scripts/git-hooks/prettier/write.sh
+++ b/scripts/git-hooks/prettier/write.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
+
+# Script adapted from example provided in Prettier documentation
+
 FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
-[ -z "$FILES" ] && exit 0
 
 INCLUDE="web"
 FILES=$(echo "$FILES" | grep -E "$INCLUDE")
+[ -z "$FILES" ] && exit 0
 
 # Prettify all selected files
 prettier_project_path="src/web/node_modules/.bin/prettier"
@@ -12,6 +15,6 @@ prettier_abs_path=${PWD}"/${prettier_project_path}"
 echo "$FILES" | xargs ${prettier_abs_path} --ignore-unknown --write
 
 # Add back the modified/prettified files to staging
-echo "$FILES" | xargs git add .
+echo "$FILES" | xargs git add
 
 exit 0


### PR DESCRIPTION
### Description
All modified files were being committed even if they were not staged for commit because the prettier pre-commit hook script added all files with changes. Now it only adds back staged files.

### Testing
**1. Test 1**
* Modified 4 files (2 TypeScript, 2 C++).
* Git add a single TS file.
* Committed the staged changes.
* Prettier updated the file as expected, and only the staged changes were committed

**2. Test 2**
* Modified 4 files (2 TypeScript, 2 C++).
* Git add a single C++ file.
* Committed the staged changes.
* Only the staged changes were committed.

**3. Test 3**
* Modified 4 files (2 TypeScript, 2 C++).
* Added a new TypeScript file.
* Added the 4 tracked files.
* Committed the staged changes.
* Only the staged changes were committed.