### PR TITLE
task/silence-console-error-output-jest

### DIFF
--- a/src/web/tests/jest.setup.js
+++ b/src/web/tests/jest.setup.js
@@ -15,4 +15,5 @@ global.ResizeObserver = class ResizeObserver {
 
 // Silence non error output while running tests
 global.console.log = jest.fn();
+global.console.error = jest.fn();
 global.console.debug = jest.fn();


### PR DESCRIPTION
## Description

Silence console errors for jest tests.

## Current Output

```
 PASS  jcc/client/components/RallyPointPanel/__tests__/RallyPointPanel.test.tsx (6.974 s)
  RallyPointPanel: Button Interaction Tests
    ✓ Test Go To Button using test-id (73 ms)
    ✓ Test Go To Button using label (26 ms)
    ✓ Test Go To Button using title (19 ms)
    ✓ Test Delete Button using test-id (22 ms)
    ✓ Test Delete Button using label (20 ms)
    ✓ Test Delete Button using title (17 ms)

  console.error
    Error while fetching GeoTIFFs list:  TypeError: Only absolute URLs are supported
        at getNodeRequestOptions (/home/ferrom/repos/jaiabot/src/web/node_modules/node-fetch/lib/index.js:1327:9)
        at getNodeRequestOptions (/home/ferrom/repos/jaiabot/src/web/node_modules/node-fetch/lib/index.js:1450:19)
        at new Promise (<anonymous>)
        at fetch (/home/ferrom/repos/jaiabot/src/web/node_modules/node-fetch/lib/index.js:1447:9)
        at call (/home/ferrom/repos/jaiabot/src/web/node_modules/isomorphic-fetch/fetch-npm-node.js:8:19)
        at CustomLayerGroupFactory.createCustomLayerGroup (/home/ferrom/repos/jaiabot/src/web/jcc/client/components/CustomLayers.ts:185:36)
        at Layers.getAllLayers (/home/ferrom/repos/jaiabot/src/web/jcc/client/components/Layers.ts:173:38)
        at createMap (/home/ferrom/repos/jaiabot/src/web/jcc/client/components/Map.ts:12:24)
        at new CommandControl (/home/ferrom/repos/jaiabot/src/web/jcc/client/components/CommandControl/CommandControl.tsx:438:24)
        at constructClassInstance (/home/ferrom/repos/jaiabot/src/web/node_modules/react-dom/cjs/react-dom.development.js:18197:18)
        at constructClassInstance (/home/ferrom/repos/jaiabot/src/web/node_modules/react-dom/cjs/react-dom.development.js:19717:5)
        at updateClassComponent (/home/ferrom/repos/jaiabot/src/web/node_modules/react-dom/cjs/react-dom.development.js:21650:16)
        at beginWork (/home/ferrom/repos/jaiabot/src/web/node_modules/react-dom/cjs/react-dom.development.js:27465:14)
        at beginWork$1 (/home/ferrom/repos/jaiabot/src/web/node_modules/react-dom/cjs/react-dom.development.js:26599:12)
        at performUnitOfWork (/home/ferrom/repos/jaiabot/src/web/node_modules/react-dom/cjs/react-dom.development.js:26505:5)
        at workLoopSync (/home/ferrom/repos/jaiabot/src/web/node_modules/react-dom/cjs/react-dom.development.js:26473:7)
        at renderRootSync (/home/ferrom/repos/jaiabot/src/web/node_modules/react-dom/cjs/react-dom.development.js:25777:74)
        at callback (/home/ferrom/repos/jaiabot/src/web/node_modules/react/cjs/react.development.js:2667:24)
        at flushActQueue (/home/ferrom/repos/jaiabot/src/web/node_modules/react/cjs/react.development.js:2582:11)
        at actImplementation (/home/ferrom/repos/jaiabot/src/web/node_modules/@testing-library/react/dist/act-compat.js:47:25)
        at renderRoot (/home/ferrom/repos/jaiabot/src/web/node_modules/@testing-library/react/dist/pure.js:180:25)
        at renderRoot (/home/ferrom/repos/jaiabot/src/web/node_modules/@testing-library/react/dist/pure.js:271:10)
        at Object.<anonymous> (/home/ferrom/repos/jaiabot/src/web/jcc/client/components/CommandControl/__tests__/CommandControl.test.tsx:41:15)
        at Promise.then.completed (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/utils.js:298:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/utils.js:231:10)
        at _callCircusTest (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/run.js:316:40)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)
        at _runTest (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/run.js:252:3)
        at _runTestsForDescribeBlock (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/run.js:126:9)
        at _runTestsForDescribeBlock (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/run.js:121:9)
        at run (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/run.js:71:3)
        at runAndTransformResultsToJestFormat (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
        at jestAdapter (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:74:19)
        at runTestInternal (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-runner/build/runTest.js:444:34)
        at Object.worker (/home/ferrom/repos/jaiabot/src/web/node_modules/jest-runner/build/testWorker.js:106:12)

      191 |             geoTiffs = (await response.json()) as GeoTiffMetadata[];
      192 |         } catch (ex) {
    > 193 |             console.error("Error while fetching GeoTIFFs list: ", ex);
          |                     ^
      194 |             return;
      195 |         }
      196 |         const sortedGeoTiffs = this.sortGeoTiffNamesAndMakeUnique(geoTiffs);

      at CustomLayerGroupFactory.createCustomLayerGroup (jcc/client/components/CustomLayers.ts:193:21)

  console.error
    Failed to GET JSON request: TypeError: Only absolute URLs are supported

      73 |                 },
      74 |                 (reason) => {
    > 75 |                     console.error(`Failed to ${method} JSON request: ${reason}`);
         |                             ^
      76 |                     console.error("Request body:");
      77 |                     console.error(requestBody);
      78 |                     return Promise.reject(new Error("Response parse fail"));

      at jcc/common/JaiaAPI.ts:75:29

  console.error
    Request body:

      74 |                 (reason) => {
      75 |                     console.error(`Failed to ${method} JSON request: ${reason}`);
    > 76 |                     console.error("Request body:");
         |                             ^
      77 |                     console.error(requestBody);
      78 |                     return Promise.reject(new Error("Response parse fail"));
      79 |                 },

      at jcc/common/JaiaAPI.ts:76:29

  console.error
    undefined

      75 |                     console.error(`Failed to ${method} JSON request: ${reason}`);
      76 |                     console.error("Request body:");
    > 77 |                     console.error(requestBody);
         |                             ^
      78 |                     return Promise.reject(new Error("Response parse fail"));
      79 |                 },
      80 |             )

      at jcc/common/JaiaAPI.ts:77:29

  console.error
    Failed to GET JSON request: TypeError: Only absolute URLs are supported

      73 |                 },
      74 |                 (reason) => {
    > 75 |                     console.error(`Failed to ${method} JSON request: ${reason}`);
         |                             ^
      76 |                     console.error("Request body:");
      77 |                     console.error(requestBody);
      78 |                     return Promise.reject(new Error("Response parse fail"));

      at jcc/common/JaiaAPI.ts:75:29

  console.error
    Request body:

      74 |                 (reason) => {
      75 |                     console.error(`Failed to ${method} JSON request: ${reason}`);
    > 76 |                     console.error("Request body:");
         |                             ^
      77 |                     console.error(requestBody);
      78 |                     return Promise.reject(new Error("Response parse fail"));
      79 |                 },

      at jcc/common/JaiaAPI.ts:76:29

  console.error
    undefined

      75 |                     console.error(`Failed to ${method} JSON request: ${reason}`);
      76 |                     console.error("Request body:");
    > 77 |                     console.error(requestBody);
         |                             ^
      78 |                     return Promise.reject(new Error("Response parse fail"));
      79 |                 },
      80 |             )

      at jcc/common/JaiaAPI.ts:77:29

  console.error
    Warning: An update to CommandControl inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at CommandControl (/home/ferrom/repos/jaiabot/src/web/jcc/client/components/CommandControl/CommandControl.tsx:301:9)

      1100 |
      1101 |     hubConnectionError(errMsg: String) {
    > 1102 |         this.setState({ disconnectionMessage: "Connection Dropped To HUB" });
           |              ^
      1103 |         console.error(errMsg);
      1104 |     }
      1105 |

      at call (node_modules/react-dom/cjs/react-dom.development.js:86:30)
      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:60:7)
      at error (node_modules/react-dom/cjs/react-dom.development.js:27628:9)
      at warnIfUpdatesNotWrappedWithActDEV (node_modules/react-dom/cjs/react-dom.development.js:25547:5)
      at Object.scheduleUpdateOnFiber [as enqueueSetState] (node_modules/react-dom/cjs/react-dom.development.js:17925:7)
      at CommandControl.enqueueSetState [as setState] (node_modules/react/cjs/react.development.js:354:16)
      at CommandControl.hubConnectionError (jcc/client/components/CommandControl/CommandControl.tsx:1102:14)
      at jcc/client/components/CommandControl/CommandControl.tsx:1026:26

  console.error
    Response parse fail

      1101 |     hubConnectionError(errMsg: String) {
      1102 |         this.setState({ disconnectionMessage: "Connection Dropped To HUB" });
    > 1103 |         console.error(errMsg);
           |                 ^
      1104 |     }
      1105 |
      1106 |     getPodStatus() {

      at CommandControl.hubConnectionError (jcc/client/components/CommandControl/CommandControl.tsx:1103:17)
      at jcc/client/components/CommandControl/CommandControl.tsx:1026:26

  console.error
    Warning: An update to CommandControl inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at CommandControl (/home/ferrom/repos/jaiabot/src/web/jcc/client/components/CommandControl/CommandControl.tsx:301:9)

      946 |                     }
      947 |                 }
    > 948 |                 this.setState({ metadata: result });
          |                      ^
      949 |             },
      950 |             (err) => {
      951 |                 console.log("Metadata polling error:\n", err);

      at call (node_modules/react-dom/cjs/react-dom.development.js:86:30)
      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:60:7)
      at error (node_modules/react-dom/cjs/react-dom.development.js:27628:9)
      at warnIfUpdatesNotWrappedWithActDEV (node_modules/react-dom/cjs/react-dom.development.js:25547:5)
      at Object.scheduleUpdateOnFiber [as enqueueSetState] (node_modules/react-dom/cjs/react-dom.development.js:17925:7)
      at CommandControl.enqueueSetState [as setState] (node_modules/react/cjs/react.development.js:354:16)
      at jcc/client/components/CommandControl/CommandControl.tsx:948:22
```