### PR TITLE
task/remove-circleci-jest-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ job-template-amd64: &job-template-amd64
         name: Run tests
         command: |
           cd build && ctest --output-on-failure
-          cd intermediate/web && npm test
 
 job-template-deb-amd64: &job-template-deb-amd64
   <<: *job-template-amd64


### PR DESCRIPTION
## Description

Remove jest tests until we find a solution for circleci running out of resources. 

## Error output

```
A jest worker process (pid=8864) was terminated by another process: signal=SIGKILL, exitCode=null. Operating system logs may contain more information on why this occurred.

