### PR TITLE
task/add-pressure-sensor-to-jaiabot-embedded-config-JAIA-1768

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/add-pressure-sensor-to-jaiabot-embedded-config"
+        - "task/add-pressure-sensor-to-jaiabot-embedded-config-JAIA-1768"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
+        - "task/add-pressure-sensor-to-jaiabot-embedded-config"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/add-pressure-sensor-to-jaiabot-embedded-config-JAIA-1768"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/debian/jaiabot-embedded.config
+++ b/debian/jaiabot-embedded.config
@@ -153,6 +153,14 @@ configure_bot() {
                 ;;
             "temperature_sensor_type")
                 if debconf_input_and_go high jaiabot-embedded/temperature_sensor_type; then
+                    state="pressure_sensor_type"
+                else
+                    go_menu jaiabot-embedded/debconf_state_bot
+
+                fi
+                ;;
+            "pressure_sensor_type")
+                if debconf_input_and_go high jaiabot-embedded/pressure_sensor_type; then
                     return 0  # success, end configuration
                 else
                     go_menu jaiabot-embedded/debconf_state_bot

--- a/debian/jaiabot-embedded.postinst
+++ b/debian/jaiabot-embedded.postinst
@@ -97,6 +97,9 @@ JAIA_MOTOR_HARNESS_TYPE=$RET
 db_get jaiabot-embedded/temperature_sensor_type
 JAIA_TEMPERATURE_SENSOR_TYPE=$RET
 
+db_get jaiabot-embedded/pressure_sensor_type
+JAIA_PRESSURE_SENSOR_TYPE=$RET
+
 /usr/share/jaiabot/config/gen/systemd.py ${JAIA_TYPE} \
                                          --enable \
                                          --jaiabot_bin_dir=/usr/bin \
@@ -109,16 +112,17 @@ JAIA_TEMPERATURE_SENSOR_TYPE=$RET
                                          --hub_index=${BOT_OR_HUB_INDEX} \
                                          --fleet_index=${FLEET_INDEX} \
                                          ${SYSTEMD_SIM_FLAG} \
-                                        --led_type=${JAIA_LED_TYPE} \
-                                        --electronics_stack=${JAIA_ELECTRONICS_STACK} \
-                                        --user_role=${JAIA_USER_ROLE} \
-                                        --imu_type=${JAIA_IMU_TYPE} \
-                                        --arduino_type=${JAIA_ARDUINO_TYPE} \
-                                        --bot_type=${JAIA_BOT_TYPE} \
-                                        --imu_install_type=${JAIA_IMU_INSTALL_TYPE} \
-                                        --data_offload_ignore_type=${JAIA_DATA_OFFLOAD_IGNORE_TYPE} \
-                                        --motor_harness_type=${JAIA_MOTOR_HARNESS_TYPE} \
-                                        --temperature_sensor_type=${JAIA_TEMPERATURE_SENSOR_TYPE}
+                                         --led_type=${JAIA_LED_TYPE} \
+                                         --electronics_stack=${JAIA_ELECTRONICS_STACK} \
+                                         --user_role=${JAIA_USER_ROLE} \
+                                         --imu_type=${JAIA_IMU_TYPE} \
+                                         --arduino_type=${JAIA_ARDUINO_TYPE} \
+                                         --bot_type=${JAIA_BOT_TYPE} \
+                                         --imu_install_type=${JAIA_IMU_INSTALL_TYPE} \
+                                         --data_offload_ignore_type=${JAIA_DATA_OFFLOAD_IGNORE_TYPE} \
+                                         --motor_harness_type=${JAIA_MOTOR_HARNESS_TYPE} \
+                                         --temperature_sensor_type=${JAIA_TEMPERATURE_SENSOR_TYPE} \
+                                         --pressure_sensor_type=${JAIA_PRESSURE_SENSOR_TYPE}
 
 echo "<<<<< Installing and enabling systemd services complete!"
 

--- a/debian/jaiabot-embedded.templates
+++ b/debian/jaiabot-embedded.templates
@@ -118,7 +118,12 @@ Description: What type of motor harness does your bot have?
 
 Template: jaiabot-embedded/temperature_sensor_type
 Type: select
-Choices: bar30, tsys01, none
+Choices: bar02, bar30, tsys01, none
 Default: bar30
 Description: What temperature sensor do you want to use?
 
+Template: jaiabot-embedded/pressure_sensor_type
+Type: select
+Choices: bar02, bar30, none
+Default: bar30
+Description: What pressure sensor do you have?

--- a/src/bin/drivers/bluerobotics_pressure_sensor/app.cpp
+++ b/src/bin/drivers/bluerobotics_pressure_sensor/app.cpp
@@ -103,6 +103,20 @@ jaiabot::apps::BlueRoboticsPressureSensorDriver::BlueRoboticsPressureSensorDrive
                 return;
             }
 
+            if (pressure_temperature_data.has_pressure_raw())
+            {
+                double pressure_raw = pressure_temperature_data.pressure_raw();
+                pressure_temperature_data.set_pressure_raw_with_units(pressure_raw * si::milli *
+                                                                      goby::util::seawater::bar);
+            }
+
+            if (pressure_temperature_data.has_temperature())
+            {
+                double temperature = pressure_temperature_data.temperature();
+                pressure_temperature_data.set_temperature_with_units(
+                    temperature * boost::units::absolute<boost::units::celsius::temperature>());
+            }
+
             glog.is_debug2() && glog << "Publishing PressureTemperatureData: "
                                      << pressure_temperature_data.ShortDebugString() << std::endl;
 

--- a/src/bin/drivers/bluerobotics_pressure_sensor/app.cpp
+++ b/src/bin/drivers/bluerobotics_pressure_sensor/app.cpp
@@ -83,24 +83,6 @@ int main(int argc, char* argv[])
 
 // Main thread
 
-// for string delimiter
-std::vector<std::string> split(std::string s, std::string delimiter)
-{
-    size_t pos_start = 0, pos_end, delim_len = delimiter.length();
-    std::string token;
-    std::vector<std::string> res;
-
-    while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos)
-    {
-        token = s.substr(pos_start, pos_end - pos_start);
-        pos_start = pos_end + delim_len;
-        res.push_back(token);
-    }
-
-    res.push_back(s.substr(pos_start));
-    return res;
-}
-
 jaiabot::apps::BlueRoboticsPressureSensorDriver::BlueRoboticsPressureSensorDriver()
     : zeromq::MultiThreadApplication<config::BlueRoboticsPressureSensorDriver>(10 * si::hertz)
 {

--- a/src/lib/messages/pressure_temperature.proto
+++ b/src/lib/messages/pressure_temperature.proto
@@ -4,6 +4,11 @@ import "dccl/option_extensions.proto";
 
 package jaiabot.protobuf;
 
+enum PressureSensorType {
+    BAR02 = 1;
+    BAR30 = 2;
+}
+
 message PressureTemperatureData
 {
     option (dccl.msg) = {
@@ -15,7 +20,7 @@ message PressureTemperatureData
     optional double temperature = 2 [(dccl.field) = {
         units { derived_dimensions: "temperature" system: "celsius" }
     }];
-    required string version = 3;
+    required PressureSensorType sensor_type = 3;
 }
 
 message PressureAdjustedData

--- a/src/python/pressure_sensor/jaiabot_pressure_sensor.py
+++ b/src/python/pressure_sensor/jaiabot_pressure_sensor.py
@@ -30,9 +30,13 @@ class SensorType(Enum):
     BAR02 = ('bar02', 1)
     BAR30 = ('bar30', 2)
 
-    def __init__(self, name, num):
-        self.name = name
-        self.num = num
+    @property
+    def name(self):
+        return self.value[0]
+
+    @property
+    def num(self):
+        return self.value[1]
 
 class SensorError(Exception):
     pass
@@ -49,13 +53,9 @@ class Sensor:
             if args.sensor_type == SensorType.BAR02.name:
                 self.sensor = ms5837.MS5837_02BA()
                 self.sensor_type = SensorType.BAR02.num
-                log.warning(f"Sensor Name: {SensorType.BAR02.name}")
-                log.warning(f"Sensor Num: {SensorType.BAR02.num}")
             else:
                 self.sensor = ms5837.MS5837_30BA()
                 self.sensor_type = SensorType.BAR30.num
-                log.warning(f"Sensor Name: {SensorType.BAR30.name}")
-                log.warning(f"Sensor Num: {SensorType.BAR30.num}")
             
             if not self.sensor.init():
                 log.error("Cannot initialize Blue Robotics pressure-temperature sensor.")

--- a/src/python/pressure_sensor/jaiabot_pressure_sensor.py
+++ b/src/python/pressure_sensor/jaiabot_pressure_sensor.py
@@ -125,13 +125,13 @@ while True:
         float(p_mbar)
     except Exception as e:
         log.error(f'Pressure cannot be converted to a float. {e}')
-        p_mbar = 0
+        continue
     
     try:
         float(t_celsius)
     except Exception as e:
         log.error(f'Temperature cannot be converted to a float. {e}')
-        t_celsius = 0
+        continue
 
     pressure_temperature_data = PressureTemperatureData()
     pressure_temperature_data.pressure_raw = p_mbar


### PR DESCRIPTION
### Summary
Set pressure sensor type in the configuration of jaiabot-embedded. This allows us to remove the auto-detection of the pressure sensor which failed this week.

### Testing
Install the jaiabot-embedded test branch on a vehicle. Verify pressure is being streamed from the python driver to the C++ driver.
![image](https://github.com/user-attachments/assets/0641bee7-4023-46a0-a7a4-996ec79af5a5)

