### PR TITLE
bug/motor-harness-type-config-not-prompted

### DIFF
--- a/debian/jaiabot-embedded.config
+++ b/debian/jaiabot-embedded.config
@@ -161,12 +161,12 @@ configure_bot() {
                 ;;
             "pressure_sensor_type")
                 if debconf_input_and_go high jaiabot-embedded/pressure_sensor_type; then
-                    return 0  # success, end configuration
+                    state="motor_harness_type"
                 else
                     go_menu jaiabot-embedded/debconf_state_bot
 
                 fi
-		;;
+                ;;
             "motor_harness_type")
                 if debconf_input_and_go high jaiabot-embedded/motor_harness_type; then
                     return 0  # success, end configuration


### PR DESCRIPTION
## Description

Fix config prompt for motor harness type.