### PR TITLE
bug/pressure-sensor-data-type-mismatch-simulator

### DIFF
--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -399,8 +399,8 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
 
         using goby::util::seawater::bar;
 
-        // construct PressureTemperatureData protobuf message
         jaiabot::protobuf::PressureTemperatureData pressure_temperature_data;
+        // convert pressure from decibars to millibars to mimic output of BARXX sensor
         pressure_temperature_data.set_pressure_raw(
             quantity<decltype(si::milli * bar)>(pressure).value());
         pressure_temperature_data.set_temperature(temperature);

--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -397,9 +397,12 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
         // randomize temperature
         temperature += temperature_distribution_(generator_);
 
+        using goby::util::seawater::bar;
+
         // construct PressureTemperatureData protobuf message
         jaiabot::protobuf::PressureTemperatureData pressure_temperature_data;
-        pressure_temperature_data.set_pressure_raw(pressure.value());
+        pressure_temperature_data.set_pressure_raw(
+            quantity<decltype(si::milli * bar)>(pressure).value());
         pressure_temperature_data.set_temperature(temperature);
         pressure_temperature_data.set_sensor_type(jaiabot::protobuf::PressureSensorType::BAR30);
 


### PR DESCRIPTION
### Summary
Changes to the Blue Robotics pressure sensor driver (https://github.com/jaiarobotics/jaiabot/pull/1031) caused the sensor to fail in simulation. The C++ driver expected to receive a message of type `PressureTemperatureData` but it received a string from the simulator application. Now the simulator application publishes data of type `PressureTemperatureData` for the `pressure_udp_out` group. 