### PR TITLE
task/add-hub-key-first-boot

### DIFF
--- a/rootfs/customization/includes.chroot/etc/jaiabot/init/first-boot.preseed.ex
+++ b/rootfs/customization/includes.chroot/etc/jaiabot/init/first-boot.preseed.ex
@@ -30,6 +30,12 @@ ssh-rsa AAAA_B64_KEY username
 EOM
 )
 
+# hub keys (/etc/jaiabot/ssh/hub_authorized_keys)
+jaia_hub_authorized_keys=$(cat << EOM
+ssh-rsa AAAA_B64_KEY username
+EOM
+)
+
 #########################################################
 # Preseed jaiabot-embedded package debconf queries
 # See jaiabot-embedded.templates from jaiabot-debian 

--- a/rootfs/customization/includes.chroot/etc/jaiabot/init/first-boot.sh
+++ b/rootfs/customization/includes.chroot/etc/jaiabot/init/first-boot.sh
@@ -13,7 +13,7 @@ CONFIG_FILE="$SSH_DIR/config"
 USING_PRESEED=false
 if [ -e "$PRESEED_DIR/first-boot.preseed" ]; then
    USING_PRESEED=true
-   source /boot/firmware/jaiabot/init/first-boot.preseed
+   source "$PRESEED_DIR/first-boot.preseed"
 fi
 
 INCLUDES_HUB_KEYS=false
@@ -271,7 +271,7 @@ echo "JAIABOT_FIRST_BOOT_DATE=\"`date -u`\"" >> /etc/jaiabot/version
 if [[ "$USING_PRESEED" = "true" ]]; then
     # avoid re-running with same preseed
     mount -o remount,rw /boot/firmware
-    mv /boot/firmware/jaiabot/init/first-boot.preseed /boot/firmware/jaiabot/init/first-boot.preseed.complete
+    mv "$PRESEED_DIR/first-boot.preseed" "$PRESEED_DIR/first-boot.preseed.complete"
     mount -o remount,ro /boot/firmware
 fi
 


### PR DESCRIPTION
## Description

We needed another way to setup the ssh keys on the hub and the bots. Now when you create an image for the hub you can save a ssh key pair next to the preseed.

This also allows the user to add the public key for the hub on the bots in the preseed as well.

This will enable us to use the JCU to complete other initial tasks.

## Testing

* This needs to be tested on a hub and a bot