### PR TITLE
bug/deploy-script-not-setting-systemd-config-files-correctly/JAIA-1788

### DIFF
--- a/scripts/arm64-deploy.sh
+++ b/scripts/arm64-deploy.sh
@@ -48,9 +48,9 @@ if [ ! -z "$jaiabot_systemd_type" ]; then
     echo "🟢 Installing and enabling $jaiabot_systemd_type systemd services (you can safely ignore bash 'Inappropriate ioctl for device' and 'no job control in this shell' errors)"
 
     if [[ "$jaiabot_systemd_type" == *"bot"* ]]; then
-
         cd ${HOME}/jaiabot/config/gen
-        ./systemd-local.sh ${jaiabot_systemd_type} --bot_index $jaia_bot_index --fleet_index $jaia_fleet_index --electronics_stack $jaia_electronics_stack --imu_type $jaia_imu_type --imu_install_type $jaia_imu_install_type --arduino_type $jaia_arduino_type --bot_type ${jaia_bot_type,,} $jaia_simulation --enable --motor_harness_type ${jaia_motor_harness_type,,}
+        (set -x; export PATH=${HOME}/jaiabot/${build_dir}/bin:$PATH;
+        ./systemd-local.sh ${jaiabot_systemd_type} --bot_index $jaia_bot_index --fleet_index $jaia_fleet_index --electronics_stack $jaia_electronics_stack --imu_type $jaia_imu_type --imu_install_type $jaia_imu_install_type --arduino_type $jaia_arduino_type --bot_type ${jaia_bot_type,,} $jaia_simulation --enable --motor_harness_type ${jaia_motor_harness_type,,})
 
     else
 


### PR DESCRIPTION
## Description
Fix: Ensure correct PATH is used for systemd service generation

- Added an explicit export of ${HOME}/jaiabot/${build_dir}/bin to PATH before invoking systemd-local.sh.
   - This is added during a hub deployment, but was left out for a bot
- This ensures systemd.py resolves binaries from the current build directory rather than default or fallback paths (e.g., /usr/bin).
- Fixes path mismatches in generated systemd configurations, aligning with the intended deployment structure.

## Tests
- Deployed to flat bot
- Confirmed the services start successfully
- Confirm a jaiabot systemd config file is setup correctly