### PR TITLE
bug/docker-deploy-script-pre-commit-hook/JAIA-1789

### DIFF
--- a/scripts/docker-arm64-build-and-deploy.sh
+++ b/scripts/docker-arm64-build-and-deploy.sh
@@ -33,9 +33,6 @@ version=${jaiabot_version:-${default_version}}
 version_lower=$(echo "$version" | tr '[:upper:]' '[:lower:]')
 distro=${jaiabot_distro:-${jaia_version_ubuntu_codename}}
 
-# install clang-format hook if not installed
-[ ! -e ${script_dir}/../.git/hooks/pre-commit ] && ${script_dir}/../scripts/git-hooks/clang-format-hooks/git-pre-commit-format install
-
 if [[ "$jaiabot_machine_type" == "virtualbox" ]]; then
     cd ${script_dir}/..
 

--- a/scripts/setup-tools-build-nodocker.sh
+++ b/scripts/setup-tools-build-nodocker.sh
@@ -47,3 +47,13 @@ nvm use ${NODE_VERSION}
 npm install -g npm@${jaia_version_npm}
 # Then, npm can install webpack
 npm install -g --no-audit webpack@${jaia_version_webpack} webpack-cli@${jaia_version_webpack_cli}
+
+# Check if pre-commit hook is installed
+if [ ! -e ${script_dir}/../.git/hooks/pre-commit ]; then
+   # Check if there is a broken symlink
+   if [ -L ${script_dir}/../.git/hooks/pre-commit ]; then
+      rm ${script_dir}/../.git/hooks/pre-commit
+   fi
+   # Install the pre-commit hook
+   ${script_dir}/../scripts/git-hooks/clang-format-hooks/git-pre-commit-format install
+fi


### PR DESCRIPTION
## Description

The docker-arm64-build-and-deploy.sh would fail on machines because the pre-commit install would fail. The reason it would fail is because of a broken symlink. I moved the pre-commit install to the setup-build script and added logic to handle broken sym links. 

## Test

### Test 1 Creation of symlink

1. Unlink the pre-commit symlink in jaiabot/.git/hooks `command: ```unlink pre-commit```
2. Run the setup-tools-build-nodocker.sh script located: ```jaiabot/scripts```
3. Confirm the symlink was create command ```ls -l jaiabot/.git/hooks```

### Test 2 Removal of broken symlink then recreate symlink

1. Unlink the pre-commit symlink in jaiabot/.git/hooks `command: ```unlink pre-commit```
2. Create a test file in jaiabot/.git/hooks command: ```touch test```
3. Create link command: ```ln -s test pre-commit```
4. Remove test file command: ```rm test```
5. Run the setup-tools-build-nodocker.sh script located: ```jaiabot/scripts```
6. Confirm the symlink was create command ```ls -l jaiabot/.git/hooks```