### PR TITLE
Bug/docker sim ci builds fail on tags/jaia 1805

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ filter-template-docker-sim-builds: &filter-template-docker-sim-builds
     branches:
       only:
         - "1.y"
+        - "bug/docker-sim-ci-builds-fail-on-tags/jaia-1805"
 
 ## Begin actual config
 version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,6 @@ filter-template-docker-sim-builds: &filter-template-docker-sim-builds
     branches:
       only:
         - "1.y"
-        - "bug/docker-sim-ci-builds-fail-on-tags/jaia-1805"
 
 ## Begin actual config
 version: 2.1

--- a/scripts/sim-docker/Dockerfile.in
+++ b/scripts/sim-docker/Dockerfile.in
@@ -7,9 +7,8 @@ RUN apt-get update
 RUN apt-get install -y sudo git gnupg lsb-release apt-utils vim
 #items below must be installed here because ENV is not passed through sudo in the scripts below
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata keyboard-configuration
-RUN git clone https://github.com/jaiarobotics/jaiabot.git
+RUN git clone https://github.com/jaiarobotics/jaiabot.git -b @JAIABOT_BRANCH_FOR_DOCKER@
 WORKDIR /jaiabot/scripts
-RUN git checkout @JAIABOT_BRANCH_FOR_DOCKER@
 RUN /jaiabot/scripts/setup-tools-build-nodocker.sh
 RUN /jaiabot/scripts/setup-tools-runtime.sh
 WORKDIR /jaiabot


### PR DESCRIPTION
Move checkout to clone line so docker cache of the `git clone` doesn't break the `git checkout <tag>`.