### PR TITLE
Debconf queries with reasonable defaults should be medium priority

### DIFF
--- a/debian/jaiabot-embedded.config
+++ b/debian/jaiabot-embedded.config
@@ -144,7 +144,7 @@ configure_bot() {
                 fi
                 ;;
             "imu_install_type")
-                if debconf_input_and_go high jaiabot-embedded/imu_install_type; then
+                if debconf_input_and_go medium jaiabot-embedded/imu_install_type; then
                     state="temperature_sensor_type"
                 else
                     go_menu jaiabot-embedded/debconf_state_bot
@@ -152,7 +152,7 @@ configure_bot() {
                 fi
                 ;;
             "temperature_sensor_type")
-                if debconf_input_and_go high jaiabot-embedded/temperature_sensor_type; then
+                if debconf_input_and_go medium jaiabot-embedded/temperature_sensor_type; then
                     state="pressure_sensor_type"
                 else
                     go_menu jaiabot-embedded/debconf_state_bot
@@ -160,7 +160,7 @@ configure_bot() {
                 fi
                 ;;
             "pressure_sensor_type")
-                if debconf_input_and_go high jaiabot-embedded/pressure_sensor_type; then
+                if debconf_input_and_go medium jaiabot-embedded/pressure_sensor_type; then
                     state="motor_harness_type"
                 else
                     go_menu jaiabot-embedded/debconf_state_bot
@@ -168,7 +168,7 @@ configure_bot() {
                 fi
                 ;;
             "motor_harness_type")
-                if debconf_input_and_go high jaiabot-embedded/motor_harness_type; then
+                if debconf_input_and_go medium jaiabot-embedded/motor_harness_type; then
                     return 0  # success, end configuration
                 else
                     go_menu jaiabot-embedded/debconf_state_bot


### PR DESCRIPTION
I'm getting prompted to set these debconf values on apt upgrade of jaiabot-embedded, where I'm guessing since defaults are set in jaiabot-embedded.templates you'd rather these defaults be used automatically.

To ensure that existing systems don't require the user to manually set the debconf value (either via the command line or the command-line UI - neither of which are supported by JCU), the priority needs to be medium or lower, not high:
