### PR TITLE
bug/init-context-on-mount

### DIFF
--- a/src/web/context/JaiaSystem/JaiaSystemContext.tsx
+++ b/src/web/context/JaiaSystem/JaiaSystemContext.tsx
@@ -86,7 +86,7 @@ export function JaiaSystemContextProvider({ children }: JaiaSystemContextProvide
     const [state, dispatch] = useReducer(jaiaSystemReducer, null);
 
     /**
-     * Sync Context with data model and starts polling when component mounts
+     * Syncs Context with data model and starts polling when component mounts
      *
      * @returns {void}
      */

--- a/src/web/context/JaiaSystem/JaiaSystemContext.tsx
+++ b/src/web/context/JaiaSystem/JaiaSystemContext.tsx
@@ -86,11 +86,13 @@ export function JaiaSystemContextProvider({ children }: JaiaSystemContextProvide
     const [state, dispatch] = useReducer(jaiaSystemReducer, null);
 
     /**
-     * Starts polling data model when component mounts
+     * Sync Context with data model and starts polling when component mounts
      *
      * @returns {void}
      */
     useEffect(() => {
+        dispatch({ type: JaiaSystemActions.SYNC_REQUESTED });
+
         const intervalID = pollDataModel(dispatch);
 
         // Clean up when component dismounts


### PR DESCRIPTION
## Overview
Provide values to the `bots`, `hubs`, and `missions` properties of `JaiaSystemContext` by dispatching a `SYNC_REQUESTED` action when the `JaiaSystemContextProvider` component mounts. This means when the `JaiaSystemContext` is not `null` we can be guaranteed to have the properties `bots`. `hubs`, and `missions` initialized.