### PR TITLE
Remove mindisk option as this leads to out of disk space on EC2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,7 +521,7 @@ jobs:
       image: ubuntu-2204:current
     resource_class: medium
     environment:
-      CREATE_IMAGE_ARGS: "--virtualbox --mindisk"
+      CREATE_IMAGE_ARGS: "--virtualbox"
       DISTRO_RELEASE_CODENAME: "jammy"
       DEBIAN_FRONTEND: "noninteractive"
     steps:

--- a/rootfs/cloud/aws/vpc.conf
+++ b/rootfs/cloud/aws/vpc.conf
@@ -18,11 +18,11 @@ AVAILABILITY_ZONE=us-east-1c
 
 
 # jaiabot-rootfs-gen repo and version
-REPO=test
+REPO=release
 REPO_VERSION=1.y
 
 # rootfs full disk size
-DISK_SIZE_GB=20
+DISK_SIZE_GB=32
 
 # AWS S3 bucket to store CloudHub data on
 # This bucket must already exist (create using 'aws s3 mb' or web console)


### PR DESCRIPTION
Increase disk image to 8GB overlay (same as real bots/hubs).

Removed `--mindisk`.

Increased Cloudhub default to 32 GB