### PR TITLE
task/make-global-context-manager-of-jaia-global/JAIA-1869

### DIFF
--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -5,7 +5,6 @@ import { GlobalActions } from "../../context/Global/GlobalActions";
 import { Feature, MapBrowserEvent } from "ol";
 import { Geometry } from "ol/geom";
 
-import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
 import { map } from "../../openlayers/maps/map";
 import { hubLayer } from "../../openlayers/layers/vector/hub-layer";
 import { botLayer } from "../../openlayers/layers/vector/bot-layer";

--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -46,15 +46,15 @@ export default function Map() {
         const nodeID = feature.get("id");
 
         if (nodeType === NodeTypes.BOT || nodeType == NodeTypes.HUB) {
-            // Update data model
-            jaiaGlobal.setSelectedNode({ type: nodeType, id: nodeID });
+            // Update React Context
+            globalDispatch({
+                type: GlobalActions.CLICKED_NODE,
+                selectedNode: { type: nodeType, id: nodeID },
+            });
 
             // Update OpenLayers
             botLayer.updateFeatures();
             hubLayer.updateFeatures();
-
-            // Update React Context
-            globalDispatch({ type: GlobalActions.CLICKED_NODE });
         }
     };
 

--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from "react";
+import { useEffect, useContext } from "react";
 import { GlobalDispatchContext } from "../../context/Global/GlobalContext";
 import { GlobalActions } from "../../context/Global/GlobalActions";
 
@@ -6,8 +6,6 @@ import { Feature, MapBrowserEvent } from "ol";
 import { Geometry } from "ol/geom";
 
 import { map } from "../../openlayers/maps/map";
-import { hubLayer } from "../../openlayers/layers/vector/hub-layer";
-import { botLayer } from "../../openlayers/layers/vector/bot-layer";
 import { NodeTypes } from "../../types/jaia-system-types";
 import { MapFeatureTypes } from "../../types/openlayers-types";
 
@@ -45,15 +43,10 @@ export default function Map() {
         const nodeID = feature.get("id");
 
         if (nodeType === NodeTypes.BOT || nodeType == NodeTypes.HUB) {
-            // Update React Context
             globalDispatch({
                 type: GlobalActions.CLICKED_NODE,
                 selectedNode: { type: nodeType, id: nodeID },
             });
-
-            // Update OpenLayers
-            botLayer.updateFeatures();
-            hubLayer.updateFeatures();
         }
     };
 

--- a/src/web/containers/CommandControl/CommandControl.tsx
+++ b/src/web/containers/CommandControl/CommandControl.tsx
@@ -114,6 +114,7 @@ import "./CommandControl.less";
 // Utility
 import cloneDeep from "lodash.clonedeep";
 import { HelpWindow } from "../HelpWindow/HelpWindow";
+import { NodeTypes } from "../../types/jaia-system-types";
 
 const rallyIcon = require("../../shared/rally.svg") as string;
 
@@ -2145,7 +2146,10 @@ export default class CommandControl extends React.Component {
             // Clicked on bot
             const botStatus = feature.get("bot") as PortalBotStatus;
             if (botStatus) {
-                this.props.globalDispatch({ type: GlobalActions.CLICKED_NODE });
+                this.props.globalDispatch({
+                    type: GlobalActions.CLICKED_NODE,
+                    selectedNode: { type: NodeTypes.BOT, id: botStatus.bot_id },
+                });
                 this.toggleBot(botStatus.bot_id);
                 return false;
             }
@@ -2155,7 +2159,10 @@ export default class CommandControl extends React.Component {
             if (hubStatus) {
                 const hubKey = Object.keys(this.state.podStatus.hubs)[0];
                 const hubID = this.state.podStatus.hubs[hubKey].hub_id;
-                this.props.globalDispatch({ type: GlobalActions.CLICKED_NODE });
+                this.props.globalDispatch({
+                    type: GlobalActions.CLICKED_NODE,
+                    selectedNode: { type: NodeTypes.HUB, id: hubID },
+                });
                 this.didClickHub(hubID);
                 return false;
             }

--- a/src/web/containers/CommandControl/CommandControl.tsx
+++ b/src/web/containers/CommandControl/CommandControl.tsx
@@ -2146,19 +2146,19 @@ export default class CommandControl extends React.Component {
             // Clicked on bot
             const botStatus = feature.get("bot") as PortalBotStatus;
             if (botStatus) {
+                const botID = botStatus.bot_id;
                 this.props.globalDispatch({
                     type: GlobalActions.CLICKED_NODE,
-                    selectedNode: { type: NodeTypes.BOT, id: botStatus.bot_id },
+                    selectedNode: { type: NodeTypes.BOT, id: botID },
                 });
-                this.toggleBot(botStatus.bot_id);
+                this.toggleBot(botID);
                 return false;
             }
 
             // Clicked on hub
             const hubStatus = feature.get("hub") as PortalHubStatus;
             if (hubStatus) {
-                const hubKey = Object.keys(this.state.podStatus.hubs)[0];
-                const hubID = this.state.podStatus.hubs[hubKey].hub_id;
+                const hubID = hubStatus.hub_id;
                 this.props.globalDispatch({
                     type: GlobalActions.CLICKED_NODE,
                     selectedNode: { type: NodeTypes.HUB, id: hubID },

--- a/src/web/containers/NodeList/NodeList.tsx
+++ b/src/web/containers/NodeList/NodeList.tsx
@@ -11,8 +11,6 @@ import {
 } from "../../context/JaiaSystem/JaiaSystemContext";
 import { GlobalActions } from "../../context/Global/GlobalActions";
 
-import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
-
 import { NodeTypes } from "../../types/jaia-system-types";
 import { HealthState } from "../../shared/JAIAProtobuf";
 
@@ -41,12 +39,10 @@ export function NodeList() {
      * @returns {void}
      */
     const handleClick = (nodeType: NodeTypes, nodeID: number) => {
-        // Update data model
-        jaiaGlobal.setSelectedNode({ type: nodeType, id: nodeID });
-
         // Update GlobalContext
         globalDispatch({
             type: GlobalActions.CLICKED_NODE,
+            selectedNode: { type: nodeType, id: nodeID },
         });
     };
 

--- a/src/web/context/Global/GlobalContext.tsx
+++ b/src/web/context/Global/GlobalContext.tsx
@@ -53,6 +53,7 @@ export interface BotAccordionStates {
 export interface GlobalAction {
     type: GlobalActions;
     clientID?: string;
+    selectedNode?: SelectedNode;
     hubAccordionName?: HubAccordionNames;
     botAccordionName?: BotAccordionNames;
 }
@@ -114,7 +115,7 @@ function globalReducer(state: GlobalContextType, action: GlobalAction) {
             return handleClosedDetails(mutableState);
 
         case GlobalActions.CLICKED_NODE:
-            return handleClickedNode(mutableState);
+            return handleClickedNode(mutableState, action.selectedNode);
 
         case GlobalActions.CLICKED_HUB_ACCORDION:
             return handleClickedHubAccordion(mutableState, action.hubAccordionName);
@@ -179,10 +180,11 @@ function handleClosedDetails(mutableState: GlobalContextType) {
  *
  * @param {GlobalContextType} mutableState State object ref for making modifications
  * @returns {GlobalContextType} Updated mutable state object
+ *
+ * @notes This function calls jaiaGlobal.setSelectedNode to make sure the
+ *        Global Data used by OpenLayers is in sync with GlobalContext
  */
-function handleClickedNode(mutableState: GlobalContextType) {
-    const selectedNode = jaiaGlobal.getSelectedNode();
-
+function handleClickedNode(mutableState: GlobalContextType, selectedNode: SelectedNode) {
     // Clicked currently selected node
     if (
         mutableState.selectedNode.type === selectedNode.type &&
@@ -194,6 +196,10 @@ function handleClickedNode(mutableState: GlobalContextType) {
         mutableState.selectedNode = selectedNode;
         mutableState.visibleDetails = selectedNode.type;
     }
+
+    // Sync OL Global Data
+    jaiaGlobal.setSelectedNode(mutableState.selectedNode);
+
     return mutableState;
 }
 

--- a/src/web/context/Global/GlobalContext.tsx
+++ b/src/web/context/Global/GlobalContext.tsx
@@ -185,11 +185,11 @@ function handleClosedDetails(mutableState: GlobalContextType) {
  *        Global Data used by OpenLayers is in sync with GlobalContext
  */
 function handleClickedNode(mutableState: GlobalContextType, selectedNode: SelectedNode) {
-    // Clicked currently selected node
     if (
         mutableState.selectedNode.type === selectedNode.type &&
         mutableState.selectedNode.id === selectedNode.id
     ) {
+        // Clicked currently selected node
         mutableState.visibleDetails = NodeTypes.NONE;
     } else {
         // Clicked non-selected node

--- a/src/web/context/Global/GlobalContext.tsx
+++ b/src/web/context/Global/GlobalContext.tsx
@@ -6,6 +6,8 @@ import { jaiaAPI } from "../../utils/jaia-api";
 import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
 import { GlobalActions } from "./GlobalActions";
 import { SelectedNode, NodeTypes } from "../../types/jaia-system-types";
+import { botLayer } from "../../openlayers/layers/vector/bot-layer";
+import { hubLayer } from "../../openlayers/layers/vector/hub-layer";
 
 export interface GlobalContextType {
     clientID: string;
@@ -197,8 +199,10 @@ function handleClickedNode(mutableState: GlobalContextType, selectedNode: Select
         mutableState.visibleDetails = selectedNode.type;
     }
 
-    // Sync OL Global Data
+    // Sync OpenLayers
     jaiaGlobal.setSelectedNode(mutableState.selectedNode);
+    botLayer.updateFeatures();
+    hubLayer.updateFeatures();
 
     return mutableState;
 }


### PR DESCRIPTION
Rework handling of `GlobalActions CLICKED_NODE` to eliminate the interdependency that required clients to call `jaiaGlobal.setSelectedNode` before dispatching the event.

- Added `selectedNode` as a Global Action parameter
- Added call to `jaiaGlobal.setSelectedNode` in `handleClickedNode` to keep the two globals in sync 
- Updated all existing calls to dispatch the `CLICKED_NODE` action

**Notes**
There is still a lot of code in CommandControl that uses the state properties selectedHubOrBot & selectedFeatures.  This code was left mostly unchanged and still needs to be refactored