### PR TITLE
task/refactor-stop-button-bot-details/JAIA-1870

### DIFF
--- a/src/web/components/DataOffloadButton/DataOffloadButton.tsx
+++ b/src/web/components/DataOffloadButton/DataOffloadButton.tsx
@@ -18,7 +18,8 @@ interface Props {
 }
 
 /**
- * Produces the data offload button for an individual Bot. It manages the alert/confirm dialog that appears when clicking on the button.
+ * Produces the data offload button for an individual Bot.
+ * It manages the alert/confirm dialog that appears when clicking on the button.
  */
 export default function DataOffloadButton(props: Props) {
     const [isDialogVisible, setIsDialogVisible] = useState(false);
@@ -63,12 +64,15 @@ export default function DataOffloadButton(props: Props) {
      *
      * @param {DialogActions} dialogAction Indicates which button was clicked
      * @returns {void}
+     *
+     * @notes
+     * After refactoring the command structure, issue the data offload command
      */
     const onDialogClose = (dialogAction: DialogActions) => {
         setIsDialogVisible(false);
 
         if (dialogAction === DialogActions.CONFIRMED) {
-            // Send command
+            // Send data offload command
         }
     };
 
@@ -76,7 +80,7 @@ export default function DataOffloadButton(props: Props) {
         <div>
             <Button
                 className={getClassName()}
-                aria-label={"data-offload-individual"}
+                aria-label={"data-offload-individual-bot"}
                 onClick={() => setIsDialogVisible(true)}
             >
                 <Icon path={mdiDownload} title="Data Offload" />

--- a/src/web/components/DataOffloadButton/DataOffloadDialog.tsx
+++ b/src/web/components/DataOffloadButton/DataOffloadDialog.tsx
@@ -1,5 +1,4 @@
-import { DisabledCodes } from "./data-offload-messages";
-import { messages } from "./data-offload-messages";
+import { DisabledCodes, messages } from "./data-offload-messages";
 
 interface DialogProps {
     isVisible: boolean;
@@ -22,11 +21,14 @@ export enum DialogActions {
 }
 
 /**
- * Produces the dialog box that appears when clicking on the data offload button. This dialog will be an alert if the command cannot be sent or a confirmation prior to sending the command.
+ * Produces the dialog box that appears when clicking on the data offload button.
+ * This dialog will be an alert if the command cannot be
+ * sent or a confirmation prior to sending the command.
  */
 export function DataOffloadDialog(props: DialogProps) {
     /**
-     * Forms the class name with a base of "jaia-dialog" and adds "alert" when the disabled code does not equal NONE.
+     * Forms the class name with a base of "jaia-dialog" and adds
+     * "alert" when the disabled code does not equal NONE.
      *
      * @returns {string} General class name jaia-dialog plus confirm/alert type
      */
@@ -51,7 +53,8 @@ export function DataOffloadDialog(props: DialogProps) {
 }
 
 /**
- * Produces the title for the dialog box. If there is nothing blocking the command from being sent the title will be Confirm, otherwise it will be Alert.
+ * Produces the title for the dialog box. If there is nothing blocking the command from
+ * being sent the title will be Confirm, otherwise it will be Alert.
  */
 function Title(props: TitleProps) {
     if (props.disabledCode === DisabledCodes.NONE) {
@@ -62,7 +65,9 @@ function Title(props: TitleProps) {
 }
 
 /**
- * Produces the buttons for the dialox box. For a confirmation dialog, the buttons will be Cancel and Confirm. For an alert, the button will be Close.
+ * Produces the buttons for the dialox box.
+ * For a confirmation dialog, the buttons will be Cancel and Confirm.
+ * For an alert, the button will be Close.
  */
 function ButtonRow(props: ButtonRowProps) {
     if (props.disabledCode === DisabledCodes.NONE) {

--- a/src/web/components/DataOffloadButton/__tests__/DataOffloadButton.test.tsx
+++ b/src/web/components/DataOffloadButton/__tests__/DataOffloadButton.test.tsx
@@ -31,7 +31,7 @@ bots.setBot(botStatusMock3);
 
 test("Click data offload button in disabled state due to mission state", async () => {
     render(<DataOffloadButton bot={bots.getBot(1)} />);
-    const button = screen.getByRole("button", { name: "data-offload-individual" });
+    const button = screen.getByRole("button", { name: "data-offload-individual-bot" });
     await userEvent.click(button);
     expect(screen.getByText("Alert")).toBeInTheDocument();
     expect(screen.getByText(messages.get(DisabledCodes.MISSION_STATE))).toBeInTheDocument();
@@ -40,7 +40,7 @@ test("Click data offload button in disabled state due to mission state", async (
 
 test("Click data offload button in disabled state due to no Wi-Fi connection", async () => {
     render(<DataOffloadButton bot={bots.getBot(2)} />);
-    const button = screen.getByRole("button", { name: "data-offload-individual" });
+    const button = screen.getByRole("button", { name: "data-offload-individual-bot" });
     await userEvent.click(button);
     expect(screen.getByText("Alert")).toBeInTheDocument();
     expect(screen.getByText(messages.get(DisabledCodes.WIFI_QUALITY))).toBeInTheDocument();
@@ -49,7 +49,7 @@ test("Click data offload button in disabled state due to no Wi-Fi connection", a
 
 test("Click data offload button in enabled state", async () => {
     render(<DataOffloadButton bot={bots.getBot(3)} />);
-    const button = screen.getByRole("button", { name: "data-offload-individual" });
+    const button = screen.getByRole("button", { name: "data-offload-individual-bot" });
     await userEvent.click(button);
     expect(screen.getByText("Confirm")).toBeInTheDocument();
     expect(screen.getByText("Cancel")).toBeInTheDocument();

--- a/src/web/components/DataOffloadButton/data-offload-messages.ts
+++ b/src/web/components/DataOffloadButton/data-offload-messages.ts
@@ -5,15 +5,15 @@ export enum DisabledCodes {
     DOWNLOAD_QUEUE = 3,
 }
 
-export const messages = new Map<DisabledCodes, string>();
-
-messages.set(DisabledCodes.NONE, "");
-messages.set(
-    DisabledCodes.MISSION_STATE,
-    "Cannot start a data offload because the Bot is not in an idle state. Try sending the stop command first.",
-);
-messages.set(
-    DisabledCodes.WIFI_QUALITY,
-    "The Bot is not connected to the Hub Wi-Fi. Try moving the Bot closer to the Hub.",
-);
-messages.set(DisabledCodes.DOWNLOAD_QUEUE, "The Bot is already in the download queue.");
+export const messages = new Map<DisabledCodes, string>([
+    [DisabledCodes.NONE, ""],
+    [
+        DisabledCodes.MISSION_STATE,
+        "Cannot start a data offload because the Bot is not in an idle state. Try sending the stop command first.",
+    ],
+    [
+        DisabledCodes.WIFI_QUALITY,
+        "The Bot is not connected to the Hub Wi-Fi. Try moving the Bot closer to the Hub.",
+    ],
+    [DisabledCodes.DOWNLOAD_QUEUE, "The Bot is already in the download queue."],
+]);

--- a/src/web/components/StopButton/StopButton.tsx
+++ b/src/web/components/StopButton/StopButton.tsx
@@ -73,7 +73,7 @@ export default function StopButton(props: Props) {
                 aria-label={"stop-individual-bot"}
                 onClick={() => setIsDialogVisible(true)}
             >
-                <Icon path={mdiStop} title="Stop Bot" />
+                <Icon path={mdiStop} title="Stop Mission" />
             </Button>
             <StopDialog
                 isVisible={isDialogVisible}

--- a/src/web/components/StopButton/StopButton.tsx
+++ b/src/web/components/StopButton/StopButton.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
+
 import { StopDialog, DialogActions } from "./StopDialog";
 import { DisabledCodes } from "./stop-messages";
-// MDI and MUI
+
 import { Icon } from "@mdi/react";
 import { Button } from "@mui/material";
 import { mdiStop } from "@mdi/js";
+
 import Bot from "../../data/bots/bot";
 import { CommandType } from "../../utils/protobuf-types";
 import { isCommandAvailable } from "../../utils/command";
@@ -16,7 +18,7 @@ interface Props {
 }
 
 /**
- * Produces the Stop button for an individual Bot.
+ * Produces the stop button for an individual Bot.
  * It manages the alert/confirm dialog that appears when clicking on the button.
  */
 export default function StopButton(props: Props) {
@@ -41,7 +43,6 @@ export default function StopButton(props: Props) {
      * Checks the Bot's state and decides what disabled code (if any) applies based on the button conditions
      *
      * @returns {DisabledCodes} The applicable disabled code based on the Bot and button conditions
-     *
      */
     const getDisabledCode = () => {
         if (!isCommandAvailable(CommandType.STOP, props.bot.getMissionStatus().missionState)) {
@@ -55,8 +56,9 @@ export default function StopButton(props: Props) {
      *
      * @param {DialogActions} dialogAction Indicates which button was clicked
      * @returns {void}
+     *
      * @notes
-     * After refactoring the commands in BotDetails will issue the stop command
+     * After refactoring the command structure, issue the stop command
      */
     const onDialogClose = (dialogAction: DialogActions) => {
         setIsDialogVisible(false);

--- a/src/web/components/StopButton/StopButton.tsx
+++ b/src/web/components/StopButton/StopButton.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import { StopDialog, DialogActions } from "./StopDialog";
 import { DisabledCodes } from "./stop-messages";
-import Bot from "../../data/bots/bot";
-import { CommandType } from "../../utils/protobuf-types";
-import { isCommandAvailable } from "../../utils/command";
-
 // MDI and MUI
 import { Icon } from "@mdi/react";
 import { Button } from "@mui/material";
 import { mdiStop } from "@mdi/js";
+import Bot from "../../data/bots/bot";
+import { CommandType } from "../../utils/protobuf-types";
+import { isCommandAvailable } from "../../utils/command";
+
 import "../../style/stylesheets/util.less";
 
 interface Props {

--- a/src/web/components/StopButton/StopButton.tsx
+++ b/src/web/components/StopButton/StopButton.tsx
@@ -73,7 +73,7 @@ export default function StopButton(props: Props) {
                 aria-label={"stop-individual-bot"}
                 onClick={() => setIsDialogVisible(true)}
             >
-                <Icon path={mdiStop} title="Data Offload" />
+                <Icon path={mdiStop} title="Stop Bot" />
             </Button>
             <StopDialog
                 isVisible={isDialogVisible}

--- a/src/web/components/StopButton/StopButton.tsx
+++ b/src/web/components/StopButton/StopButton.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { StopDialog, DialogActions } from "./StopDialog";
+import { DisabledCodes } from "./stop-messages";
+import Bot from "../../data/bots/bot";
+import { CommandType } from "../../utils/protobuf-types";
+import { isCommandAvailable } from "../../utils/command";
+
+// MDI and MUI
+import { Icon } from "@mdi/react";
+import { Button } from "@mui/material";
+import { mdiStop } from "@mdi/js";
+import "../../style/stylesheets/util.less";
+
+interface Props {
+    bot: Bot;
+}
+
+/**
+ * Produces the Stop button for an individual Bot.
+ * It manages the alert/confirm dialog that appears when clicking on the button.
+ */
+export default function StopButton(props: Props) {
+    const [isDialogVisible, setIsDialogVisible] = useState(false);
+
+    /**
+     * Forms the style of the button (light if enabled, dark if disabled)
+     *
+     * @returns {string} General class name jaia-button plus enable/disable factor
+     */
+    const getClassName = () => {
+        let className = "jaia-button";
+
+        if (getDisabledCode() !== DisabledCodes.NONE) {
+            className += " disabled";
+        }
+
+        return className;
+    };
+
+    /**
+     * Checks the Bot's state and decides what disabled code (if any) applies based on the button conditions
+     *
+     * @returns {DisabledCodes} The applicable disabled code based on the Bot and button conditions
+     *
+     */
+    const getDisabledCode = () => {
+        if (!isCommandAvailable(CommandType.STOP, props.bot.getMissionStatus().missionState)) {
+            return DisabledCodes.MISSION_STATE;
+        }
+        return DisabledCodes.NONE;
+    };
+
+    /**
+     * Closes the dialog box then acts based on the type of button clicked
+     *
+     * @param {DialogActions} dialogAction Indicates which button was clicked
+     * @returns {void}
+     * @notes
+     * After refactoring the commands in BotDetails will issue the stop command
+     */
+    const onDialogClose = (dialogAction: DialogActions) => {
+        setIsDialogVisible(false);
+
+        if (dialogAction === DialogActions.CONFIRMED) {
+            // Send stop command
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                className={getClassName()}
+                aria-label={"stop-individual-bot"}
+                onClick={() => setIsDialogVisible(true)}
+            >
+                <Icon path={mdiStop} title="Data Offload" />
+            </Button>
+            <StopDialog
+                isVisible={isDialogVisible}
+                disabledCode={getDisabledCode()}
+                onClose={onDialogClose}
+            />
+        </div>
+    );
+}

--- a/src/web/components/StopButton/StopDialog.tsx
+++ b/src/web/components/StopButton/StopDialog.tsx
@@ -1,8 +1,9 @@
 import { DisabledCodes, messages } from "./stop-messages";
 
-export enum DialogActions {
-    NONE = 0,
-    CONFIRMED = 1,
+interface DialogProps {
+    isVisible: boolean;
+    disabledCode: DisabledCodes;
+    onClose: (dialogAction: DialogActions) => void;
 }
 
 interface TitleProps {
@@ -14,10 +15,9 @@ interface ButtonRowProps {
     onClose: (dialogAction: DialogActions) => void;
 }
 
-interface DialogProps {
-    isVisible: boolean;
-    disabledCode: DisabledCodes;
-    onClose: (dialogAction: DialogActions) => void;
+export enum DialogActions {
+    NONE = 0,
+    CONFIRMED = 1,
 }
 
 /**

--- a/src/web/components/StopButton/StopDialog.tsx
+++ b/src/web/components/StopButton/StopDialog.tsx
@@ -1,0 +1,94 @@
+import { DisabledCodes, messages } from "./stop-messages";
+
+export enum DialogActions {
+    NONE = 0,
+    CONFIRMED = 1,
+}
+
+interface TitleProps {
+    disabledCode: DisabledCodes;
+}
+
+interface ButtonRowProps {
+    disabledCode: DisabledCodes;
+    onClose: (dialogAction: DialogActions) => void;
+}
+
+interface DialogProps {
+    isVisible: boolean;
+    disabledCode: DisabledCodes;
+    onClose: (dialogAction: DialogActions) => void;
+}
+
+/**
+ * Produces the dialog box that appears when clicking on the Stop Button
+ * This dialog will be an alert if the command cannot be
+ * sent or a confirmation prior to sending the command.
+ */
+export function StopDialog(props: DialogProps) {
+    /**
+     * Forms the class name with a base of "jaia-dialog" and adds
+     * "alert" when the disabled code does not equal NONE.
+     *
+     * @returns {string} General class name jaia-dialog plus confirm/alert type
+     */
+    const getClassName = () => {
+        return `jaia-dialog ${props.disabledCode !== DisabledCodes.NONE ? "alert" : ""}`;
+    };
+
+    if (!props.isVisible) {
+        return <div></div>;
+    }
+
+    return (
+        <div>
+            <div className="blocking-overlay" onClick={() => {}}></div>
+            <div className={getClassName()}>
+                <Title disabledCode={props.disabledCode} />
+                <p>{messages.get(props.disabledCode)}</p>
+                <ButtonRow disabledCode={props.disabledCode} onClose={props.onClose} />
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Produces the title for the dialog box. If there is nothing blocking the command from
+ * being sent the title will be Confirm, otherwise it will be Alert.
+ */
+function Title(props: TitleProps) {
+    if (props.disabledCode === DisabledCodes.NONE) {
+        return <h1>Confirm</h1>;
+    }
+
+    return <h1>Alert</h1>;
+}
+
+/**
+ * Produces the buttons for the dialox box.
+ * For a confirmation dialog, the buttons will be Cancel and Confirm.
+ * For an alert, the button will be Stop.
+ */
+function ButtonRow(props: ButtonRowProps) {
+    if (props.disabledCode === DisabledCodes.NONE) {
+        return (
+            <div className="dialog-button-row">
+                <button className="dialog-button" onClick={() => props.onClose(DialogActions.NONE)}>
+                    Cancel
+                </button>
+                <button
+                    className="dialog-button"
+                    onClick={() => props.onClose(DialogActions.CONFIRMED)}
+                >
+                    Stop
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <button className="dialog-button" onClick={() => props.onClose(DialogActions.NONE)}>
+            Close
+        </button>
+    );
+}

--- a/src/web/components/StopButton/StopDialog.tsx
+++ b/src/web/components/StopButton/StopDialog.tsx
@@ -21,7 +21,7 @@ export enum DialogActions {
 }
 
 /**
- * Produces the dialog box that appears when clicking on the Stop Button
+ * Produces the dialog box that appears when clicking on the stop button.
  * This dialog will be an alert if the command cannot be
  * sent or a confirmation prior to sending the command.
  */

--- a/src/web/components/StopButton/__tests__/StopButton.test.tsx
+++ b/src/web/components/StopButton/__tests__/StopButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+import StopButton from "../StopButton";
+import { DisabledCodes, messages } from "../stop-messages";
+
+import { bots } from "../../../data/bots/bots";
+import { PortalBotStatus } from "../../../shared/PortalStatus";
+import { MissionState } from "../../../utils/protobuf-types";
+
+type testParams = {
+    missionState: MissionState;
+    buttonAvailable: boolean;
+};
+
+const testCases: testParams[] = [
+    { missionState: MissionState.PRE_DEPLOYMENT__STARTING_UP, buttonAvailable: false },
+    { missionState: MissionState.IN_MISSION__UNDERWAY__MOVEMENT__TRANSIT, buttonAvailable: true },
+    { missionState: MissionState.IN_MISSION__UNDERWAY__TASK__STATION_KEEP, buttonAvailable: true },
+    { missionState: MissionState.IN_MISSION__UNDERWAY__RECOVERY__TRANSIT, buttonAvailable: true },
+    { missionState: MissionState.IN_MISSION__UNDERWAY__RECOVERY__STOPPED, buttonAvailable: false },
+    { missionState: MissionState.IN_MISSION__PAUSE__IMU_RESTART, buttonAvailable: true },
+    { missionState: MissionState.POST_DEPLOYMENT__RECOVERED, buttonAvailable: false },
+];
+
+test.each(testCases)(
+    "Exercise the Stop button in the $missionState state",
+    async ({ missionState, buttonAvailable }) => {
+        let botStatus: PortalBotStatus = {
+            bot_id: 1,
+            mission_state: missionState,
+        };
+        bots.setBot(botStatus);
+        render(<StopButton bot={bots.getBot(1)} />);
+        const button = screen.getByLabelText("stop-individual-bot");
+        await userEvent.click(button);
+        if (buttonAvailable) {
+            expect(screen.getByText("Confirm")).toBeInTheDocument();
+            expect(screen.getByText("Cancel")).toBeInTheDocument();
+            expect(screen.getByText("Stop")).toBeInTheDocument();
+        } else {
+            expect(screen.getByText("Alert")).toBeInTheDocument();
+            expect(screen.getByText(messages.get(DisabledCodes.MISSION_STATE))).toBeInTheDocument();
+            expect(screen.getByText("Close")).toBeInTheDocument();
+        }
+    },
+);

--- a/src/web/components/StopButton/stop-messages.ts
+++ b/src/web/components/StopButton/stop-messages.ts
@@ -1,0 +1,8 @@
+export enum DisabledCodes {
+    NONE = 0,
+    MISSION_STATE = 1,
+}
+export const messages: ReadonlyMap<DisabledCodes, string> = new Map([
+    [DisabledCodes.NONE, ""],
+    [DisabledCodes.MISSION_STATE, "The Bot can only be stopped while it is performing a mission"],
+]);


### PR DESCRIPTION
Created new version of the Stop Button (for BotDetailsPanel) using the logic in [task/refactor-data-offload-button/JAIA-1853 #1075](https://github.com/jaiarobotics/jaiabot/pull/1075) as a pattern.

Tested with unit test and rendered button in browser to confirm functionality.

Follow on tasks will consolidate the common logic into a generic button and the Stop and Data Offload button will be refactored.