### PR TITLE
Increase virtualfleet disk size to match non-mindisk image minimum

### DIFF
--- a/config/ansible/cloud/create-virtualfleet.yml
+++ b/config/ansible/cloud/create-virtualfleet.yml
@@ -5,7 +5,7 @@
   vars:
     warp: 5
     instance_type: t3a.small
-    volume_size_gb: 20
+    volume_size_gb: 32
     server_ssh_privkey_path: /home/jaia/.ssh/id_ed25519
     server_ssh_pubkey_path: /home/jaia/.ssh/id_ed25519.pub
 


### PR DESCRIPTION
This fixes a regression introduced due to: https://github.com/jaiarobotics/jaiabot/pull/1065:

```
Failed to create new EC2 instance: An error occurred (InvalidBlockDeviceMapping) when calling the RunInstances operation: Volume of size 20GB is smaller than snapshot 'snap-07d437af7f6e20b60', expect size>= 32GB
```

I forgot to increase VirtualFleet minimum when making that change.

Until this is fixed, new VirtualFleets cannot be created.