### PR TITLE
bug/python-packages-version-mismatch/JAIA-1883

### DIFF
--- a/src/python/build_venv.sh
+++ b/src/python/build_venv.sh
@@ -25,7 +25,9 @@ echo 🟢 Building the python venv into ${TARGET_DIR}
 
     # Create the venv
     pushd ${TARGET_DIR} > /dev/null
-        python3 -m venv venv --system-site-packages
-        ./venv/bin/pip install -q wheel
-        ./venv/bin/pip install -q -r requirements.txt
+        python3 -m venv venv
+        ./venv/bin/pip install -qU pip
+        ./venv/bin/pip install -qU wheel
+        ./venv/bin/pip install -qU setuptools
+	./venv/bin/pip install -qr requirements.txt
     popd > /dev/null

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -56,7 +56,7 @@ rpi-ws281x==4.3.4
 RPi.GPIO==0.7.1
 scipy==1.9.1
 scour==0.37
-setuptools==44.0.0
+setuptools==75.3.0
 Shapely==1.8.5.post1
 simplejson==3.16.0
 six==1.16.0


### PR DESCRIPTION
## Description

We ran into a issue installing the python dependencies required to run jcc and jdv. This is a temp fix until we fix how we are installing our local packages.

## Near Future Work
https://jaia-innovation.atlassian.net/browse/JAIA-1884