### PR TITLE
task/pressure-read-function-review/JAIA-1864

### DIFF
--- a/src/python/pressure_sensor/jaiabot_pressure_sensor.py
+++ b/src/python/pressure_sensor/jaiabot_pressure_sensor.py
@@ -44,7 +44,6 @@ class SensorError(Exception):
 class Sensor:
     def __init__(self):
         self.is_setup = False
-        self.pressure_0 = None
         self.sensor_type = None
 
     def setup(self):
@@ -73,10 +72,7 @@ class Sensor:
 
         try:
             if self.sensor.read():
-                if self.pressure_0 is None:
-                    self.pressure_0 = self.sensor.pressure()
-
-                return (self.sensor.pressure() - self.pressure_0, self.sensor.temperature())
+                return (self.sensor.pressure(), self.sensor.temperature())
                 
             else:
                 log.warning('Sensor read fail')


### PR DESCRIPTION
## Description

Before the JaiaBot begins a dive we zero out the pressure readings. In the python driver on start up we set a zero pressure variable for the first reading and use it for all other readings. I am removing this code as it seems redundant. 

## Test
* Test on the bench
* Test in the water (sea trial)