### PR TITLE
bug/systemd-echo-config-incorrect/JAIA-1909

### DIFF
--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -541,7 +541,7 @@ else:
     ]
     jaiabot_apps.extend(jaiabot_apps_imu)
 
-if jaia_bot_type.value == 'echo':
+if jaia_bot_type.value == 'ECHO':
     jaiabot_apps_echo = [
         {'exe': 'jaiabot_echo_driver',
         'description': 'JaiaBot Echo Driver',


### PR DESCRIPTION
## Description

Change systemd.py config logic for the echo to match what was expected. We had a lowercase value, but needed uppercase.

## Test
* Deploying to PAM variant 
* Ensure the services are running