### PR TITLE
Workaround graphviz bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "bug/workaround-graphviz-assertion-failure"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
+        - "bug/workaround-graphviz-assertion-failure"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,8 @@ add_subdirectory(src)
 
 
 if(export_goby_interfaces)
-  set(INTERFACE_COMMON_PARAMS "--omit-group-regex=jaiabot::state_change;--omit-node-regex='.*statechart::Notify.*'")
+  # remove splines= when https://gitlab.com/graphviz/graphviz/-/issues/1408 fix is available (2.y)?
+  set(INTERFACE_COMMON_PARAMS "--splines=line;--omit-group-regex=jaiabot::state_change;--omit-node-regex='.*statechart::Notify.*'")
   generate_interfaces_figure(${project_SRC_DIR}/doc/deployment/simulation_deployment.yml ${YML_OUT_DIR} simulation_interfaces.svg "--no-disconnected;${INTERFACE_COMMON_PARAMS}")
   generate_interfaces_figure(${project_SRC_DIR}/doc/deployment/simulation_deployment.yml ${YML_OUT_DIR} simulation_interfaces_inc_unused.svg "${INTERFACE_COMMON_PARAMS}")
   generate_interfaces_figure(${project_SRC_DIR}/doc/deployment/runtime_deployment.yml ${YML_OUT_DIR} runtime_deployment.svg "--no-disconnected;${INTERFACE_COMMON_PARAMS}")


### PR DESCRIPTION
This bug in Graphviz https://gitlab.com/graphviz/graphviz/-/issues/1408 is now hitting us (it's fairly random).

This only effects 'spline=ortho' which is the best looking way to render the Goby pub/sub graphs, but not if it doesn't work.

I've changed this to 'spline=line' which is a bit harder to read but will work until we are using a patched Graphviz (~2.y~ 3.y?)