### PR TITLE
Fix jaia_json_file.py run for playbooks in child directory of config/ansible

### DIFF
--- a/config/ansible/cloud/callback_plugins
+++ b/config/ansible/cloud/callback_plugins
@@ -1,0 +1,1 @@
+../callback_plugins

--- a/config/ansible/fleet/callback_plugins
+++ b/config/ansible/fleet/callback_plugins
@@ -1,0 +1,1 @@
+../callback_plugins

--- a/config/ansible/major_upgrade/callback_plugins
+++ b/config/ansible/major_upgrade/callback_plugins
@@ -1,0 +1,1 @@
+../callback_plugins


### PR DESCRIPTION
Fixes issue: https://jaia-innovation.atlassian.net/browse/JAIA-1930

As seen on VirtualHub:
![image](https://github.com/user-attachments/assets/3f29250e-2962-463c-a5bb-fd4cc19da3fb)

This is due to the change in ansible-playbooks to use a custom JSON callback plugin to allow us to also stream stdout at the same time (from https://github.com/jaiarobotics/jaiabot/pull/1085).

Apparently ansible needs `callback_plugins` to be relative to the playbook directory, not the current working directory.

The fix is to create symlinks in these subdirectories to the real `callback_plugins` in config/ansible.