### PR TITLE
Task/major upgrade fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/major-upgrade-fixes"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -196,7 +195,6 @@ filter-template-normal-builds: &filter-template-normal-builds
     branches:
       ignore:
         - "1.y"
-        - "task/major-upgrade-fixes"
 
 # which branches to run the rootfs filesystem builds
 filter-template-rootfs-builds: &filter-template-rootfs-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
+        - "task/major-upgrade-fixes"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -195,6 +196,7 @@ filter-template-normal-builds: &filter-template-normal-builds
     branches:
       ignore:
         - "1.y"
+        - "task/major-upgrade-fixes"
 
 # which branches to run the rootfs filesystem builds
 filter-template-rootfs-builds: &filter-template-rootfs-builds

--- a/config/ansible/cloud/callback_plugins
+++ b/config/ansible/cloud/callback_plugins
@@ -1,0 +1,1 @@
+../callback_plugins

--- a/config/ansible/fleet/callback_plugins
+++ b/config/ansible/fleet/callback_plugins
@@ -1,0 +1,1 @@
+../callback_plugins

--- a/config/ansible/major_upgrade/callback_plugins
+++ b/config/ansible/major_upgrade/callback_plugins
@@ -1,0 +1,1 @@
+../callback_plugins

--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -51,8 +51,18 @@
     - name: Create the upgrade tmp directory
       file:
         path: '{{ upgrade_tmp_dir }}'
-        state: directory                
-      
+        state: directory
+
+    - name: Check that architecture matches
+      shell: |
+        current_arch=$(dpkg --print-architecture)
+        major_upgrade_arch="{{major_upgrade_arch if major_upgrade_arch is defined else ''}}"
+
+        # for ISOs that include major_upgrade_arch, ensure it matches
+        if [[ ! -z "${major_upgrade_arch}" && ! "${major_upgrade_arch}" = "${current_arch}" ]]; then
+            echo "Major upgrade architecture does not match existing system architecture (${major_upgrade_arch} != ${current_arch})"
+            return 1
+        fi
         
     - name: Check that Ubuntu version is greater than current version
       shell: |

--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -56,10 +56,9 @@
     - name: Check that architecture matches
       shell: |
         current_arch=$(dpkg --print-architecture)
-        major_upgrade_arch="{{major_upgrade_arch if major_upgrade_arch is defined else ''}}"
+        major_upgrade_arch="{{major_upgrade_arch}}"
 
-        # for ISOs that include major_upgrade_arch, ensure it matches
-        if [[ ! -z "${major_upgrade_arch}" && ! "${major_upgrade_arch}" = "${current_arch}" ]]; then
+        if [[ ! "${major_upgrade_arch}" = "${current_arch}" ]]; then
             echo "Major upgrade architecture does not match existing system architecture (${major_upgrade_arch} != ${current_arch})"
             return 1
         fi

--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -20,7 +20,14 @@
     - include_tasks: ../tasks/read-debconf.yml
         
   tasks:
-
+    - name: Mount updates disk (on hub)
+      delegate_to: localhost
+      mount:
+        path: /var/www/html/updates
+        src: LABEL=updates
+        state: mounted
+        fstype: auto
+    
     - name: Create the upgrade base working directory
       file:
         path: '{{ upgrade_dir_base }}'
@@ -90,6 +97,7 @@
         dest: '{{ upgrade_dir }}/do-major-upgrade.sh'
         mode: a=rwx
 
+    # Nohup so we complete the ansible job and get to the reboot splash screen before the crazy happens
     - name: Run upgrade script
       shell: |
-        {{ upgrade_dir }}/do-major-upgrade.sh > {{ upgrade_dir }}/major_upgrade_final.log 2>&1
+        nohup /bin/bash -c 'sleep 5 && {{ upgrade_dir }}/do-major-upgrade.sh > {{ upgrade_dir }}/major_upgrade_final.log 2>&1 &' > /dev/null

--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -77,7 +77,7 @@
         mkdir -p {{ upgrade_boot_dir }}
         tar -xz -f {{ upgrade_dir }}/{{ major_upgrade_rootfs_version }}.boot.tar.gz -C {{ upgrade_boot_dir }}
         jaia admin fleet generate --bootdir {{ upgrade_boot_dir }} {{ upgrade_dir }}/fleet{{ jaiabot_embedded_fleet_id }}.cfg {{ jaiabot_embedded_type }} {{ jaiabot_embedded_hub_id if jaiabot_embedded_type == 'hub' else jaiabot_embedded_bot_id }}
-        rm {{ upgrade_boot_dir }}/jaiabot/init/id_vpn_tmp*
+        rm -f {{ upgrade_boot_dir }}/jaiabot/init/id_vpn_tmp*
 
     - name: Set facts for upgrade script
       set_fact:

--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -22,11 +22,8 @@
   tasks:
     - name: Mount updates disk (on hub)
       delegate_to: localhost
-      mount:
-        path: /var/www/html/updates
-        src: LABEL=updates
-        state: mounted
-        fstype: auto
+      shell: |
+        mount | grep -q updates || mount LABEL=updates
     
     - name: Create the upgrade base working directory
       file:

--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -54,8 +54,9 @@
       shell: |
         current_arch=$(dpkg --print-architecture)
         major_upgrade_arch="{{major_upgrade_arch}}"
-
-        if [[ ! "${major_upgrade_arch}" = "${current_arch}" ]]; then
+        if [ "${major_upgrade_arch}" = "${current_arch}" ]; then
+            echo "Major upgrade architecture matches existing system architecture (${major_upgrade_arch} = ${current_arch})"
+        else
             echo "Major upgrade architecture does not match existing system architecture (${major_upgrade_arch} != ${current_arch})"
             return 1
         fi

--- a/config/ansible/major_upgrade/tasks/check-disk-space.yml
+++ b/config/ansible/major_upgrade/tasks/check-disk-space.yml
@@ -1,3 +1,7 @@
+- name: Set required disk space for /var/log based on whether do_backup is set
+  set_fact:
+    var_log_min_space_KiB: '{{ var_log_min_space_backup_KiB if do_backup | bool else var_log_min_space_no_backup_KiB}}'
+
 - name: Check required partition available space / sizes
   shell: "df {{ item.path }} --output={{ item.output }} | tail -1"
   register: partition_info

--- a/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
+++ b/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
@@ -1,14 +1,7 @@
-- name: Set facts for primary and iso fleet configuration
+- name: Set facts for existing and iso fleet configuration
   set_fact:
-    primary_fleet_cfg: "/etc/jaiabot/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
     iso_fleet_cfg: "/var/www/html/updates/major_upgrade/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
-
-- name: Check if the primary fleet config file exists on the control node (hub)
-  delegate_to: localhost
-  run_once: true
-  stat:
-    path: "{{ primary_fleet_cfg }}"
-  register: primary_fleet_file
+    existing_fleet_cfg: "/etc/jaiabot/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
 
 - name: Check if the iso fleet config file exists on the control node (hub)
   delegate_to: localhost
@@ -16,22 +9,29 @@
   stat:
     path: "{{ iso_fleet_cfg }}"
   register: iso_fleet_file
-  when: not primary_fleet_file.stat.exists
 
-- name: Copy the primary fleet config file if it exists
-  copy:
-    src: "{{ primary_fleet_cfg }}"
-    dest: "{{ upgrade_dir }}"
-  when: primary_fleet_file.stat.exists
+- name: Check if the existing fleet config file exists on the control node (hub)
+  delegate_to: localhost
+  run_once: true
+  stat:
+    path: "{{ existing_fleet_cfg }}"
+  register: existing_fleet_file
+  when: not iso_fleet_file.stat.exists
 
-- name: Copy the iso fleet config file if the primary does not exist
+- name: Copy the iso fleet config file if it exists
   copy:
     src: "{{ iso_fleet_cfg }}"
     dest: "{{ upgrade_dir }}"
-  when: not primary_fleet_file.stat.exists and iso_fleet_file.stat.exists
+  when: iso_fleet_file.stat.exists
+
+- name: Copy the existing fleet config file if the iso config does not exist
+  copy:
+    src: "{{ existing_fleet_cfg }}"
+    dest: "{{ upgrade_dir }}"
+  when: not iso_fleet_file.stat.exists and existing_fleet_file.stat.exists
 
 - name: Fail if neither fleet config file exists
   fail:
-    msg: "Neither {{ primary_fleet_cfg }} nor {{ iso_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_iso' to create this image)"
-  when: not primary_fleet_file.stat.exists and not iso_fleet_file.stat.exists
+    msg: "Neither {{ iso_fleet_cfg }} nor {{ existing_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_existing' to create this image)"
+  when: not iso_fleet_file.stat.exists and not existing_fleet_file.stat.exists
   run_once: true

--- a/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
+++ b/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
@@ -3,12 +3,16 @@
     primary_fleet_cfg: "/etc/jaiabot/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
     iso_fleet_cfg: "/var/www/html/updates/major_upgrade/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
 
-- name: Check if the primary fleet config file exists
+- name: Check if the primary fleet config file exists on the control node (hub)
+  delegate_to: localhost
+  run_once: true
   stat:
     path: "{{ primary_fleet_cfg }}"
   register: primary_fleet_file
 
-- name: Check if the iso fleet config file exists
+- name: Check if the iso fleet config file exists on the control node (hub)
+  delegate_to: localhost
+  run_once: true
   stat:
     path: "{{ iso_fleet_cfg }}"
   register: iso_fleet_file
@@ -28,5 +32,6 @@
 
 - name: Fail if neither fleet config file exists
   fail:
-    msg: "Neither {{ primary_fleet_cfg }} nor {{ iso_fleet_cfg }} exist. Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_iso' to create this image)"
+    msg: "Neither {{ primary_fleet_cfg }} nor {{ iso_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_iso' to create this image)"
   when: not primary_fleet_file.stat.exists and not iso_fleet_file.stat.exists
+  run_once: true

--- a/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
+++ b/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
@@ -32,6 +32,6 @@
 
 - name: Fail if neither fleet config file exists
   fail:
-    msg: "Neither {{ iso_fleet_cfg }} nor {{ existing_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_existing' to create this image)"
+    msg: "Neither {{ iso_fleet_cfg }} nor {{ existing_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_iso' to create this image)"
   when: not iso_fleet_file.stat.exists and not existing_fleet_file.stat.exists
   run_once: true

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -119,9 +119,14 @@ if [ -e /boot/grub/grub.cfg ]; then
         mount --move "$mountpoint" "$new_mount"
     done
 
-    # Enable serial console for AWS debugging
-    sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 console=ttyS0"/' /etc/default/grub
-    
+    if [ "$(cloud-init query cloud_id)" = "nocloud" ]; then
+        # VirtualBox cloud init source
+        sed -i 's|\(GRUB_CMDLINE_LINUX_DEFAULT=".*\)"|\1 ds=nocloud\\;s=file:///etc/jaiabot/init/ network-config=disabled"|' /etc/default/grub
+    elif [ "$(cloud-init query cloud_id)" = "aws" ]; then       
+        # Enable serial console for AWS debugging
+        sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 console=ttyS0"/' /etc/default/grub
+    fi
+       
     update-grub
     
     root_partition=$(findmnt -n -o SOURCE /)

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -103,11 +103,8 @@ fi
 # Reboot    
 ###############################
 
-if [ "{{ upgrade_type }}" = "embedded" ]; then
-    ## in place major upgrade
-    systemctl reboot --force
-else
-    ## AWS AMI
+if [ -e /boot/grub/grub.cfg ]; then
+    ## AWS AMI or VirtualBox VM
     
     # Pivot to new root
     mount --make-rprivate /
@@ -135,3 +132,8 @@ else
 
     grub-install "/dev/$root_device" --no-uefi-secure-boot --removable
 fi
+
+if [ "{{ upgrade_type }}" = "embedded" ]; then
+    systemctl reboot --force
+fi
+ 

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -139,6 +139,6 @@ if [ -e /boot/grub/grub.cfg ]; then
 fi
 
 if [ "{{ upgrade_type }}" = "embedded" ]; then
-    systemctl reboot --force
+    nohup /bin/bash -c 'sleep 5 && systemctl reboot --force &' > /dev/null
 fi
- 
+

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -139,6 +139,6 @@ if [ -e /boot/grub/grub.cfg ]; then
 fi
 
 if [ "{{ upgrade_type }}" = "embedded" ]; then
-    nohup /bin/bash -c 'sleep 5 && systemctl reboot --force &' > /dev/null
+    systemctl reboot --force
 fi
 

--- a/config/ansible/major_upgrade/vars/disk-space.yml
+++ b/config/ansible/major_upgrade/vars/disk-space.yml
@@ -1,3 +1,4 @@
-var_log_min_space_KiB: 20000000
+var_log_min_space_backup_KiB: 20000000
+var_log_min_space_no_backup_KiB: 4000000
 overlay_min_space_KiB:  8000000
 rootfs_min_space_KiB:   8000000

--- a/config/ansible/reboot-hubs.yml
+++ b/config/ansible/reboot-hubs.yml
@@ -7,4 +7,5 @@
     - name: Reboot hubs
       # since we're running this on the hub, we will reboot the machine running ansible
       # this precludes using the reboot builtin
-      shell: "systemctl start reboot.target"
+      shell: "nohup /bin/bash -c 'sleep 5 && systemctl reboot &' > /dev/null"
+

--- a/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
+++ b/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
@@ -128,6 +128,7 @@ add_commander_tab: false
             value: "no"
         }
         
+        causes_hub_reboot: true
     }
 
     
@@ -172,6 +173,7 @@ add_commander_tab: false
         name: "Reboot Hub"
         section: "Reboot"
         role: USER
+        causes_hub_reboot: true
     }    
 
     ansible_playbook {

--- a/debian/jaiabot-web.install
+++ b/debian/jaiabot-web.install
@@ -1,2 +1,3 @@
 usr/share/jaiabot/web/*
 etc/apache2/sites-available/*
+var/www/html/reboot-check/*

--- a/src/lib/liaison/prelaunch/CMakeLists.txt
+++ b/src/lib/liaison/prelaunch/CMakeLists.txt
@@ -6,3 +6,8 @@ target_link_libraries(jaiabot_liaison_prelaunch goby ${Boost_LIBRARIES} jaiabot_
 configure_file(goby_liaison_prelaunch_jaiabot.in ${project_BIN_DIR}/goby_liaison_prelaunch_jaiabot @ONLY)
 
 project_install_lib(jaiabot_liaison_prelaunch)
+
+option(install_liaison_reboot_check "Install Liaison Reboot check to /var/www/html/reboot-check" ON)
+if(install_motd)
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/reboot-check DESTINATION /var/www/html)
+endif()

--- a/src/lib/liaison/prelaunch/config.proto
+++ b/src/lib/liaison/prelaunch/config.proto
@@ -34,6 +34,7 @@ message UpgradeConfig
         optional string limit = 7;
         optional string inventory = 8; // overrides ansible_inventory at parent scope
         optional string section = 9 [default = "General"];
+        optional bool causes_hub_reboot = 10 [default = false];
     }
     repeated AnsiblePlaybook ansible_playbook = 2;
     required string ansible_inventory = 3;
@@ -48,6 +49,7 @@ message UpgradeConfig
     optional string ansible_log_dir = 7 [default = "/tmp/jaiabot-ansible"];
     
     optional double check_freq = 10 [default = 10];
+
 }
 
 extend goby.apps.zeromq.protobuf.LiaisonConfig

--- a/src/lib/liaison/prelaunch/liaison_upgrade.cpp
+++ b/src/lib/liaison/prelaunch/liaison_upgrade.cpp
@@ -242,14 +242,6 @@ void jaiabot::LiaisonUpgrade::loop()
             }
             else
             {
-                if (playbook.pb_playbook.causes_hub_reboot())
-                {
-                    std::string hostname = wApp->environment().hostName();
-                    if (auto pos = hostname.find(':'))
-                        hostname = hostname.substr(0, pos);
-                    wApp->redirect("http://" + hostname + "/reboot-check/index.html");
-                }
-
                 std::ifstream json_log(playbook.json_file, std::ios::in);
                 playbook.last_log.clear();
                 {
@@ -364,6 +356,7 @@ void jaiabot::LiaisonUpgrade::process_ansible_json_result(nlohmann::json root_js
         set_style(result_table->elementAt(row, column), true);
     }
 
+    bool hub_success = false;
     for (const auto& result_p : results)
     {
         column = 0;
@@ -382,6 +375,8 @@ void jaiabot::LiaisonUpgrade::process_ansible_json_result(nlohmann::json root_js
         {
             case jaiabot::LiaisonUpgrade::Result::SUCCESS:
                 cell->addWidget(new Wt::WText("Success"));
+                if (result_p.first.find("hub") != std::string::npos)
+                    hub_success = true;
                 break;
             case jaiabot::LiaisonUpgrade::Result::FAILURE:
                 cell->addWidget(new Wt::WText("Failure"));
@@ -402,6 +397,14 @@ void jaiabot::LiaisonUpgrade::process_ansible_json_result(nlohmann::json root_js
 
             set_style(result_table->elementAt(row, column));
         }
+    }
+
+    if (hub_success && playbook.pb_playbook.causes_hub_reboot())
+    {
+        std::string hostname = wApp->environment().hostName();
+        if (auto pos = hostname.find(':'))
+            hostname = hostname.substr(0, pos);
+        wApp->redirect("http://" + hostname + "/reboot-check/index.html");
     }
 
     playbook.result_text->setText("");

--- a/src/lib/liaison/prelaunch/liaison_upgrade.cpp
+++ b/src/lib/liaison/prelaunch/liaison_upgrade.cpp
@@ -247,7 +247,7 @@ void jaiabot::LiaisonUpgrade::loop()
                     std::string hostname = wApp->environment().hostName();
                     if (auto pos = hostname.find(':'))
                         hostname = hostname.substr(0, pos);
-                    wApp->redirect(hostname + "/reboot-check/index.html");
+                    wApp->redirect("http://" + hostname + "/reboot-check/index.html");
                 }
 
                 std::ifstream json_log(playbook.json_file, std::ios::in);

--- a/src/lib/liaison/prelaunch/liaison_upgrade.cpp
+++ b/src/lib/liaison/prelaunch/liaison_upgrade.cpp
@@ -1,6 +1,7 @@
 #include <Wt/WComboBox>
 #include <Wt/WContainerWidget>
 #include <Wt/WDialog>
+#include <Wt/WEnvironment>
 #include <Wt/WGroupBox>
 #include <Wt/WPanel>
 #include <Wt/WPushButton>
@@ -241,6 +242,14 @@ void jaiabot::LiaisonUpgrade::loop()
             }
             else
             {
+                if (playbook.pb_playbook.causes_hub_reboot())
+                {
+                    std::string hostname = wApp->environment().hostName();
+                    if (auto pos = hostname.find(':'))
+                        hostname = hostname.substr(0, pos);
+                    wApp->redirect(hostname + "/reboot-check/index.html");
+                }
+
                 std::ifstream json_log(playbook.json_file, std::ios::in);
                 playbook.last_log.clear();
                 {

--- a/src/lib/liaison/prelaunch/reboot-check/index.html
+++ b/src/lib/liaison/prelaunch/reboot-check/index.html
@@ -1,64 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Server Reboot Check</title>
     <link rel="stylesheet" type="text/css" href="liaison.css">
     <script>
-        const serverIP = window.location.hostname;
-        const checkInterval = 3000; // 3 seconds
-        let serverDown = false;
-        let elapsedTime = 0;
-        
-        async function checkServer() {
-            try {
-                await fetch(`http://${serverIP}:80`, { method: "HEAD", mode: "no-cors" });
-                serverDown = false;
-            } catch (error) {
-                serverDown = true;
-                console.log("Server unreachable, waiting...");
-            }
-            
-            if (serverDown) {
-                elapsedTime = 0;
-                updateStatus();
-                checkServerRestore();
-            } else {
-                setTimeout(checkServer, checkInterval);
-            }
-        }
-        
-        function updateStatus() {
-            document.getElementById("status").innerText = `Waiting for Hub to reboot, please wait... (${elapsedTime}s)`;
-            elapsedTime += 1;
-            setTimeout(updateStatus, 1000);
-        }
-        
-        async function checkServerRestore() {
-            try {
-                await fetch(`http://${serverIP}:9091`, { method: "HEAD", mode: "no-cors" });
-                window.location.href = `http://${serverIP}:9091`;
-            } catch (error) {
-                setTimeout(checkServerRestore, checkInterval);
-            }
-        }
-        
-        window.onload = checkServer;
+      const serverIP = window.location.hostname;
+      const checkInterval = 1000; // 1 second
+      let serverDown = false;
+      let elapsedTime = 0;
+      
+      async function checkServer() {
+          try {
+              await fetch(`http://${serverIP}:80`, { method: "HEAD", mode: "no-cors" });
+              serverDown = false;
+          } catch (error) {
+              serverDown = true;
+              console.log("Server unreachable, waiting...");
+          }
+          
+          updateStatus();
+          if (serverDown) {
+              checkServerRestore();
+          } else {
+              setTimeout(checkServer, checkInterval);
+          }
+      }
+      
+      function updateStatus() {
+          if (serverDown) {             
+              document.getElementById("status").innerText = `Waiting for Hub to finish rebooting, please wait... (${elapsedTime}s)`;
+              setTimeout(updateStatus, 1000);  // 1 second
+          }
+          else {
+              document.getElementById("status").innerText = `Finishing task (this make take several minutes), please wait... (${elapsedTime}s)`;
+          }
+          elapsedTime += 1;
+      }
+      
+      async function checkServerRestore() {
+          try {
+              await fetch(`http://${serverIP}:9091`, { method: "HEAD", mode: "no-cors" });
+              window.location.href = `http://${serverIP}:9091`;
+          } catch (error) {
+              setTimeout(checkServerRestore, checkInterval);
+          }
+      }
+      
+      window.onload = checkServer;
     </script>
-</head>
-<body>
+  </head>
+  <body>
     <div id="main">
-        <div id="header">
-            <h1 id="header">Jaiabot Fleet Upgrade and Configuration</h1>
-	    <hr/>
+      <div id="header">
+        <span id="header">goby liaison: Jaiabot Fleet Upgrade and Configuration</span>
+      </div>
+      <hr/>
+      <div id="contents">
+        <h2>Hub Reboot Status</h2>
+        <div class="status-box">
+          <p id="status">Please wait...</p>
         </div>
-        <div id="contents">
-            <h2>Hub Reboot Status</h2>
-            <div class="status-box">
-                <p id="status">Finishing task, pending reboot. Please wait...</p>
-            </div>
-        </div>
+      </div>
     </div>
-</body>
+  </body>
 </html>

--- a/src/lib/liaison/prelaunch/reboot-check/index.html
+++ b/src/lib/liaison/prelaunch/reboot-check/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Server Reboot Check</title>
+    <script>
+        const serverIP = window.location.hostname; // Get the current server's hostname/IP
+        const checkInterval = 3000; // 3 seconds
+        let serverDown = false;
+
+        async function checkServer() {
+            try {
+                await fetch(`http://${serverIP}:80`, { method: "HEAD", mode: "no-cors" });
+                serverDown = false;
+            } catch (error) {
+                serverDown = true;
+                console.log("Server unreachable, waiting...");
+            }
+
+            if (serverDown) {
+                document.getElementById("status").innerText = "Waiting for Hub to finish rebooting, please wait...";
+                checkServerRestore();
+            } else {
+                setTimeout(checkServer, checkInterval);
+            }
+        }
+
+        async function checkServerRestore() {
+            try {
+                await fetch(`http://${serverIP}:9091`, { method: "HEAD", mode: "no-cors" });
+                window.location.href = `http://${serverIP}:9091`;
+            } catch (error) {
+                setTimeout(checkServerRestore, checkInterval);
+            }
+        }
+
+        window.onload = checkServer;
+    </script>
+</head>
+<body>
+    <h1 id="status">Task finalizing, please wait...</h1>
+</body>
+</html>

--- a/src/lib/liaison/prelaunch/reboot-check/index.html
+++ b/src/lib/liaison/prelaunch/reboot-check/index.html
@@ -4,11 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Server Reboot Check</title>
+    <link rel="stylesheet" type="text/css" href="liaison.css">
     <script>
-        const serverIP = window.location.hostname; // Get the current server's hostname/IP
+        const serverIP = window.location.hostname;
         const checkInterval = 3000; // 3 seconds
         let serverDown = false;
-
+        let elapsedTime = 0;
+        
         async function checkServer() {
             try {
                 await fetch(`http://${serverIP}:80`, { method: "HEAD", mode: "no-cors" });
@@ -17,15 +19,22 @@
                 serverDown = true;
                 console.log("Server unreachable, waiting...");
             }
-
+            
             if (serverDown) {
-                document.getElementById("status").innerText = "Waiting for Hub to finish rebooting, please wait...";
+                elapsedTime = 0;
+                updateStatus();
                 checkServerRestore();
             } else {
                 setTimeout(checkServer, checkInterval);
             }
         }
-
+        
+        function updateStatus() {
+            document.getElementById("status").innerText = `Waiting for Hub to reboot, please wait... (${elapsedTime}s)`;
+            elapsedTime += 1;
+            setTimeout(updateStatus, 1000);
+        }
+        
         async function checkServerRestore() {
             try {
                 await fetch(`http://${serverIP}:9091`, { method: "HEAD", mode: "no-cors" });
@@ -34,11 +43,22 @@
                 setTimeout(checkServerRestore, checkInterval);
             }
         }
-
+        
         window.onload = checkServer;
     </script>
 </head>
 <body>
-    <h1 id="status">Task finalizing, please wait...</h1>
+    <div id="main">
+        <div id="header">
+            <h1 id="header">Jaiabot Fleet Upgrade and Configuration</h1>
+	    <hr/>
+        </div>
+        <div id="contents">
+            <h2>Hub Reboot Status</h2>
+            <div class="status-box">
+                <p id="status">Finishing task, pending reboot. Please wait...</p>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/src/lib/liaison/prelaunch/reboot-check/liaison.css
+++ b/src/lib/liaison/prelaunch/reboot-check/liaison.css
@@ -1,0 +1,191 @@
+/* general */
+
+html { height: 95%; }
+ 
+
+body {
+    font-size:100%;
+    height:100%;
+}
+* { font-family: Gentium, serif; }
+
+/* main holds all this
+/*     [                 header                   ]   */
+/*     [           ][                             ]   */  
+/*     [           ][                             ]   */  
+/*     [   menu    ][        contents             ]   */  
+/*     [           ][                             ]   */  
+/*     [           ][                             ]   */  
+
+
+div#main
+{
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width:  80%;
+    min-width: 60em;
+    position: relative;
+    height: 100%;
+}
+
+div#header
+{
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+    height: 72px;
+}
+
+span#header 
+{
+  position:relative;
+  top: 50%;
+  display:block;
+  font-size: 1.3em;
+  vertical-align: bottom;
+}
+
+div.menu
+{
+  position:absolute;
+  display: block;
+  width: 15%;
+}
+
+ul.menu
+{
+  list-style-type: none;
+  padding:10px;
+}
+
+.Wt-itemview
+{
+ /* height: 10em; */
+}
+
+.Wt-spinbox
+{
+/*    width: 3em*/
+
+}
+
+div#contents
+{
+  position:absolute;
+  display: block;
+  left: 15%;
+  right: 0%;
+}
+
+div.fill
+{
+  width: 100%;
+  height: 100%;
+}
+
+
+input[type="text"]
+ { 
+   width: 20em; 
+ } 
+
+a#goby_logo { display:block; position: absolute; left:0px; top:0px;}
+a#lp_logo { display:block; position: absolute; right:0px; top:0px;}
+
+/*.fl { float:left; }*/
+table.basic_small 
+{
+ border-collapse:collapse;
+ font-size:80%;
+}
+
+table.basic_small td, table.basic_small th
+{ 
+padding: 3px;
+border: 1px solid black;
+}
+
+
+a { outline:0; }
+a:link { color:#006a94; }
+a:hover, a:hover img,  div:hover.do_hover { background:#EEE; }
+a:active {color:#E36034}
+
+a:visited, a:link
+{
+    text-decoration:none;
+    border-bottom:1px dotted #aaa;
+}
+
+a.no_ul
+{
+    text-decoration:none;
+    border-bottom:0px; 
+}
+
+
+.Wt-treetable table.even
+{
+    background-color: #fff;
+}
+
+.Wt-treetable table.odd
+{
+    background-color: #eee;
+}
+
+tr.even
+{
+    background-color: #fff;
+}
+
+tr.odd
+{
+    background-color: #eee;
+}
+
+li.even
+{
+    background-color: #fff;
+}
+
+li.odd
+{
+    background-color: #eee;
+}
+
+
+/* for scope trees */
+.faded
+{
+    color:gray;
+}
+
+.invisible
+{
+    visibility:hidden;
+}
+
+.fixed-right
+{
+    position:fixed; bottom:2%; right:2%; z-index:1;
+    font-size:80%;
+    max-width:40%;
+    overflow: auto;
+}
+
+.fixed-left
+{
+    position:fixed; bottom:2%; left:2%; z-index:1;
+    font-size:80%;
+    max-width:40%;
+    overflow: auto;
+    background-color: #fff;
+    border:1px solid;
+    padding:2px;
+}
+
+.Wt-progressbar .Wt-pgb-bar {
+    background: #1C9FCB
+}

--- a/src/web/jcc.conf
+++ b/src/web/jcc.conf
@@ -2,6 +2,7 @@
     ServerName hub
     
     Alias /updates /var/www/html/updates
+    Alias /reboot-check /var/www/html/reboot-check
 
     WSGIDaemonProcess rest_api user=jaia group=jaia threads=5 python-path=/usr/share/jaiabot/python/pyjaiaprotobuf home=/usr/share/jaiabot/web/rest_api
     WSGIDaemonProcess jcc user=jaia group=jaia threads=5 python-home=/usr/share/jaiabot/python/venv home=/usr/share/jaiabot/web/server


### PR DESCRIPTION
Fixes/ Improvements to major upgrade script (to upgrade 1.y to 2.y):
 - Correctly check fleetN.cfg exists on hub (don't require bots have it)
 - Support for upgrading VirtualBox fleet (for testing purposes)
 - Only require 4GB free on /var/log/jaiabot when not doing a backup of the old rootfs/overlay (otherwise 20GB as before).
- Add prelaunch/reboot-check/index.html for use when Liaison needs to reboot the hub for a cleaner user experience.
- https://github.com/jaiarobotics/jaiabot/pull/1106
- Added to major_upgrade a check for correct architecture.

This will need to be on the 1.y bots to allow the major_upgrade to work successfully.

