### PR TITLE
Bug/2.y ami name cannot contain tilde

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
+        - "bug/2.y-ami-name-cannot-contain-tilde"
           
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -185,6 +186,7 @@ filter-template-normal-builds: &filter-template-normal-builds
     branches:
       ignore:
         - "2.y"
+        - "bug/2.y-ami-name-cannot-contain-tilde"
 
 # which branches to run the rootfs filesystem builds
 filter-template-rootfs-builds: &filter-template-rootfs-builds
@@ -194,6 +196,7 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
     branches:
       only:
         - "2.y"
+        - "bug/2.y-ami-name-cannot-contain-tilde"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
@@ -203,6 +206,7 @@ filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
     branches:
       only:
         - "2.y"
+        - "bug/2.y-ami-name-cannot-contain-tilde"
 
 # which branches to build Docker simulator
 filter-template-docker-sim-builds: &filter-template-docker-sim-builds
@@ -608,7 +612,7 @@ jobs:
             export JAIA_UPGRADE_ISO_SOURCE=local
             export JAIA_UPGRADE_ISO_LOCAL_DIR=/tmp/bundle/result/amd64
 
-            AMI_NAME=$(echo $IMAGE_NAME | sed 's/+/[plus]/g')
+            AMI_NAME=$(echo $IMAGE_NAME | sed 's/+/[plus]/g' | sed 's/~/[tilde]/g')
 
             rootfs/cloud/aws/packer/packer-create-ami-by-upgrade.sh "${AMI_NAME}"
             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
-        - "bug/2.y-ami-name-cannot-contain-tilde"
           
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -186,7 +185,6 @@ filter-template-normal-builds: &filter-template-normal-builds
     branches:
       ignore:
         - "2.y"
-        - "bug/2.y-ami-name-cannot-contain-tilde"
 
 # which branches to run the rootfs filesystem builds
 filter-template-rootfs-builds: &filter-template-rootfs-builds
@@ -196,7 +194,6 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
     branches:
       only:
         - "2.y"
-        - "bug/2.y-ami-name-cannot-contain-tilde"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
@@ -206,7 +203,6 @@ filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
     branches:
       only:
         - "2.y"
-        - "bug/2.y-ami-name-cannot-contain-tilde"
 
 # which branches to build Docker simulator
 filter-template-docker-sim-builds: &filter-template-docker-sim-builds

--- a/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
+++ b/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
@@ -1,14 +1,7 @@
-- name: Set facts for primary and iso fleet configuration
+- name: Set facts for existing and iso fleet configuration
   set_fact:
-    primary_fleet_cfg: "/etc/jaiabot/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
     iso_fleet_cfg: "/var/www/html/updates/major_upgrade/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
-
-- name: Check if the primary fleet config file exists on the control node (hub)
-  delegate_to: localhost
-  run_once: true
-  stat:
-    path: "{{ primary_fleet_cfg }}"
-  register: primary_fleet_file
+    existing_fleet_cfg: "/etc/jaiabot/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
 
 - name: Check if the iso fleet config file exists on the control node (hub)
   delegate_to: localhost
@@ -16,22 +9,29 @@
   stat:
     path: "{{ iso_fleet_cfg }}"
   register: iso_fleet_file
-  when: not primary_fleet_file.stat.exists
 
-- name: Copy the primary fleet config file if it exists
-  copy:
-    src: "{{ primary_fleet_cfg }}"
-    dest: "{{ upgrade_dir }}"
-  when: primary_fleet_file.stat.exists
+- name: Check if the existing fleet config file exists on the control node (hub)
+  delegate_to: localhost
+  run_once: true
+  stat:
+    path: "{{ existing_fleet_cfg }}"
+  register: existing_fleet_file
+  when: not iso_fleet_file.stat.exists
 
-- name: Copy the iso fleet config file if the primary does not exist
+- name: Copy the iso fleet config file if it exists
   copy:
     src: "{{ iso_fleet_cfg }}"
     dest: "{{ upgrade_dir }}"
-  when: not primary_fleet_file.stat.exists and iso_fleet_file.stat.exists
+  when: iso_fleet_file.stat.exists
+
+- name: Copy the existing fleet config file if the iso config does not exist
+  copy:
+    src: "{{ existing_fleet_cfg }}"
+    dest: "{{ upgrade_dir }}"
+  when: not iso_fleet_file.stat.exists and existing_fleet_file.stat.exists
 
 - name: Fail if neither fleet config file exists
   fail:
-    msg: "Neither {{ primary_fleet_cfg }} nor {{ iso_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_iso' to create this image)"
-  when: not primary_fleet_file.stat.exists and not iso_fleet_file.stat.exists
+    msg: "Neither {{ iso_fleet_cfg }} nor {{ existing_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_existing' to create this image)"
+  when: not iso_fleet_file.stat.exists and not existing_fleet_file.stat.exists
   run_once: true

--- a/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
+++ b/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
@@ -1,7 +1,14 @@
-- name: Set facts for existing and iso fleet configuration
+- name: Set facts for primary and iso fleet configuration
   set_fact:
+    primary_fleet_cfg: "/etc/jaiabot/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
     iso_fleet_cfg: "/var/www/html/updates/major_upgrade/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
-    existing_fleet_cfg: "/etc/jaiabot/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
+
+- name: Check if the primary fleet config file exists on the control node (hub)
+  delegate_to: localhost
+  run_once: true
+  stat:
+    path: "{{ primary_fleet_cfg }}"
+  register: primary_fleet_file
 
 - name: Check if the iso fleet config file exists on the control node (hub)
   delegate_to: localhost
@@ -9,29 +16,22 @@
   stat:
     path: "{{ iso_fleet_cfg }}"
   register: iso_fleet_file
+  when: not primary_fleet_file.stat.exists
 
-- name: Check if the existing fleet config file exists on the control node (hub)
-  delegate_to: localhost
-  run_once: true
-  stat:
-    path: "{{ existing_fleet_cfg }}"
-  register: existing_fleet_file
-  when: not iso_fleet_file.stat.exists
+- name: Copy the primary fleet config file if it exists
+  copy:
+    src: "{{ primary_fleet_cfg }}"
+    dest: "{{ upgrade_dir }}"
+  when: primary_fleet_file.stat.exists
 
-- name: Copy the iso fleet config file if it exists
+- name: Copy the iso fleet config file if the primary does not exist
   copy:
     src: "{{ iso_fleet_cfg }}"
     dest: "{{ upgrade_dir }}"
-  when: iso_fleet_file.stat.exists
-
-- name: Copy the existing fleet config file if the iso config does not exist
-  copy:
-    src: "{{ existing_fleet_cfg }}"
-    dest: "{{ upgrade_dir }}"
-  when: not iso_fleet_file.stat.exists and existing_fleet_file.stat.exists
+  when: not primary_fleet_file.stat.exists and iso_fleet_file.stat.exists
 
 - name: Fail if neither fleet config file exists
   fail:
-    msg: "Neither {{ iso_fleet_cfg }} nor {{ existing_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_existing' to create this image)"
-  when: not iso_fleet_file.stat.exists and not existing_fleet_file.stat.exists
+    msg: "Neither {{ primary_fleet_cfg }} nor {{ iso_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_iso' to create this image)"
+  when: not primary_fleet_file.stat.exists and not iso_fleet_file.stat.exists
   run_once: true


### PR DESCRIPTION
AWS AMI names cannot contain certain characters. The `~` in `2.0.0~beta1` is one such character.

This PR replaces `~` with `[tilde]` (same way that `+` is already dealt with).