### PR TITLE
Remove setting X.y for test repo

### DIFF
--- a/config/ansible/change-sources.yml
+++ b/config/ansible/change-sources.yml
@@ -39,11 +39,6 @@
   tasks:
     - include_tasks: tasks/read-debconf.yml
   
-    - name: Set version to X.y for test repo
-      set_fact:
-        internal_version: "{{ 'X.y' if repo == 'test' else version }}"
-      when: mode != "offline"
-      
     - name: Remove deprecated gobysoft.list
       ansible.builtin.file:
         dest: "/etc/apt/sources.list.d/gobysoft.list"


### PR DESCRIPTION
test/1.y, test/2.y exist now (and have for some time). This removes the old need to change X.y -> 1.y (which doesn't work obviously for 2.y).