### PR TITLE
Bug/2.y/new firmware wrong uart numbers

### DIFF
--- a/rootfs/customization/includes.chroot/etc/udev/rules.d/90-jaiabot_serial.rules
+++ b/rootfs/customization/includes.chroot/etc/udev/rules.d/90-jaiabot_serial.rules
@@ -2,5 +2,5 @@
 KERNEL=="ttyUSB0", SYMLINK+="arduino"
 
 ## xbee
-KERNEL=="ttyAMA2", SYMLINK+="xbee"
+KERNEL=="ttyAMA4", SYMLINK+="xbee"
 


### PR DESCRIPTION
Pending confirmation from @jason-jaia that this is the uart expected, then I think RPI just remapped the /dev/ttyAMA numbers to match the uart numbers defined in dtoverlay (config.txt).