### PR TITLE
bug/1.y/Remove known hosts on major upgrade 

### DIFF
--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -20,6 +20,11 @@
     - include_tasks: ../tasks/read-debconf.yml
         
   tasks:
+    - name: Remove known_hosts to avoid SSH connection issues to new bots
+      file:
+        path: /home/jaia/.ssh/known_hosts
+        state: absent
+    
     - name: Mount updates disk (on hub)
       delegate_to: localhost
       shell: |


### PR DESCRIPTION
Avoids issue where the hub can't reconnect on SSH after it is upgraded but some of the bots weren't,  after these  bots are upgraded.