### PR TITLE
Add check to ensure new fleet config ssh key matches.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
+        - "task/1.y/major-upgrade-check-hub-key-matches-fleet-config"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -44,42 +44,12 @@
         upgrade_backup_dir: '{{ upgrade_dir }}/backup'
         upgrade_boot_dir: '{{ upgrade_dir }}/boot'
 
-
     - name: Create the upgrade tmp directory
       file:
         path: '{{ upgrade_tmp_dir }}'
         state: directory
 
-    - name: Check that architecture matches
-      shell: |
-        current_arch=$(dpkg --print-architecture)
-        major_upgrade_arch="{{major_upgrade_arch}}"
-        if [ "${major_upgrade_arch}" = "${current_arch}" ]; then
-            echo "Major upgrade architecture matches existing system architecture (${major_upgrade_arch} = ${current_arch})"
-        else
-            echo "Major upgrade architecture does not match existing system architecture (${major_upgrade_arch} != ${current_arch})"
-            return 1
-        fi
-        
-    - name: Check that Ubuntu version is greater than current version
-      shell: |
-        current_ubuntu_version=$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)
-        if ! dpkg --compare-versions {{ major_upgrade_ubuntu_version }} gt ${current_ubuntu_version} ; then
-            echo "New Ubuntu version ({{ major_upgrade_ubuntu_version }}) is not greater than current version (${current_ubuntu_version})"
-            return 1
-        fi
-      
-    - name: Debug version
-      debug:
-        msg: "Found major upgrade version: {{ major_upgrade_version }}, current version: {{ jaiabot_current_version }}"
-        
-    - name: Check that upgrade version is greater than or equal to than current version
-      shell: |
-        if ! dpkg --compare-versions {{ major_upgrade_version }} ge $(echo {{ jaiabot_current_version }} | cut -d '-' -f1) ; then
-            echo "New major version ({{ major_upgrade_version }}) is not greater than or equal to current version ({{ jaiabot_current_version }})"
-            return 1
-        fi
-      
+    - include_tasks: tasks/check-versions.yml
     - include_tasks: tasks/check-disk-space.yml
     - include_tasks: tasks/get-new-filesystems.yml
     - include_tasks: tasks/copy-fleet-config.yml
@@ -93,6 +63,8 @@
         jaia admin fleet generate --bootdir {{ upgrade_boot_dir }} {{ upgrade_dir }}/fleet{{ jaiabot_embedded_fleet_id }}.cfg {{ jaiabot_embedded_type }} {{ jaiabot_embedded_hub_id if jaiabot_embedded_type == 'hub' else jaiabot_embedded_bot_id }}
         rm -f {{ upgrade_boot_dir }}/jaiabot/init/id_vpn_tmp*
 
+    - include_tasks: tasks/check-hub-ssh-keys.yml
+        
     - name: Set facts for upgrade script
       set_fact:
         rootfs_filename: '{{ upgrade_dir }}/{{ major_upgrade_rootfs_version }}.rootfs.tar.gz'

--- a/config/ansible/major_upgrade/tasks/check-hub-ssh-keys.yml
+++ b/config/ansible/major_upgrade/tasks/check-hub-ssh-keys.yml
@@ -1,0 +1,25 @@
+- name: Set facts for hub key
+  set_fact:
+    hub_privkey: "hub{{ hub_id }}_fleet{{ jaiabot_embedded_fleet_id }}"
+
+- name: Check ssh hub key info
+  delegate_to: localhost
+  stat:
+    path: "/home/jaia/.ssh/{{ hub_privkey }}"
+  register: hub_privkey_file
+
+- name: Fail if ssh hub key does not exist
+  delegate_to: localhost
+  fail:
+    msg: "Hub key must exist in /home/jaia/.ssh/{{ hub_privkey }}"
+  when: not hub_privkey_file.stat.exists
+
+- name: Check hub ssh key matches fleet config ssh key 
+  delegate_to: localhost
+  shell: |
+    existing_hub_privkey_fingerprint=$(ssh-keygen -l -f /home/jaia/.ssh/{{ hub_privkey }})
+    fleet_cfg_hub_privkey_fingerprint=$(ssh-keygen -l -f {{ upgrade_boot_dir }}/jaiabot/init/{{ hub_privkey }})
+    if [ "${existing_hub_privkey_fingerprint}" != "${fleet_cfg_hub_privkey_fingerprint}" ]; then
+      echo "Existing hub SSH key does not match hub SSH key in fleet configuration file. Update the fleet configuration file to match the hub SSH key to ensure connectivity."
+      return 1
+    fi

--- a/config/ansible/major_upgrade/tasks/check-versions.yml
+++ b/config/ansible/major_upgrade/tasks/check-versions.yml
@@ -1,0 +1,29 @@
+- name: Check that architecture matches
+  shell: |
+    current_arch=$(dpkg --print-architecture)
+    major_upgrade_arch="{{major_upgrade_arch}}"
+    if [ "${major_upgrade_arch}" = "${current_arch}" ]; then
+      echo "Major upgrade architecture matches existing system architecture (${major_upgrade_arch} = ${current_arch})"
+    else
+      echo "Major upgrade architecture does not match existing system architecture (${major_upgrade_arch} != ${current_arch})"
+      return 1
+    fi
+        
+- name: Check that Ubuntu version is greater than current version
+  shell: |
+    current_ubuntu_version=$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)
+    if ! dpkg --compare-versions {{ major_upgrade_ubuntu_version }} gt ${current_ubuntu_version} ; then
+    echo "New Ubuntu version ({{ major_upgrade_ubuntu_version }}) is not greater than current version (${current_ubuntu_version})"
+      return 1
+    fi
+      
+- name: Debug version
+  debug:
+    msg: "Found major upgrade version: {{ major_upgrade_version }}, current version: {{ jaiabot_current_version }}"
+        
+- name: Check that upgrade version is greater than or equal to than current version
+  shell: |
+    if ! dpkg --compare-versions {{ major_upgrade_version }} ge $(echo {{ jaiabot_current_version }} | cut -d '-' -f1) ; then
+    echo "New major version ({{ major_upgrade_version }}) is not greater than or equal to current version ({{ jaiabot_current_version }})"
+      return 1
+    fi

--- a/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
+++ b/config/ansible/major_upgrade/tasks/copy-fleet-config.yml
@@ -5,14 +5,12 @@
 
 - name: Check if the iso fleet config file exists on the control node (hub)
   delegate_to: localhost
-  run_once: true
   stat:
     path: "{{ iso_fleet_cfg }}"
   register: iso_fleet_file
 
 - name: Check if the existing fleet config file exists on the control node (hub)
   delegate_to: localhost
-  run_once: true
   stat:
     path: "{{ existing_fleet_cfg }}"
   register: existing_fleet_file
@@ -34,4 +32,3 @@
   fail:
     msg: "Neither {{ iso_fleet_cfg }} nor {{ existing_fleet_cfg }} exist on the control node (hub). Please use a ISO image with an attached fleet configuration (use 'jaia admin fleet update_iso' to create this image)"
   when: not iso_fleet_file.stat.exists and not existing_fleet_file.stat.exists
-  run_once: true


### PR DESCRIPTION
If the hub doesn't have the same ssh key on major upgrade, it won't be able to connect to any un-upgraded bots.

This new check ensures that the hub keys is the same in the fleet configuration, or else refuses to upgrade (the solution here would be to fix the fleet.cfg to match the existing hub key).

Moved version checking tasks to their own file at config/ansible/major_upgrade/tasks/check-versions.yml

Remove "run_once: true" to ensure hub fails if any bot fails, so we don't go to the reboot-check splash screen when we shouldn't.