### PR TITLE
Throttle 1 on mount to avoid race condition (hopefully)

### DIFF
--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -24,7 +24,9 @@
       delegate_to: localhost
       shell: |
         mount | grep -q updates || mount LABEL=updates
-    
+      # without throttle, we get a race condition  
+      throttle: 1
+        
     - name: Create the upgrade base working directory
       file:
         path: '{{ upgrade_dir_base }}'


### PR DESCRIPTION
Hopefully fixes issue on upgrading bots:

```

fatal: [bot1-fleet7]: FAILED! => {"changed": true, "cmd": "mount | grep -q updates || mount LABEL=updates\n", "delta": "0:00:00.089582", "end": "2025-03-20 20:45:08.205120", "msg": "non-zero return code", "rc": 32, "start": "2025-03-20 20:45:08.115538", "stderr": "mount: /var/www/html/updates: /dev/sdb already mounted on /var/www/html/updates.", "stderr_lines": ["mount: /var/www/html/updates: /dev/sdb already mounted on /var/www/html/updates."], "stdout": "", "stdout_lines": []}
changed: [bot2-fleet7]
fatal: [hub1-fleet7]: FAILED! => {"changed": true, "cmd": "mount | grep -q updates || mount LABEL=updates\n", "delta": "0:00:00.082745", "end": "2025-03-20 20:45:08.235696", "msg": "non-zero return code", "rc": 32, "start": "2025-03-20 20:45:08.152951", "stderr": "mount: /var/www/html/updates: /dev/sdb already mounted on /var/www/html/updates.", "stderr_lines": ["mount: /var/www/html/updates: /dev/sdb already mounted on /var/www/html/updates."], "stdout": "", "stdout_lines": []}
```