### PR TITLE
task/cleanup-crc-check-code-sub-sensor-app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/cleanup-crc-check-code-sub-sensor-app"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "sub/skeleton-app-for-running-sensor-drivers"
+        - "task/cleanup-crc-check-code-sub-sensor-app"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -156,24 +156,19 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
     constexpr int bits_in_byte = 8;
     constexpr int bytes_in_crc32 = 4;
 
+    io_msg.
+
     try
     {
         glog.is_debug1() && glog << "Received bytes from MCU: "
                                  << goby::util::hex_encode(io_msg.data()) << std::endl;
 
         const auto& encoded = io_msg.data();
-        std::string hex_str = goby::util::hex_encode(encoded);
-        size_t length = hex_str.size() / 2;
-
-        uint8_t data[length];
-
-        if (length < bytes_in_crc32)
+        if (encoded.size() < bytes_in_crc32)
             throw(std::runtime_error("Message is too small"));
 
-        hex_string_to_bytes(hex_str.c_str(), data, length);
-
-        uint32_t computed_crc = crc::calculate_crc32(data, length - bytes_in_crc32);
-
+        uint32_t computed_crc =
+            crc::calculate_crc32(encoded.data(), encoded.size() - bytes_in_crc32);
         uint32_t provided_crc = 0;
 
         std::size_t i = 0;
@@ -183,8 +178,6 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
 
         if (computed_crc != provided_crc)
         {
-            glog.is_debug1() && glog << "Computed CRC: " << computed_crc << std::endl;
-            glog.is_debug1() && glog << "Provided CRC: " << provided_crc << std::endl;
             throw(std::runtime_error("Computed CRC (" + std::to_string(computed_crc) +
                                      ") does not equal CRC on message (" +
                                      std::to_string(provided_crc) + ")"));

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -73,11 +73,6 @@ class Sensors : public zeromq::MultiThreadApplication<config::Sensors>
     boost::crc_32_type crc32_calc_;
 };
 
-void hex_string_to_bytes(const char* hex, uint8_t* bytes, size_t length)
-{
-    for (size_t i = 0; i < length; i++) { sscanf(&hex[i * 2], "%2hhx", &bytes[i]); }
-}
-
 } // namespace apps
 } // namespace jaiabot
 

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -120,7 +120,7 @@ void jaiabot::apps::Sensors::send_to_mcu(sensor::protobuf::SensorRequest request
     std::string* encoded = io_msg->mutable_data();
     request.SerializeToString(encoded);
 
-    uint32_t crc32_value = crc::calculate_crc32(encoded, encoded->size());
+    uint32_t crc32_value = crc::calculate_crc32(encoded->data(), encoded->size());
 
     constexpr int bits_in_byte = 8;
     constexpr int bytes_in_crc32 = 4;

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -155,20 +155,18 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
 {
     constexpr int bits_in_byte = 8;
     constexpr int bytes_in_crc32 = 4;
-
     try
     {
         glog.is_debug1() && glog << "Received bytes from MCU: "
                                  << goby::util::hex_encode(io_msg.data()) << std::endl;
 
         const auto& encoded = io_msg.data();
-        std::vector<uint8_t> mcu_bytes(encoded.begin(), encoded.end());
 
-        if (mcu_bytes.size() < bytes_in_crc32)
+        if (encoded.size() < bytes_in_crc32)
             throw(std::runtime_error("Message is too small"));
 
         uint32_t computed_crc =
-            crc::calculate_crc32(mcu_bytes.data(), mcu_bytes.size() - bytes_in_crc32);
+            crc::calculate_crc32(encoded.data(), encoded.size() - bytes_in_crc32);
         uint32_t provided_crc = 0;
 
         std::size_t i = 0;

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -156,8 +156,6 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
     constexpr int bits_in_byte = 8;
     constexpr int bytes_in_crc32 = 4;
 
-    io_msg.
-
     try
     {
         glog.is_debug1() && glog << "Received bytes from MCU: "

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -62,12 +62,6 @@ class Sensors : public zeromq::MultiThreadApplication<config::Sensors>
     void receive_from_mcu(const goby::middleware::protobuf::IOData& io_msg);
     void receive_metadata_from_mcu(const sensor::protobuf::Metadata& metadata);
 
-    template <typename C> std::uint32_t compute_crc32(C begin, C end)
-    {
-        crc32_calc_.process_bytes(&(*begin), end - begin);
-        return crc32_calc_.checksum();
-    }
-
   private:
     std::set<jaiabot::sensor::protobuf::Sensor> drivers_launched_;
     boost::crc_32_type crc32_calc_;
@@ -146,6 +140,7 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
 {
     constexpr int bits_in_byte = 8;
     constexpr int bytes_in_crc32 = 4;
+
     try
     {
         glog.is_debug1() && glog << "Received bytes from MCU: "

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -164,11 +164,13 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
                                  << goby::util::hex_encode(io_msg.data()) << std::endl;
 
         const auto& encoded = io_msg.data();
-        if (encoded.size() < bytes_in_crc32)
+        std::vector<uint8_t> mcu_bytes(encoded.begin(), encoded.end());
+
+        if (mcu_bytes.size() < bytes_in_crc32)
             throw(std::runtime_error("Message is too small"));
 
         uint32_t computed_crc =
-            crc::calculate_crc32(encoded.data(), encoded.size() - bytes_in_crc32);
+            crc::calculate_crc32(mcu_bytes.data(), mcu_bytes.size() - bytes_in_crc32);
         uint32_t provided_crc = 0;
 
         std::size_t i = 0;

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -131,11 +131,7 @@ void jaiabot::apps::Sensors::send_to_mcu(sensor::protobuf::SensorRequest request
     std::string* encoded = io_msg->mutable_data();
     request.SerializeToString(encoded);
 
-    std::string hex_str = goby::util::hex_encode(io_msg->data());
-    size_t length = hex_str.size() / 2;
-    uint8_t data[length];
-    hex_string_to_bytes(hex_str.c_str(), data, length);
-    uint32_t crc32_value = crc::calculate_crc32(data, length);
+    uint32_t crc32_value = crc::calculate_crc32(encoded, encoded->size());
 
     constexpr int bits_in_byte = 8;
     constexpr int bytes_in_crc32 = 4;


### PR DESCRIPTION
### Summary
Removes byte to hex conversions that arose from debugging and initial development. Now we rely on the `std::string` that comes from accessing the protobuf type `bytes` in C++ when passing data to the CRC functions. This PR also removes the unused CRC function in the sensor app.

### Testing
Successfully sent `SensorRequest` messages and received `SensorData` messages between the Pi and STM32.

![image](https://github.com/user-attachments/assets/aae7435e-012d-41fc-b6c9-efbd061ea565)


