### PR TITLE
Bug/1.y/fix retrofit ssh keys

### DIFF
--- a/config/ansible/fleet/retrofit-ssh-config.yml
+++ b/config/ansible/fleet/retrofit-ssh-config.yml
@@ -42,7 +42,15 @@
         {{ RO_ROOT_CMD }} chown root:root /etc/udev/rules.d/70-jaiabot_yubikey.rules
         
     - include_tasks: tasks/set-jaiabot-ssh-perms.yml
-        
-    - name: Install yubikey-manager
+      
+- name: Retrofit hubs with yubikey-manager
+  hosts: hubs
+  gather_facts: no
+  become: yes
+  pre_tasks:
+    - include_tasks: tasks/set-facts.yml
+  tasks:
+    - name: Install latest yubikey-manager
       shell: |
-        {{ RO_ROOT_CMD }} apt-get update && apt-get -y install yubikey-manager
+        apt-get -y install software-properties-common
+        {{ RO_ROOT_CMD }} add-apt-repository -y ppa:yubico/stable && apt-get -y install yubikey-manager libfido2-1

--- a/config/ansible/fleet/retrofit-ssh-config.yml
+++ b/config/ansible/fleet/retrofit-ssh-config.yml
@@ -6,6 +6,7 @@
   vars:
     rootfs_dir: "{{ (playbook_dir + '../../../../rootfs') | realpath }}"
     rootfs_includes_dir: "{{ rootfs_dir + '/customization/includes.chroot' }}"
+    config_dir: "{{ (rootfs_dir + '/../config') | realpath }}"
 
   pre_tasks:
     - include_tasks: tasks/set-facts.yml
@@ -15,7 +16,7 @@
         
     - name: Copy root ssh keys
       synchronize:
-        src: "{{ rootfs_includes_dir }}/etc/jaiabot/ssh/root_authorized_keys"
+        src: "{{ config_dir }}/ssh/root_authorized_keys"
         dest: "/tmp/root_authorized_keys"
         rsync_path: "sudo {{ RO_CMD }} rsync"
         

--- a/config/ansible/fleet/tasks/set-facts.yml
+++ b/config/ansible/fleet/tasks/set-facts.yml
@@ -36,7 +36,7 @@
 
 - name: Setup ssh dest variable
   set_fact:
-    HUB_DEST_KEYFILE: "{{ JAIA_SSH_DIR }}/id_{{ HUB_NAME }}"
+    HUB_DEST_KEYFILE: "{{ JAIA_SSH_DIR }}/{{ HUB_NAME }}"
   when: jaiabot_embedded_type == "hub"
 
 - name: Ensure .ssh exists


### PR DESCRIPTION
The Hub yubikey introduced in https://github.com/jaiarobotics/jaiabot/pull/896 does not work in Ubuntu jammy/focal as there's a race condition in the Yubico code that doesn't allow multiple SSH connections at once (you get an error `Failed to connect to the host via ssh: sign_and_send_pubkey: signing failed for ED25519-SK device not found` for some random subset of bots when using JCU).

This appears to be fixed in the latest Yubico code, so this PR updates the `config/ansible/fleet/retrofit-ssh-config.yml` playbook to install the latest PPA Yubico code on the hub. This issue also doesn't present itself in the Ubuntu 24.04 version of Yubico tools (for 2.y).

This PR also fixes a path mistake for the root_authorized_keys file (which was moved but not updated here).

Finally I changed the name of the hub SSH keys written by the old fleet config to match those created by the new fleet config (`~/.ssh/hubN_fleetM[.pub]` not `~/.ssh/id_hubN_fleet_M[.pub]`).

My suggested process for 2.y upgrades is:

- Create a new fleet config using `jaia admin fleet create` with a Yubikey
- Retrofit fleet with Hub Yubikey using old fleet config
  -  Retrofit SSH config to support Yubikeys
  - Setup SSH Keys amongst fleet
  - Reboot
- Add Yubikey to new fleet config
- Run 2.y major upgrade.


## TODO 

- consider scratching this PR in favor of simpler scenario - see TODO at https://github.com/jaiarobotics/jaiabot/pull/1123
- draft guidance with more detail on this process.
- add yubikey support to `jaia admin fleet create`
