### PR TITLE
bug/1.y/fix-docker-sim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,6 @@ filter-template-docker-sim-builds: &filter-template-docker-sim-builds
     branches:
       only:
         - "1.y"
-        - "bug/1.y/fix-docker-sim"
 
 ## Begin actual config
 version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ filter-template-docker-sim-builds: &filter-template-docker-sim-builds
     branches:
       only:
         - "1.y"
+        - "bug/1.y/fix-docker-sim"
 
 ## Begin actual config
 version: 2.1

--- a/scripts/sim-docker/entrypoint.sh
+++ b/scripts/sim-docker/entrypoint.sh
@@ -5,7 +5,8 @@ cd /jaiabot/build/amd64/share/jaiabot/web/server/
 source /jaiabot/build/web_dev/python/venv/bin/activate
 ./app.py &
 cd /jaiabot/build/amd64/share/jaiabot/web/rest_api/
-./app.py -e 1:localhost:40000 &
+./app.py &
 cd /jaiabot/config/launch/simulation/
+deactivate
 ./generate_all_launch.sh $JAIA_SIM_BOTS $JAIA_SIM_WARP
 ./all.launch


### PR DESCRIPTION
## Description
Need to deactivate python venv or else yaml module not found when starting the backend of the sim

## Testing
* Built the docker image
* Started container
* Confirmed the sim was up and running (JCC and REST API)