### PR TITLE
task/add-udev-rules-for-bio

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -50,7 +50,7 @@ if "jaia_arduino_type" in os.environ:
 if jaia_arduino_type == "spi":
     jaia_arduino_dev_location="/dev/ttyAMA1"
 elif jaia_arduino_type == 'usb':
-    jaia_arduino_dev_location="/dev/ttyUSB0"
+    jaia_arduino_dev_location="/dev/arduino"
 else:
     jaia_arduino_dev_location="/dev/ttyAMA1"
 

--- a/rootfs/customization/includes.chroot/etc/udev/rules.d/90-jaiabot_serial.rules
+++ b/rootfs/customization/includes.chroot/etc/udev/rules.d/90-jaiabot_serial.rules
@@ -1,6 +1,9 @@
-## arduino
-KERNEL=="ttyUSB0", SYMLINK+="arduino"
+## Arduino
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="arduino"
 
-## xbee
+## BIO payload board
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", SYMLINK+="bio-payload"
+
+## XBee
 KERNEL=="ttyAMA2", SYMLINK+="xbee"
 


### PR DESCRIPTION
## Summary
Distinguish between Arduino and BIO USB devices by evaluating the vendor and product IDs. The Arduino device lives at `/dev/arduino` and the BIO payload device lives at `/dev/bio-payload`. 

## Testing
* Applied the udev rules to to Fleet 0 Bot 2. 
* Ran `sudo udevadm control --reload-rules && sudo udevadm trigger`
* Connected and disconnected Arduino and BIO Payload USBs while viewing the list of devices

**Testing Matrix**

![image](https://github.com/user-attachments/assets/6504fd40-3ff8-481b-9b01-cc632389f813)

## Considerations
Will the Arduinos of older JaiaBots have the same vendor and product ID? A 2023 vehicle did have the same identification. The vendor and product ID comes from the USB to serial UART chip which on the Arduino Nano is the FT232R from Future Technology Devices International (https://ftdichip.com/wp-content/uploads/2020/08/DS_FT232R.pdf). As long as this chip does not change, we will not have a discovery problem. The vendor and product ID for this chip can be found on page 30 of the linked datasheet.

![P23069-L23046](https://github.com/user-attachments/assets/ef0540c2-81e3-4af0-825e-680d2974cf02)

