### PR TITLE
Fix bug where wrong git branch was selected for 'jaia admin fleet create'

### DIFF
--- a/scripts/fleet/jaia-create-fleet-config.sh
+++ b/scripts/fleet/jaia-create-fleet-config.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e -u
 
+script_dir=$(dirname $0)
+echo "script_dir: ${script_dir}"
 
 # --binary=jaia admin fleet create
 binary="$1"
@@ -229,7 +231,8 @@ echo "## (may take a bit to prepare)                      ##"
 echo "######################################################"
 
 
-git_branch=$(git branch --show-current 2> /dev/null || true)
+git_branch=$(cd ${script_dir}; git branch --show-current 2> /dev/null || true)
+echo "git branch: ${git_branch}"
 # if running in git, use the same rev
 if [ ! "${git_branch}" = "" ]; then
     git_branch_cmd="-b ${git_branch}"


### PR DESCRIPTION
If your working directory is a different git repo from `jaiabot`, the `jaia admin fleet create` would try to use that git branch to read the debconf settings from. This PR fixes it to use the correct branch (the `jaiabot` branch of the script).