### PR TITLE
task/publish-ph-do-temperature-readings

### DIFF
--- a/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
@@ -59,7 +59,14 @@ void jaiabot::apps::AtlasScientificOEMDODriver::receive_data(
                              << "Received do_data: " << do_data.ShortDebugString() << std::endl;
 
     jaiabot::sensor::protobuf::AtlasScientificOEMDO do_msg;
-    do_msg.set_dissolved_oxygen(do_data.dissolved_oxygen());
+    if (do_data.has_dissolved_oxygen())
+    {
+        do_msg.set_dissolved_oxygen(do_data.dissolved_oxygen());
+    }
+    if (do_data.has_temperature())
+    {
+        do_msg.set_temperature(do_data.temperature());
+    }
     interprocess().publish<jaiabot::groups::dissolved_oxygen>(do_msg);
 
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA thread

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
@@ -59,7 +59,15 @@ void jaiabot::apps::AtlasScientificOEMPHDriver::receive_data(
                              << "Received ph_data: " << ph_data.ShortDebugString() << std::endl;
 
     jaiabot::sensor::protobuf::AtlasScientificOEMpH ph_msg;
-    ph_msg.set_ph(ph_data.ph());
+
+    if (ph_data.has_ph())
+    {
+        ph_msg.set_ph(ph_data.ph());
+    }
+    if (ph_data.has_temperature())
+    {
+        ph_msg.set_temperature(ph_data.temperature());
+    }
     interprocess().publish<jaiabot::groups::ph>(ph_msg);
 
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA thread

--- a/src/bin/sensors/drivers/blue_robotics_bar30.cpp
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.cpp
@@ -22,6 +22,7 @@
 
 #include "blue_robotics_bar30.h"
 
+#include <boost/units/systems/temperature/celsius.hpp>
 #include <goby/time/system_clock.h>
 #include <goby/util/seawater/units.h>
 
@@ -69,6 +70,13 @@ void jaiabot::apps::BlueRoboticsBar30Driver::receive_data(
     {
         pressure_temperature_data.set_pressure_raw_with_units(bar30_data.pressure() * si::deci *
                                                               goby::util::seawater::bar);
+    }
+
+    if (bar30_data.has_temperature())
+    {
+        pressure_temperature_data.set_temperature_with_units(
+            bar30_data.temperature() *
+            boost::units::absolute<boost::units::celsius::temperature>());
     }
 
     interprocess().publish<jaiabot::groups::pressure_temperature>(pressure_temperature_data);


### PR DESCRIPTION
### Summary
The message definitions for pH, dissolved oxygen, and pressure/temperature already included a temperature field. We just needed to add the temperature data to the messages being published.