### PR TITLE
task/hide-mcu-raw-data-from-goby-logs

### DIFF
--- a/config/gen/common/logger.py
+++ b/config/gen/common/logger.py
@@ -3,9 +3,9 @@ import os
 # This is a map between the value of the environment variable and the regex
 #   to use to filter logging by group name
 GOBY_LOGGER_GROUP_REGEX_DICT = {
-    'RELEASE': r'(?!(.*_internal.*|.*moos.*|.*engineering.*)).*',
-    'ENGINEERING': r'(?!(.*_internal.*|.*moos.*)).*',
-    'DEBUG': r'(?!(.*_internal.*)).*'
+    'RELEASE': r'(?!(.*_internal.*|.*moos.*|.*engineering.*|.*mcu_pb_data.*)).*',
+    'ENGINEERING': r'(?!(.*_internal.*|.*moos.*|.*mcu_pb_data.*)).*',
+    'DEBUG': r'(?!(.*_internal.*|.*mcu_pb_data.*)).*'
 }
 
 


### PR DESCRIPTION
### Summary
Hides raw MCU data from Goby logs to prevent confusion that occurs when visualizing the oneof field in JDV.