### PR TITLE
bug/camera-driver-not-able-to-save-images

### DIFF
--- a/src/python/camera/camera_driver.py
+++ b/src/python/camera/camera_driver.py
@@ -32,7 +32,7 @@ def parse_args():
 
 
 def now_string():
-    return datetime.datetime.now().isoformat()
+    return datetime.datetime.now().strftime("%Y%m%d-%H%M%S-%f")
 
 
 class MockCamera:

--- a/src/python/camera/camera_driver.service.template
+++ b/src/python/camera/camera_driver.service.template
@@ -3,8 +3,8 @@ Description=JaiaBot Camera Driver
 
 [Service]
 Type=simple
-User=${USER}
-Group=${USER}
+User=root
+Group=root
 
 WorkingDirectory=/home/${USER}
 ExecStart=/home/${USER}/venv/bin/python3 ./camera/camera_driver.py --device /dev/ttyS0

--- a/src/python/camera/camera_driver.service.template
+++ b/src/python/camera/camera_driver.service.template
@@ -4,6 +4,8 @@ Description=JaiaBot Camera Driver
 [Service]
 Type=simple
 User=${USER}
+Group=${USER}
+
 WorkingDirectory=/home/${USER}
 ExecStart=/home/${USER}/venv/bin/python3 ./camera/camera_driver.py --device /dev/ttyS0
 


### PR DESCRIPTION
## Description

Change how we write the file names when taking images or videos so we do not have colons so now we have: Date (YYYYMMDD)- Time (HHMMSS) - Microseconds. The colons were causing an error when writing to /var/log/jaiabot.

## Testing

We tested this on one of the Bio bots