### PR TITLE
task/add-voltage-to-ph-do-and-fluorometer-messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
+        - "sub/skeleton-app-for-running-sensor-drivers"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "sub/skeleton-app-for-running-sensor-drivers"
+        - "task/add-voltage-to-ph-do-and-fluorometer-messages"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/add-voltage-to-ph-do-and-fluorometer-messages"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
@@ -67,6 +67,10 @@ void jaiabot::apps::AtlasScientificOEMDODriver::receive_data(
     {
         do_msg.set_temperature(do_data.temperature());
     }
+    if (do_data.has_temperature_voltage())
+    {
+        do_msg.set_temperature_voltage(do_data.temperature_voltage());
+    }
     interprocess().publish<jaiabot::groups::dissolved_oxygen>(do_msg);
 
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA thread

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
@@ -42,7 +42,7 @@ jaiabot::apps::AtlasScientificOEMPHDriver::AtlasScientificOEMPHDriver(
         });
 
     // configure our sensor
-    sensor::protobuf::SensorRequest request;
+    sensor::protobuf::SensorRequest request; 
     request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
     auto& sensor_cfg = *request.mutable_cfg();
     sensor_cfg.set_sensor(config.metadata().sensor());
@@ -67,6 +67,10 @@ void jaiabot::apps::AtlasScientificOEMPHDriver::receive_data(
     if (ph_data.has_temperature())
     {
         ph_msg.set_temperature(ph_data.temperature());
+    }
+    if (ph_data.has_temperature_voltage())
+    {
+        ph_msg.set_temperature_voltage(ph_data.temperature_voltage());
     }
     interprocess().publish<jaiabot::groups::ph>(ph_msg);
 

--- a/src/bin/sensors/drivers/turner__c_fluor.cpp
+++ b/src/bin/sensors/drivers/turner__c_fluor.cpp
@@ -59,7 +59,14 @@ void jaiabot::apps::TurnerCFluorDriver::receive_data(
                              << std::endl;
 
     jaiabot::sensor::protobuf::TurnerCFluor turner_c_fluor_msg;
-    turner_c_fluor_msg.set_concentration(turner_c_fluor_data.concentration());
+    if (turner_c_fluor_data.has_concentration())
+    {
+        turner_c_fluor_msg.set_concentration(turner_c_fluor_data.concentration());
+    }
+    if (turner_c_fluor_data.has_concentration_voltage())
+    {
+        turner_c_fluor_msg.set_concentration_voltage(turner_c_fluor_data.concentration_voltage());
+    }
     interprocess().publish<jaiabot::groups::concentration>(turner_c_fluor_msg);
 
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA threadcd

--- a/src/bin/sensors/drivers/turner__c_fluor.cpp
+++ b/src/bin/sensors/drivers/turner__c_fluor.cpp
@@ -67,7 +67,7 @@ void jaiabot::apps::TurnerCFluorDriver::receive_data(
     {
         turner_c_fluor_msg.set_concentration_voltage(turner_c_fluor_data.concentration_voltage());
     }
-    interprocess().publish<jaiabot::groups::concentration>(turner_c_fluor_msg);
+    interprocess().publish<jaiabot::groups::fluorometer>(turner_c_fluor_msg);
 
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA threadcd
 }

--- a/src/lib/groups.h
+++ b/src/lib/groups.h
@@ -45,7 +45,7 @@ constexpr goby::middleware::Group pressure_adjusted{"jaiabot::pressure_adjusted"
 constexpr goby::middleware::Group salinity{"jaiabot::salinity"};
 constexpr goby::middleware::Group dissolved_oxygen{"jaiabot::dissolved_oxygen"};
 constexpr goby::middleware::Group ph{"jaiabot::ph"};
-constexpr goby::middleware::Group concentration{"jaiabot::concentration"};
+constexpr goby::middleware::Group fluorometer{"jaiabot::fluorometer"};
 constexpr goby::middleware::Group echo{"jaiabot::echo"};
 constexpr goby::middleware::Group tsys01{"jaiabot::tsys01"};
 

--- a/src/lib/messages/sensor/atlas_scientific__oem_do.proto
+++ b/src/lib/messages/sensor/atlas_scientific__oem_do.proto
@@ -13,6 +13,7 @@ message AtlasScientificOEMDO
     // notional - add units and additional fields as needed
     optional double dissolved_oxygen = 1;
     optional double temperature = 2;
+    optional double temperature_voltage = 3;
 }
 
 

--- a/src/lib/messages/sensor/atlas_scientific__oem_ph.proto
+++ b/src/lib/messages/sensor/atlas_scientific__oem_ph.proto
@@ -13,6 +13,7 @@ message AtlasScientificOEMpH
     // notional - add units and additional fields as needed
     optional double ph = 1;
     optional double temperature = 2;
+    optional double temperature_voltage = 3;
 }
 
 

--- a/src/lib/messages/sensor/turner__c_fluor.proto
+++ b/src/lib/messages/sensor/turner__c_fluor.proto
@@ -12,6 +12,7 @@ message TurnerCFluor
 
     // notional - add units and additional fields as needed
     optional double concentration = 1;
+    optional double concentration_voltage = 2;
 }
 
 


### PR DESCRIPTION
This branch changes the name of the fluorometer group from "concentration" to "fluorometer" to better reflect the actual sensor. It also adds logging for the pH and DO temperature raw voltages, as well as the fluorometer concentration's raw voltage. These voltage values come from the STM32's 12 bit ADC.