### PR TITLE
task/show-errors-for-failed-bio-sensor-initializations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/show-errors-for-failed-bio-sensor-initializations"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "sub/skeleton-app-for-running-sensor-drivers"
+        - "task/show-errors-for-failed-bio-sensor-initializations"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -236,6 +236,7 @@ void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::M
     if (metadata.init_failed())
     {
         failed_initializations.insert(metadata.sensor());
+        return;
     }
 
     switch (metadata.sensor())

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -28,13 +28,14 @@
 #include <goby/zeromq/application/multi_thread.h>
 
 #include "config.pb.h"
-#include "drivers/atlas_scientific__oem_ec.h"
 #include "drivers/atlas_scientific__oem_do.h"
+#include "drivers/atlas_scientific__oem_ec.h"
 #include "drivers/atlas_scientific__oem_ph.h"
 #include "drivers/blue_robotics_bar30.h"
 #include "drivers/turner__c_fluor.h"
 #include "jaiabot/crc/crc32.h"
 #include "jaiabot/groups.h"
+#include "jaiabot/messages/health.pb.h"
 #include "jaiabot/messages/sensor/catalog.pb.h"
 #include "jaiabot/messages/sensor/sensor_core.pb.h"
 
@@ -60,6 +61,7 @@ class Sensors : public zeromq::MultiThreadApplication<config::Sensors>
 
   private:
     void loop() override;
+    void health(goby::middleware::protobuf::ThreadHealth& health) override;
     void query_metadata();
     void send_to_mcu(sensor::protobuf::SensorRequest request);
     void receive_from_mcu(const goby::middleware::protobuf::IOData& io_msg);
@@ -67,6 +69,8 @@ class Sensors : public zeromq::MultiThreadApplication<config::Sensors>
 
   private:
     std::set<jaiabot::sensor::protobuf::Sensor> drivers_launched_;
+    std::set<jaiabot::sensor::protobuf::Sensor> failed_initializations;
+    std::map<jaiabot::sensor::protobuf::Sensor, jaiabot::protobuf::Warning> warning_names;
     boost::crc_32_type crc32_calc_;
 };
 
@@ -100,6 +104,17 @@ jaiabot::apps::Sensors::Sensors()
         [this](const sensor::protobuf::SensorRequest& request) { send_to_mcu(request); });
 
     launch_thread<MCUSerialThread>(cfg().mcu_serial());
+
+    warning_names = {{jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_DO,
+                      jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_DO},
+                     {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_EC,
+                      jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_EC},
+                     {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_PH,
+                      jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_PH},
+                     {jaiabot::sensor::protobuf::BLUE_ROBOTICS__BAR30,
+                      jaiabot::protobuf::WARNING__INIT_FAILED__BLUE_ROBOTICS__BAR30},
+                     {jaiabot::sensor::protobuf::TURNER__C_FLUOR,
+                      jaiabot::protobuf::WARNING__INIT_FAILED__TURNER__C_FLUOR}};
 }
 
 void jaiabot::apps::Sensors::loop()
@@ -108,6 +123,17 @@ void jaiabot::apps::Sensors::loop()
     {
         // keep querying the MCU until it responds with at least one sensor
         query_metadata();
+    }
+}
+
+void jaiabot::apps::Sensors::health(goby::middleware::protobuf::ThreadHealth& health)
+{
+    health.ClearExtension(jaiabot::protobuf::jaiabot_thread);
+
+    for (const jaiabot::sensor::protobuf::Sensor& sensor : failed_initializations)
+    {
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+            ->add_warning(warning_names.at(sensor));
     }
 }
 
@@ -205,6 +231,11 @@ void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::M
                                << ", not launching another." << std::endl;
 
         return;
+    }
+
+    if (metadata.init_failed())
+    {
+        failed_initializations.insert(metadata.sensor());
     }
 
     switch (metadata.sensor())

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -70,7 +70,10 @@ class Sensors : public zeromq::MultiThreadApplication<config::Sensors>
   private:
     std::set<jaiabot::sensor::protobuf::Sensor> drivers_launched_;
     std::set<jaiabot::sensor::protobuf::Sensor> failed_initializations;
-    std::map<jaiabot::sensor::protobuf::Sensor, jaiabot::protobuf::Warning> warning_names;
+    std::map<jaiabot::sensor::protobuf::Sensor, jaiabot::protobuf::Error>
+        initialization_error_names;
+    std::map<jaiabot::sensor::protobuf::Sensor, jaiabot::protobuf::Warning>
+        initialization_warning_names;
     boost::crc_32_type crc32_calc_;
 };
 
@@ -105,16 +108,18 @@ jaiabot::apps::Sensors::Sensors()
 
     launch_thread<MCUSerialThread>(cfg().mcu_serial());
 
-    warning_names = {{jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_DO,
-                      jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_DO},
-                     {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_EC,
-                      jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_EC},
-                     {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_PH,
-                      jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_PH},
-                     {jaiabot::sensor::protobuf::BLUE_ROBOTICS__BAR30,
-                      jaiabot::protobuf::WARNING__INIT_FAILED__BLUE_ROBOTICS__BAR30},
-                     {jaiabot::sensor::protobuf::TURNER__C_FLUOR,
-                      jaiabot::protobuf::WARNING__INIT_FAILED__TURNER__C_FLUOR}};
+    initialization_error_names = {{jaiabot::sensor::protobuf::BLUE_ROBOTICS__BAR30,
+                                   jaiabot::protobuf::ERROR__INIT_FAILED__BLUE_ROBOTICS__BAR30}};
+
+    initialization_warning_names = {
+        {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_DO,
+         jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_DO},
+        {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_EC,
+         jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_EC},
+        {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_PH,
+         jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_PH},
+        {jaiabot::sensor::protobuf::TURNER__C_FLUOR,
+         jaiabot::protobuf::WARNING__INIT_FAILED__TURNER__C_FLUOR}};
 }
 
 void jaiabot::apps::Sensors::loop()
@@ -132,8 +137,16 @@ void jaiabot::apps::Sensors::health(goby::middleware::protobuf::ThreadHealth& he
 
     for (const jaiabot::sensor::protobuf::Sensor& sensor : failed_initializations)
     {
-        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
-            ->add_warning(warning_names.at(sensor));
+        if (initialization_error_names.count(sensor) == 1)
+        {
+            health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+                ->add_error(initialization_error_names.at(sensor));
+        }
+        else if (initialization_warning_names.count(sensor) == 1)
+        {
+            health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+                ->add_warning(initialization_warning_names.at(sensor));
+        }
     }
 }
 

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -115,7 +115,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xa7c151e4dbded035")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0x3ed9fba514d62f4f")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xd6cdaf32db2fd089")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0xf4bad9b633f50b7f")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -115,7 +115,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xe76c215fa5d3b82d")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xa7c151e4dbded035")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xd6cdaf32db2fd089")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0xf4bad9b633f50b7f")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -115,7 +115,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xd8d3c53b6ab73fc5")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xf91b23b48d5fb564")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xd6cdaf32db2fd089")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0xf4bad9b633f50b7f")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -115,7 +115,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0x3ed9fba514d62f4f")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xa7c151e4dbded035")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xd6cdaf32db2fd089")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0xf4bad9b633f50b7f")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/health.proto
+++ b/src/lib/messages/health.proto
@@ -320,6 +320,18 @@ enum Warning
         [(jaia.ev).rest_api.presence = GUARANTEED];
     WARNING__MISSION__DATA_POST_OFFLOAD_FAILED = 723
         [(jaia.ev).rest_api.presence = GUARANTEED];
+    
+    // from jaiabot_sensors
+    WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_DO = 800
+        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_EC = 801
+        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_PH = 802
+        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__INIT_FAILED__BLUE_ROBOTICS__BAR30 = 803
+        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__INIT_FAILED__TURNER__C_FLUOR = 804
+        [(jaia.ev).rest_api.presence = GUARANTEED];
 }
 
 message LinuxHardwareStatus

--- a/src/lib/messages/health.proto
+++ b/src/lib/messages/health.proto
@@ -225,6 +225,10 @@ enum Error
     ];  // INTERVEHICLE_API_VERSION_mismatch - hub_version > bot_version
     ERROR__ARDUINO_CONNECTION_FAILED = 704
         [(jaia.ev).rest_api.presence = GUARANTEED];
+
+    // jaiabot sensors
+    ERROR__INIT_FAILED__BLUE_ROBOTICS__BAR30 = 800
+        [(jaia.ev).rest_api.presence = GUARANTEED];
 }
 
 enum Warning
@@ -328,9 +332,7 @@ enum Warning
         [(jaia.ev).rest_api.presence = GUARANTEED];
     WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_PH = 802
         [(jaia.ev).rest_api.presence = GUARANTEED];
-    WARNING__INIT_FAILED__BLUE_ROBOTICS__BAR30 = 803
-        [(jaia.ev).rest_api.presence = GUARANTEED];
-    WARNING__INIT_FAILED__TURNER__C_FLUOR = 804
+    WARNING__INIT_FAILED__TURNER__C_FLUOR = 803
         [(jaia.ev).rest_api.presence = GUARANTEED];
 }
 

--- a/src/lib/messages/sensor/metadata.proto
+++ b/src/lib/messages/sensor/metadata.proto
@@ -43,5 +43,6 @@ message Metadata
     }
 
     repeated MetadataValue metadata = 5 [(nanopb).max_count = 16];
+    optional bool init_failed = 6;
 }
 

--- a/src/lib/messages/sensor/metadata.proto
+++ b/src/lib/messages/sensor/metadata.proto
@@ -44,6 +44,6 @@ message Metadata
     }
 
     repeated MetadataValue metadata = 5 [(nanopb).max_count = 16];
-    optional bool init_failed = 6;
+    optional bool init_failed = 7;
 }
 


### PR DESCRIPTION
### Overview
When a sensor on the BIO payload board does not initialize successfully, a warning will appear in the JCC to alert the operator.

### Implementation
1. A failed initialization will result in the FAILED value living in the `Sensors` array on the STM32 for the particular sensor.

2. When the metadata is transmitted for each sensor, if it is in a `FAILED` state, then the `Metadata` message will contain the field `init_failed` which will be set to true.

3. The `jaiabot_sensors` application will process the incoming metadata. If it comes across a message that has the `init_failed` field set to true, it will insert the sensor into the `failed_initializtions` set.

4. The overridden `health` function will add a warning to the health thread for the sensor that failed. For example, `jaiabot::protobuf::WARNING__INIT_FAILED__TURNER__C_FLUOR.`

5. This addition will be picked up by the JCC code and display in the Bot details panel.

### Testing
**Bar30 Failed Initialization**
![bar30-failed-initialization](https://github.com/user-attachments/assets/9913aeea-2198-463a-8a25-c1503f8c443f)

**All Sensors Failed Initializations**
![all-sensor-failed-initializations](https://github.com/user-attachments/assets/9fea1339-1e8c-49d8-ae8a-e44e62400dd2)
