### PR TITLE
feature/add-error-handling-for-missing-sensor-data-mcu

### DIFF
--- a/config/templates/bot/jaiabot_sensors.pb.cfg.in
+++ b/config/templates/bot/jaiabot_sensors.pb.cfg.in
@@ -4,5 +4,4 @@ mcu_serial {
     port: "$port"
     baud: $baud
 }
-sample_rate: 10
 

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -192,10 +192,6 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
 
 void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::Metadata& metadata)
 {
-    sensor::protobuf::SensorThreadConfig thread_cfg;
-    thread_cfg.mutable_metadata()->CopyFrom(metadata);
-    thread_cfg.set_sample_rate(cfg().sample_rate());
-
     if (drivers_launched_.count(metadata.sensor()))
     {
         glog.is_warn() && glog << "Driver already launched for sensor: "
@@ -208,23 +204,23 @@ void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::M
     switch (metadata.sensor())
     {
         case sensor::protobuf::ATLAS_SCIENTIFIC__OEM_EC:
-            launch_thread<AtlasScientificOEMECDriver>(thread_cfg);
+            launch_thread<AtlasScientificOEMECDriver>(cfg().ec());
             break;
 
         case sensor::protobuf::BLUE_ROBOTICS__BAR30:
-            launch_thread<BlueRoboticsBar30Driver>(thread_cfg);
+            launch_thread<BlueRoboticsBar30Driver>(cfg().bar30());
             break;
 
         case sensor::protobuf::ATLAS_SCIENTIFIC__OEM_PH:
-            launch_thread<AtlasScientificOEMPHDriver>(thread_cfg);
+            launch_thread<AtlasScientificOEMPHDriver>(cfg().ph());
             break;
 
         case sensor::protobuf::ATLAS_SCIENTIFIC__OEM_DO:
-            launch_thread<AtlasScientificOEMDODriver>(thread_cfg);
+            launch_thread<AtlasScientificOEMDODriver>(cfg().dissolved_oxygen());
             break;
 
         case sensor::protobuf::TURNER__C_FLUOR:
-            launch_thread<TurnerCFluorDriver>(thread_cfg);
+            launch_thread<TurnerCFluorDriver>(cfg().fluorometer());
             break;
 
         default:

--- a/src/bin/sensors/config.proto
+++ b/src/bin/sensors/config.proto
@@ -32,30 +32,35 @@ message AtlasOEMECThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
+    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
 }
 
 message BlueRoboticsBar30ThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
+    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
 }
 
 message AtlasOEMPHThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
+    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
 }
 
 message AtlasOEMDOThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
+    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
 }
 
 message TurnorCFluorThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
+    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
 }
 
 message Sensors

--- a/src/bin/sensors/config.proto
+++ b/src/bin/sensors/config.proto
@@ -32,35 +32,35 @@ message AtlasOEMECThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
-    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
+    optional int32 resend_cfg_timeout_seconds = 3 [default = 20];
 }
 
 message BlueRoboticsBar30ThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
-    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
+    optional int32 resend_cfg_timeout_seconds = 3 [default = 20];
 }
 
 message AtlasOEMPHThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
-    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
+    optional int32 resend_cfg_timeout_seconds = 3 [default = 20];
 }
 
 message AtlasOEMDOThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
-    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
+    optional int32 resend_cfg_timeout_seconds = 3 [default = 20];
 }
 
 message TurnorCFluorThreadConfig
 {
     optional int32 sample_rate = 1 [default = 10];
     optional int32 report_timeout_seconds = 2 [default = 20];
-    optional int32 trigger_cfg_resend_timeout_seconds = 3 [default = 20];
+    optional int32 resend_cfg_timeout_seconds = 3 [default = 20];
 }
 
 message Sensors

--- a/src/bin/sensors/config.proto
+++ b/src/bin/sensors/config.proto
@@ -28,10 +28,44 @@ import "goby/middleware/protobuf/serial_config.proto";
 
 package jaiabot.config;
 
+message AtlasOEMECThreadConfig
+{
+    optional int32 sample_rate = 1 [default = 10];
+    optional int32 report_timeout_seconds = 2 [default = 20];
+}
+
+message BlueRoboticsBar30ThreadConfig
+{
+    optional int32 sample_rate = 1 [default = 10];
+    optional int32 report_timeout_seconds = 2 [default = 20];
+}
+
+message AtlasOEMPHThreadConfig
+{
+    optional int32 sample_rate = 1 [default = 10];
+    optional int32 report_timeout_seconds = 2 [default = 20];
+}
+
+message AtlasOEMDOThreadConfig
+{
+    optional int32 sample_rate = 1 [default = 10];
+    optional int32 report_timeout_seconds = 2 [default = 20];
+}
+
+message TurnorCFluorThreadConfig
+{
+    optional int32 sample_rate = 1 [default = 10];
+    optional int32 report_timeout_seconds = 2 [default = 20];
+}
+
 message Sensors
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
     optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
     optional goby.middleware.protobuf.SerialConfig mcu_serial = 3;
-    optional int32 sample_rate = 4;
+    optional AtlasOEMECThreadConfig ec = 10;
+    optional BlueRoboticsBar30ThreadConfig bar30 = 20;
+    optional AtlasOEMPHThreadConfig ph = 30;
+    optional AtlasOEMDOThreadConfig dissolved_oxygen = 40;
+    optional TurnorCFluorThreadConfig fluorometer = 50;  
 }

--- a/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
@@ -45,7 +45,7 @@ jaiabot::apps::AtlasScientificOEMDODriver::AtlasScientificOEMDODriver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    last_report_time_ = goby::time::SteadyClock::now();
+    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -96,7 +96,13 @@ void jaiabot::apps::AtlasScientificOEMDODriver::health(
         health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
             ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_DO_DATA);
 
-        send_cfg();
+        // Send configuration request at a configured rate
+        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+            goby::time::SteadyClock::now())
+        {
+            send_cfg();
+            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+        }
     }
 
     health.set_state(health_state);

--- a/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
@@ -45,7 +45,7 @@ jaiabot::apps::AtlasScientificOEMDODriver::AtlasScientificOEMDODriver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
+    resend_cfg_timeout_ = config.resend_cfg_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -97,11 +97,11 @@ void jaiabot::apps::AtlasScientificOEMDODriver::health(
             ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_DO_DATA);
 
         // Send configuration request at a configured rate
-        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+        if (last_resend_cfg_time_ + std::chrono::seconds(resend_cfg_timeout_) <
             goby::time::SteadyClock::now())
         {
             send_cfg();
-            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+            last_resend_cfg_time_ = goby::time::SteadyClock::now();
         }
     }
 

--- a/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_do.cpp
@@ -28,8 +28,8 @@
 using goby::glog;
 
 jaiabot::apps::AtlasScientificOEMDODriver::AtlasScientificOEMDODriver(
-    const jaiabot::sensor::protobuf::SensorThreadConfig& config)
-    : goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>(config)
+    const jaiabot::config::AtlasOEMDOThreadConfig& config)
+    : goby::middleware::SimpleThread<jaiabot::config::AtlasOEMDOThreadConfig>(config)
 
 {
     glog.add_group("oem_do", goby::util::Colors::blue);
@@ -40,15 +40,15 @@ jaiabot::apps::AtlasScientificOEMDODriver::AtlasScientificOEMDODriver(
                 receive_data(sensor_data.oem_do());
         });
 
-    // configure our sensor
-    sensor::protobuf::SensorRequest request;
-    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
-    auto& sensor_cfg = *request.mutable_cfg();
-    sensor_cfg.set_sensor(config.metadata().sensor());
+    // Set sample rate config
+    sample_rate_ = config.sample_rate();
 
-    // TODO - hardcode or configuration?
-    sensor_cfg.set_sample_freq_with_units(config.sample_rate() * boost::units::si::hertz);
-    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+    // Set timeout on missing report
+    report_timeout_ = config.report_timeout_seconds();
+    last_report_time_ = goby::time::SteadyClock::now();
+
+    // configure our sensor
+    send_cfg();
 }
 
 void jaiabot::apps::AtlasScientificOEMDODriver::receive_data(
@@ -68,5 +68,36 @@ void jaiabot::apps::AtlasScientificOEMDODriver::receive_data(
     }
     interprocess().publish<jaiabot::groups::dissolved_oxygen>(do_msg);
 
+    last_report_time_ = goby::time::SteadyClock::now();
+
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA thread
+}
+
+void jaiabot::apps::AtlasScientificOEMDODriver::send_cfg()
+{
+    sensor::protobuf::SensorRequest request;
+    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
+    auto& sensor_cfg = *request.mutable_cfg();
+    sensor_cfg.set_sensor(jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_DO);
+
+    sensor_cfg.set_sample_freq_with_units(sample_rate_ * boost::units::si::hertz);
+    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+}
+
+void jaiabot::apps::AtlasScientificOEMDODriver::health(
+    goby::middleware::protobuf::ThreadHealth& health)
+{
+    auto health_state = goby::middleware::protobuf::HEALTH__OK;
+
+    if (last_report_time_ + std::chrono::seconds(report_timeout_) < goby::time::SteadyClock::now())
+    {
+        glog.is_warn() && glog << "Timeout on atlas oem do report" << std::endl;
+        health_state = goby::middleware::protobuf::HEALTH__DEGRADED;
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+            ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_DO_DATA);
+
+        send_cfg();
+    }
+
+    health.set_state(health_state);
 }

--- a/src/bin/sensors/drivers/atlas_scientific__oem_do.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_do.h
@@ -23,6 +23,8 @@
 #ifndef JAIABOT_SENSORS_DRIVERS_ATLAS_SCIENTIFIC_OEM_DO_H
 #define JAIABOT_SENSORS_DRIVERS_ATLAS_SCIENTIFIC_OEM_DO_H
 
+#include "config.pb.h"
+#include "jaiabot/messages/health.pb.h"
 #include "jaiabot/messages/sensor/atlas_scientific__oem_do.pb.h"
 #include "jaiabot/messages/sensor/sensor_core.pb.h"
 #include <goby/zeromq/application/multi_thread.h>
@@ -32,13 +34,20 @@ namespace jaiabot
 namespace apps
 {
 class AtlasScientificOEMDODriver
-    : public goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>
+    : public goby::middleware::SimpleThread<jaiabot::config::AtlasOEMDOThreadConfig>
 {
   public:
-    AtlasScientificOEMDODriver(const jaiabot::sensor::protobuf::SensorThreadConfig& config);
+    AtlasScientificOEMDODriver(const jaiabot::config::AtlasOEMDOThreadConfig& config);
 
   private:
     void receive_data(const sensor::protobuf::AtlasScientificOEMDO& do_data);
+    void health(goby::middleware::protobuf::ThreadHealth& health) override;
+    void send_cfg();
+
+  private:
+    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    int32_t sample_rate_{10};
+    int32_t report_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/atlas_scientific__oem_do.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_do.h
@@ -45,9 +45,12 @@ class AtlasScientificOEMDODriver
     void send_cfg();
 
   private:
-    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
+        goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
+    int32_t trigger_cfg_resend_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/atlas_scientific__oem_do.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_do.h
@@ -46,11 +46,10 @@ class AtlasScientificOEMDODriver
 
   private:
     goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
-    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
-        goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_resend_cfg_time_{goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
-    int32_t trigger_cfg_resend_timeout_{20};
+    int32_t resend_cfg_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ec.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ec.cpp
@@ -45,7 +45,7 @@ jaiabot::apps::AtlasScientificOEMECDriver::AtlasScientificOEMECDriver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
+    resend_cfg_timeout_ = config.resend_cfg_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -101,11 +101,11 @@ void jaiabot::apps::AtlasScientificOEMECDriver::health(
             ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_EC_DATA);
 
         // Send configuration request at a configured rate
-        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+        if (last_resend_cfg_time_ + std::chrono::seconds(resend_cfg_timeout_) <
             goby::time::SteadyClock::now())
         {
             send_cfg();
-            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+            last_resend_cfg_time_ = goby::time::SteadyClock::now();
         }
     }
 

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ec.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ec.cpp
@@ -28,8 +28,8 @@
 using goby::glog;
 
 jaiabot::apps::AtlasScientificOEMECDriver::AtlasScientificOEMECDriver(
-    const jaiabot::sensor::protobuf::SensorThreadConfig& config)
-    : goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>(config)
+    const jaiabot::config::AtlasOEMECThreadConfig& config)
+    : goby::middleware::SimpleThread<jaiabot::config::AtlasOEMECThreadConfig>(config)
 
 {
     glog.add_group("oem_ec", goby::util::Colors::blue);
@@ -40,14 +40,15 @@ jaiabot::apps::AtlasScientificOEMECDriver::AtlasScientificOEMECDriver(
                 receive_data(sensor_data.oem_ec());
         });
 
-    // configure our sensor
-    sensor::protobuf::SensorRequest request;
-    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
-    auto& sensor_cfg = *request.mutable_cfg();
-    sensor_cfg.set_sensor(config.metadata().sensor());
+    // Set sample rate config
+    sample_rate_ = config.sample_rate();
 
-    sensor_cfg.set_sample_freq_with_units(config.sample_rate() * boost::units::si::hertz);
-    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+    // Set timeout on missing report
+    report_timeout_ = config.report_timeout_seconds();
+    last_report_time_ = goby::time::SteadyClock::now();
+
+    // configure our sensor
+    send_cfg();
 }
 
 void jaiabot::apps::AtlasScientificOEMECDriver::receive_data(
@@ -71,5 +72,36 @@ void jaiabot::apps::AtlasScientificOEMECDriver::receive_data(
     }
     interprocess().publish<jaiabot::groups::salinity>(ec_msg);
 
+    last_report_time_ = goby::time::SteadyClock::now();
+
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA thread
+}
+
+void jaiabot::apps::AtlasScientificOEMECDriver::send_cfg()
+{
+    sensor::protobuf::SensorRequest request;
+    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
+    auto& sensor_cfg = *request.mutable_cfg();
+    sensor_cfg.set_sensor(jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_EC);
+
+    sensor_cfg.set_sample_freq_with_units(sample_rate_ * boost::units::si::hertz);
+    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+}
+
+void jaiabot::apps::AtlasScientificOEMECDriver::health(
+    goby::middleware::protobuf::ThreadHealth& health)
+{
+    auto health_state = goby::middleware::protobuf::HEALTH__OK;
+
+    if (last_report_time_ + std::chrono::seconds(report_timeout_) < goby::time::SteadyClock::now())
+    {
+        glog.is_warn() && glog << "Timeout on atlas oem ec report" << std::endl;
+        health_state = goby::middleware::protobuf::HEALTH__DEGRADED;
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+            ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_EC_DATA);
+
+        send_cfg();
+    }
+
+    health.set_state(health_state);
 }

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ec.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ec.cpp
@@ -45,7 +45,7 @@ jaiabot::apps::AtlasScientificOEMECDriver::AtlasScientificOEMECDriver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    last_report_time_ = goby::time::SteadyClock::now();
+    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -100,7 +100,13 @@ void jaiabot::apps::AtlasScientificOEMECDriver::health(
         health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
             ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_EC_DATA);
 
-        send_cfg();
+        // Send configuration request at a configured rate
+        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+            goby::time::SteadyClock::now())
+        {
+            send_cfg();
+            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+        }
     }
 
     health.set_state(health_state);

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ec.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ec.h
@@ -45,9 +45,12 @@ class AtlasScientificOEMECDriver
     void send_cfg();
 
   private:
-    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
+        goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
+    int32_t trigger_cfg_resend_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ec.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ec.h
@@ -46,11 +46,10 @@ class AtlasScientificOEMECDriver
 
   private:
     goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
-    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
-        goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_resend_cfg_time_{goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
-    int32_t trigger_cfg_resend_timeout_{20};
+    int32_t resend_cfg_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ec.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ec.h
@@ -23,6 +23,8 @@
 #ifndef JAIABOT_SENSORS_DRIVERS_ATLAS_SCIENTIFIC_OEM_EC_H
 #define JAIABOT_SENSORS_DRIVERS_ATLAS_SCIENTIFIC_OEM_EC_H
 
+#include "config.pb.h"
+#include "jaiabot/messages/health.pb.h"
 #include "jaiabot/messages/sensor/atlas_scientific__oem_ec.pb.h"
 #include "jaiabot/messages/sensor/sensor_core.pb.h"
 #include <goby/zeromq/application/multi_thread.h>
@@ -32,13 +34,20 @@ namespace jaiabot
 namespace apps
 {
 class AtlasScientificOEMECDriver
-    : public goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>
+    : public goby::middleware::SimpleThread<jaiabot::config::AtlasOEMECThreadConfig>
 {
   public:
-    AtlasScientificOEMECDriver(const jaiabot::sensor::protobuf::SensorThreadConfig& config);
+    AtlasScientificOEMECDriver(const jaiabot::config::AtlasOEMECThreadConfig& config);
 
   private:
     void receive_data(const sensor::protobuf::AtlasScientificOEMEC& ec_data);
+    void health(goby::middleware::protobuf::ThreadHealth& health) override;
+    void send_cfg();
+
+  private:
+    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    int32_t sample_rate_{10};
+    int32_t report_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
@@ -45,7 +45,7 @@ jaiabot::apps::AtlasScientificOEMPHDriver::AtlasScientificOEMPHDriver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    last_report_time_ = goby::time::SteadyClock::now();
+    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -97,7 +97,13 @@ void jaiabot::apps::AtlasScientificOEMPHDriver::health(
         health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
             ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_PH_DATA);
 
-        send_cfg();
+        // Send configuration request at a configured rate
+        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+            goby::time::SteadyClock::now())
+        {
+            send_cfg();
+            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+        }
     }
 
     health.set_state(health_state);

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
@@ -28,8 +28,8 @@
 using goby::glog;
 
 jaiabot::apps::AtlasScientificOEMPHDriver::AtlasScientificOEMPHDriver(
-    const jaiabot::sensor::protobuf::SensorThreadConfig& config)
-    : goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>(config)
+    const jaiabot::config::AtlasOEMPHThreadConfig& config)
+    : goby::middleware::SimpleThread<jaiabot::config::AtlasOEMPHThreadConfig>(config)
 
 {
     glog.add_group("oem_ph", goby::util::Colors::blue);
@@ -40,15 +40,15 @@ jaiabot::apps::AtlasScientificOEMPHDriver::AtlasScientificOEMPHDriver(
                 receive_data(sensor_data.oem_ph());
         });
 
-    // configure our sensor
-    sensor::protobuf::SensorRequest request;
-    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
-    auto& sensor_cfg = *request.mutable_cfg();
-    sensor_cfg.set_sensor(config.metadata().sensor());
+    // Set sample rate config
+    sample_rate_ = config.sample_rate();
 
-    // TODO - hardcode or configuration?
-    sensor_cfg.set_sample_freq_with_units(config.sample_rate() * boost::units::si::hertz);
-    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+    // Set timeout on missing report
+    report_timeout_ = config.report_timeout_seconds();
+    last_report_time_ = goby::time::SteadyClock::now();
+
+    // configure our sensor
+    send_cfg();
 }
 
 void jaiabot::apps::AtlasScientificOEMPHDriver::receive_data(
@@ -69,5 +69,36 @@ void jaiabot::apps::AtlasScientificOEMPHDriver::receive_data(
     }
     interprocess().publish<jaiabot::groups::ph>(ph_msg);
 
+    last_report_time_ = goby::time::SteadyClock::now();
+
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA thread
+}
+
+void jaiabot::apps::AtlasScientificOEMPHDriver::send_cfg()
+{
+    sensor::protobuf::SensorRequest request;
+    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
+    auto& sensor_cfg = *request.mutable_cfg();
+    sensor_cfg.set_sensor(jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_PH);
+
+    sensor_cfg.set_sample_freq_with_units(sample_rate_ * boost::units::si::hertz);
+    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+}
+
+void jaiabot::apps::AtlasScientificOEMPHDriver::health(
+    goby::middleware::protobuf::ThreadHealth& health)
+{
+    auto health_state = goby::middleware::protobuf::HEALTH__OK;
+
+    if (last_report_time_ + std::chrono::seconds(report_timeout_) < goby::time::SteadyClock::now())
+    {
+        glog.is_warn() && glog << "Timeout on atlas oem ph report" << std::endl;
+        health_state = goby::middleware::protobuf::HEALTH__DEGRADED;
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+            ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_PH_DATA);
+
+        send_cfg();
+    }
+
+    health.set_state(health_state);
 }

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ph.cpp
@@ -45,7 +45,7 @@ jaiabot::apps::AtlasScientificOEMPHDriver::AtlasScientificOEMPHDriver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
+    resend_cfg_timeout_ = config.resend_cfg_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -98,11 +98,11 @@ void jaiabot::apps::AtlasScientificOEMPHDriver::health(
             ->add_warning(protobuf::WARNING__MISSING_DATA__ATLAS_OEM_PH_DATA);
 
         // Send configuration request at a configured rate
-        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+        if (last_resend_cfg_time_ + std::chrono::seconds(resend_cfg_timeout_) <
             goby::time::SteadyClock::now())
         {
             send_cfg();
-            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+            last_resend_cfg_time_ = goby::time::SteadyClock::now();
         }
     }
 

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ph.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ph.h
@@ -45,9 +45,12 @@ class AtlasScientificOEMPHDriver
     void send_cfg();
 
   private:
-    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
+        goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
+    int32_t trigger_cfg_resend_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ph.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ph.h
@@ -46,11 +46,10 @@ class AtlasScientificOEMPHDriver
 
   private:
     goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
-    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
-        goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_resend_cfg_time_{goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
-    int32_t trigger_cfg_resend_timeout_{20};
+    int32_t resend_cfg_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/atlas_scientific__oem_ph.h
+++ b/src/bin/sensors/drivers/atlas_scientific__oem_ph.h
@@ -23,6 +23,8 @@
 #ifndef JAIABOT_SENSORS_DRIVERS_ATLAS_SCIENTIFIC_OEM_PH_H
 #define JAIABOT_SENSORS_DRIVERS_ATLAS_SCIENTIFIC_OEM_PH_H
 
+#include "config.pb.h"
+#include "jaiabot/messages/health.pb.h"
 #include "jaiabot/messages/sensor/atlas_scientific__oem_ph.pb.h"
 #include "jaiabot/messages/sensor/sensor_core.pb.h"
 #include <goby/zeromq/application/multi_thread.h>
@@ -32,13 +34,20 @@ namespace jaiabot
 namespace apps
 {
 class AtlasScientificOEMPHDriver
-    : public goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>
+    : public goby::middleware::SimpleThread<jaiabot::config::AtlasOEMPHThreadConfig>
 {
   public:
-    AtlasScientificOEMPHDriver(const jaiabot::sensor::protobuf::SensorThreadConfig& config);
+    AtlasScientificOEMPHDriver(const jaiabot::config::AtlasOEMPHThreadConfig& config);
 
   private:
     void receive_data(const sensor::protobuf::AtlasScientificOEMpH& ph_data);
+    void health(goby::middleware::protobuf::ThreadHealth& health) override;
+    void send_cfg();
+
+  private:
+    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    int32_t sample_rate_{10};
+    int32_t report_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/blue_robotics_bar30.cpp
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.cpp
@@ -50,7 +50,7 @@ jaiabot::apps::BlueRoboticsBar30Driver::BlueRoboticsBar30Driver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
+    resend_cfg_timeout_ = config.resend_cfg_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -110,11 +110,11 @@ void jaiabot::apps::BlueRoboticsBar30Driver::health(
             ->add_error(protobuf::ERROR__MISSING_DATA__BLUEROBOTICS_BAR30_DATA);
 
         // Send configuration request at a configured rate
-        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+        if (last_resend_cfg_time_ + std::chrono::seconds(resend_cfg_timeout_) <
             goby::time::SteadyClock::now())
         {
             send_cfg();
-            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+            last_resend_cfg_time_ = goby::time::SteadyClock::now();
         }
     }
 

--- a/src/bin/sensors/drivers/blue_robotics_bar30.cpp
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.cpp
@@ -105,9 +105,9 @@ void jaiabot::apps::BlueRoboticsBar30Driver::health(
     if (last_report_time_ + std::chrono::seconds(report_timeout_) < goby::time::SteadyClock::now())
     {
         glog.is_warn() && glog << "Timeout on blue robotics bar30 report" << std::endl;
-        health_state = goby::middleware::protobuf::HEALTH__DEGRADED;
+        health_state = goby::middleware::protobuf::HEALTH__FAILED;
         health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
-            ->add_warning(protobuf::WARNING__MISSING_DATA__BLUEROBOTICS_BAR30_DATA);
+            ->add_error(protobuf::ERROR__MISSING_DATA__BLUEROBOTICS_BAR30_DATA);
 
         // Send configuration request at a configured rate
         if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <

--- a/src/bin/sensors/drivers/blue_robotics_bar30.cpp
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.cpp
@@ -33,8 +33,8 @@ using goby::glog;
 namespace si = boost::units::si;
 
 jaiabot::apps::BlueRoboticsBar30Driver::BlueRoboticsBar30Driver(
-    const jaiabot::sensor::protobuf::SensorThreadConfig& config)
-    : goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>(config)
+    const jaiabot::config::BlueRoboticsBar30ThreadConfig& config)
+    : goby::middleware::SimpleThread<jaiabot::config::BlueRoboticsBar30ThreadConfig>(config)
 
 {
     glog.add_group("bar30", goby::util::Colors::blue);
@@ -45,15 +45,15 @@ jaiabot::apps::BlueRoboticsBar30Driver::BlueRoboticsBar30Driver(
                 receive_data(sensor_data.bar30());
         });
 
-    // configure our sensor
-    sensor::protobuf::SensorRequest request;
-    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
-    auto& sensor_cfg = *request.mutable_cfg();
-    sensor_cfg.set_sensor(config.metadata().sensor());
+    // Set sample rate config
+    sample_rate_ = config.sample_rate();
 
-    // TODO - hardcode or configuration?
-    sensor_cfg.set_sample_freq_with_units(config.sample_rate() * boost::units::si::hertz);
-    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+    // Set timeout on missing report
+    report_timeout_ = config.report_timeout_seconds();
+    last_report_time_ = goby::time::SteadyClock::now();
+
+    // configure our sensor
+    send_cfg();
 }
 
 void jaiabot::apps::BlueRoboticsBar30Driver::receive_data(
@@ -81,5 +81,36 @@ void jaiabot::apps::BlueRoboticsBar30Driver::receive_data(
 
     interprocess().publish<jaiabot::groups::pressure_temperature>(pressure_temperature_data);
 
+    last_report_time_ = goby::time::SteadyClock::now();
+
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA threadcd
+}
+
+void jaiabot::apps::BlueRoboticsBar30Driver::send_cfg()
+{
+    sensor::protobuf::SensorRequest request;
+    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
+    auto& sensor_cfg = *request.mutable_cfg();
+    sensor_cfg.set_sensor(jaiabot::sensor::protobuf::BLUE_ROBOTICS__BAR30);
+
+    sensor_cfg.set_sample_freq_with_units(sample_rate_ * boost::units::si::hertz);
+    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+}
+
+void jaiabot::apps::BlueRoboticsBar30Driver::health(
+    goby::middleware::protobuf::ThreadHealth& health)
+{
+    auto health_state = goby::middleware::protobuf::HEALTH__OK;
+
+    if (last_report_time_ + std::chrono::seconds(report_timeout_) < goby::time::SteadyClock::now())
+    {
+        glog.is_warn() && glog << "Timeout on blue robotics bar30 report" << std::endl;
+        health_state = goby::middleware::protobuf::HEALTH__DEGRADED;
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+            ->add_warning(protobuf::WARNING__MISSING_DATA__BLUEROBOTICS_BAR30_DATA);
+
+        send_cfg();
+    }
+
+    health.set_state(health_state);
 }

--- a/src/bin/sensors/drivers/blue_robotics_bar30.cpp
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.cpp
@@ -50,7 +50,7 @@ jaiabot::apps::BlueRoboticsBar30Driver::BlueRoboticsBar30Driver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    last_report_time_ = goby::time::SteadyClock::now();
+    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -109,7 +109,13 @@ void jaiabot::apps::BlueRoboticsBar30Driver::health(
         health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
             ->add_warning(protobuf::WARNING__MISSING_DATA__BLUEROBOTICS_BAR30_DATA);
 
-        send_cfg();
+        // Send configuration request at a configured rate
+        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+            goby::time::SteadyClock::now())
+        {
+            send_cfg();
+            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+        }
     }
 
     health.set_state(health_state);

--- a/src/bin/sensors/drivers/blue_robotics_bar30.h
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.h
@@ -46,11 +46,10 @@ class BlueRoboticsBar30Driver
 
   private:
     goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
-    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
-        goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_resend_cfg_time_{goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
-    int32_t trigger_cfg_resend_timeout_{20};
+    int32_t resend_cfg_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/blue_robotics_bar30.h
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.h
@@ -23,6 +23,8 @@
 #ifndef JAIABOT_SENSORS_DRIVERS_BLUE_ROBOTICS_BAR30_H
 #define JAIABOT_SENSORS_DRIVERS_BLUE_ROBOTICS_BAR30_H
 
+#include "config.pb.h"
+#include "jaiabot/messages/health.pb.h"
 #include "jaiabot/messages/sensor/blue_robotics__bar30.pb.h"
 #include "jaiabot/messages/sensor/sensor_core.pb.h"
 #include <goby/zeromq/application/multi_thread.h>
@@ -32,13 +34,20 @@ namespace jaiabot
 namespace apps
 {
 class BlueRoboticsBar30Driver
-    : public goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>
+    : public goby::middleware::SimpleThread<jaiabot::config::BlueRoboticsBar30ThreadConfig>
 {
   public:
-    BlueRoboticsBar30Driver(const jaiabot::sensor::protobuf::SensorThreadConfig& config);
+    BlueRoboticsBar30Driver(const jaiabot::config::BlueRoboticsBar30ThreadConfig& config);
 
   private:
     void receive_data(const sensor::protobuf::BlueRoboticsBar30& ec_data);
+    void health(goby::middleware::protobuf::ThreadHealth& health) override;
+    void send_cfg();
+
+  private:
+    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    int32_t sample_rate_{10};
+    int32_t report_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/blue_robotics_bar30.h
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.h
@@ -45,9 +45,12 @@ class BlueRoboticsBar30Driver
     void send_cfg();
 
   private:
-    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
+        goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
+    int32_t trigger_cfg_resend_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/turner__c_fluor.cpp
+++ b/src/bin/sensors/drivers/turner__c_fluor.cpp
@@ -44,7 +44,7 @@ jaiabot::apps::TurnerCFluorDriver::TurnerCFluorDriver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
+    resend_cfg_timeout_ = config.resend_cfg_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -88,11 +88,11 @@ void jaiabot::apps::TurnerCFluorDriver::health(goby::middleware::protobuf::Threa
             ->add_warning(protobuf::WARNING__MISSING_DATA__TURNOR_C_FLUOR_DATA);
 
         // Send configuration request at a configured rate
-        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+        if (last_resend_cfg_time_ + std::chrono::seconds(resend_cfg_timeout_) <
             goby::time::SteadyClock::now())
         {
             send_cfg();
-            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+            last_resend_cfg_time_ = goby::time::SteadyClock::now();
         }
     }
 

--- a/src/bin/sensors/drivers/turner__c_fluor.cpp
+++ b/src/bin/sensors/drivers/turner__c_fluor.cpp
@@ -28,8 +28,8 @@
 using goby::glog;
 
 jaiabot::apps::TurnerCFluorDriver::TurnerCFluorDriver(
-    const jaiabot::sensor::protobuf::SensorThreadConfig& config)
-    : goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>(config)
+    const jaiabot::config::TurnorCFluorThreadConfig& config)
+    : goby::middleware::SimpleThread<jaiabot::config::TurnorCFluorThreadConfig>(config)
 {
     glog.add_group("turner_c_fluor", goby::util::Colors::blue);
 
@@ -39,15 +39,15 @@ jaiabot::apps::TurnerCFluorDriver::TurnerCFluorDriver(
                 receive_data(sensor_data.c_fluor());
         });
 
-    // configure our sensor
-    sensor::protobuf::SensorRequest request;
-    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
-    auto& sensor_cfg = *request.mutable_cfg();
-    sensor_cfg.set_sensor(config.metadata().sensor());
+    // Set sample rate config
+    sample_rate_ = config.sample_rate();
 
-    // TODO - hardcode or configuration?
-    sensor_cfg.set_sample_freq_with_units(1 * boost::units::si::hertz);
-    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+    // Set timeout on missing report
+    report_timeout_ = config.report_timeout_seconds();
+    last_report_time_ = goby::time::SteadyClock::now();
+
+    // configure our sensor
+    send_cfg();
 }
 
 void jaiabot::apps::TurnerCFluorDriver::receive_data(
@@ -60,5 +60,35 @@ void jaiabot::apps::TurnerCFluorDriver::receive_data(
     turner_c_fluor_msg.set_concentration(turner_c_fluor_data.concentration());
     interprocess().publish<jaiabot::groups::concentration>(turner_c_fluor_msg);
 
+    last_report_time_ = goby::time::SteadyClock::now();
+
     // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA threadcd
+}
+
+void jaiabot::apps::TurnerCFluorDriver::send_cfg()
+{
+    sensor::protobuf::SensorRequest request;
+    request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
+    auto& sensor_cfg = *request.mutable_cfg();
+    sensor_cfg.set_sensor(jaiabot::sensor::protobuf::TURNER__C_FLUOR);
+
+    sensor_cfg.set_sample_freq_with_units(sample_rate_ * boost::units::si::hertz);
+    interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
+}
+
+void jaiabot::apps::TurnerCFluorDriver::health(goby::middleware::protobuf::ThreadHealth& health)
+{
+    auto health_state = goby::middleware::protobuf::HEALTH__OK;
+
+    if (last_report_time_ + std::chrono::seconds(report_timeout_) < goby::time::SteadyClock::now())
+    {
+        glog.is_warn() && glog << "Timeout on turner c fluorometer report" << std::endl;
+        health_state = goby::middleware::protobuf::HEALTH__DEGRADED;
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+            ->add_warning(protobuf::WARNING__MISSING_DATA__TURNOR_C_FLUOR_DATA);
+
+        send_cfg();
+    }
+
+    health.set_state(health_state);
 }

--- a/src/bin/sensors/drivers/turner__c_fluor.cpp
+++ b/src/bin/sensors/drivers/turner__c_fluor.cpp
@@ -44,7 +44,7 @@ jaiabot::apps::TurnerCFluorDriver::TurnerCFluorDriver(
 
     // Set timeout on missing report
     report_timeout_ = config.report_timeout_seconds();
-    last_report_time_ = goby::time::SteadyClock::now();
+    trigger_cfg_resend_timeout_ = config.trigger_cfg_resend_timeout_seconds();
 
     // configure our sensor
     send_cfg();
@@ -87,7 +87,13 @@ void jaiabot::apps::TurnerCFluorDriver::health(goby::middleware::protobuf::Threa
         health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
             ->add_warning(protobuf::WARNING__MISSING_DATA__TURNOR_C_FLUOR_DATA);
 
-        send_cfg();
+        // Send configuration request at a configured rate
+        if (last_trigger_cfg_resend_time_ + std::chrono::seconds(trigger_cfg_resend_timeout_) <
+            goby::time::SteadyClock::now())
+        {
+            send_cfg();
+            last_trigger_cfg_resend_time_ = goby::time::SteadyClock::now();
+        }
     }
 
     health.set_state(health_state);

--- a/src/bin/sensors/drivers/turner__c_fluor.h
+++ b/src/bin/sensors/drivers/turner__c_fluor.h
@@ -45,9 +45,12 @@ class TurnerCFluorDriver
     void send_cfg();
 
   private:
-    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
+        goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
+    int32_t trigger_cfg_resend_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/turner__c_fluor.h
+++ b/src/bin/sensors/drivers/turner__c_fluor.h
@@ -46,11 +46,10 @@ class TurnerCFluorDriver
 
   private:
     goby::time::SteadyClock::time_point last_report_time_{goby::time::SteadyClock::now()};
-    goby::time::SteadyClock::time_point last_trigger_cfg_resend_time_{
-        goby::time::SteadyClock::now()};
+    goby::time::SteadyClock::time_point last_resend_cfg_time_{goby::time::SteadyClock::now()};
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
-    int32_t trigger_cfg_resend_timeout_{20};
+    int32_t resend_cfg_timeout_{20};
 };
 
 } // namespace apps

--- a/src/bin/sensors/drivers/turner__c_fluor.h
+++ b/src/bin/sensors/drivers/turner__c_fluor.h
@@ -23,6 +23,8 @@
 #ifndef JAIABOT_SENSORS_DRIVERS_TURNER_C_FLUOR_H
 #define JAIABOT_SENSORS_DRIVERS_TURNER_C_FLUOR_H
 
+#include "config.pb.h"
+#include "jaiabot/messages/health.pb.h"
 #include "jaiabot/messages/sensor/sensor_core.pb.h"
 #include "jaiabot/messages/sensor/turner__c_fluor.pb.h"
 #include <goby/zeromq/application/multi_thread.h>
@@ -32,13 +34,20 @@ namespace jaiabot
 namespace apps
 {
 class TurnerCFluorDriver
-    : public goby::middleware::SimpleThread<jaiabot::sensor::protobuf::SensorThreadConfig>
+    : public goby::middleware::SimpleThread<jaiabot::config::TurnorCFluorThreadConfig>
 {
   public:
-    TurnerCFluorDriver(const jaiabot::sensor::protobuf::SensorThreadConfig& config);
+    TurnerCFluorDriver(const jaiabot::config::TurnorCFluorThreadConfig& config);
 
   private:
     void receive_data(const sensor::protobuf::TurnerCFluor& fluor_data);
+    void health(goby::middleware::protobuf::ThreadHealth& health) override;
+    void send_cfg();
+
+  private:
+    goby::time::SteadyClock::time_point last_report_time_{std::chrono::seconds(0)};
+    int32_t sample_rate_{10};
+    int32_t report_timeout_{20};
 };
 
 } // namespace apps

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -115,7 +115,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xd81a3640701e59a5")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0x2125361708f53070")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xd6cdaf32db2fd089")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0xf4bad9b633f50b7f")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -115,7 +115,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0x2125361708f53070")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xa516e8fa29708761")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xd6cdaf32db2fd089")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0xf4bad9b633f50b7f")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/health.proto
+++ b/src/lib/messages/health.proto
@@ -225,6 +225,10 @@ enum Error
     ];  // INTERVEHICLE_API_VERSION_mismatch - hub_version > bot_version
     ERROR__ARDUINO_CONNECTION_FAILED = 704
         [(jaia.ev).rest_api.presence = GUARANTEED];
+
+    // jaiabot_sensor
+    ERROR__MISSING_DATA__BLUEROBOTICS_BAR30_DATA = 800
+        [(jaia.ev).rest_api.presence = GUARANTEED];
 }
 
 enum Warning
@@ -328,9 +332,7 @@ enum Warning
         [(jaia.ev).rest_api.presence = GUARANTEED];
     WARNING__MISSING_DATA__ATLAS_OEM_DO_DATA = 802
         [(jaia.ev).rest_api.presence = GUARANTEED];
-    WARNING__MISSING_DATA__BLUEROBOTICS_BAR30_DATA = 803
-        [(jaia.ev).rest_api.presence = GUARANTEED];
-    WARNING__MISSING_DATA__TURNOR_C_FLUOR_DATA = 804
+    WARNING__MISSING_DATA__TURNOR_C_FLUOR_DATA = 803
         [(jaia.ev).rest_api.presence = GUARANTEED];
 }
 

--- a/src/lib/messages/health.proto
+++ b/src/lib/messages/health.proto
@@ -320,6 +320,18 @@ enum Warning
         [(jaia.ev).rest_api.presence = GUARANTEED];
     WARNING__MISSION__DATA_POST_OFFLOAD_FAILED = 723
         [(jaia.ev).rest_api.presence = GUARANTEED];
+
+    // from jaiabot_sensor
+    WARNING__MISSING_DATA__ATLAS_OEM_EC_DATA = 800
+        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__MISSING_DATA__ATLAS_OEM_PH_DATA = 801
+        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__MISSING_DATA__ATLAS_OEM_DO_DATA = 802
+        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__MISSING_DATA__BLUEROBOTICS_BAR30_DATA = 803
+        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__MISSING_DATA__TURNOR_C_FLUOR_DATA = 804
+        [(jaia.ev).rest_api.presence = GUARANTEED];
 }
 
 message LinuxHardwareStatus

--- a/src/lib/messages/sensor/sensor_core.proto
+++ b/src/lib/messages/sensor/sensor_core.proto
@@ -61,9 +61,3 @@ message SensorData
         // EchoData echo_data = 17;
     }
 }
-
-message SensorThreadConfig
-{
-    optional Metadata metadata = 1;
-    optional int32 sample_rate = 2;
-}


### PR DESCRIPTION
## Description

This will add warnings for missing ec, ph, conductivity, and fluorometer data. It will add a error for missing bar30 data. If we detect missing data a sensor request message will be sent on a configurable rate (default 20 seconds). 

## Testing
1. Power on BIO payload board. All sensors are reporting.
2. Disconnect BIO payload board. Sensor values freeze in Liaison.
3. After 20+ seconds of no new sensor data, warnings and errors appear in Liaison. (The time can vary because of the `jaiabot_sensors` application update frequency).
4. Reconnect BIO payload board. Sensor values start to update as new cfg messages are received on the payload board. The warnings and errors are removed in Liaison.