### PR TITLE
Bug/1.y/workaround ubuntu linux libc dev mismatch

### DIFF
--- a/.docker/focal/arm64/Dockerfile.in
+++ b/.docker/focal/arm64/Dockerfile.in
@@ -99,4 +99,4 @@ ENV PATH $NODE_PATH:$PATH
 # Work around issue where linux-libc-dev distributed for amd64 is newer than that for arm64
 # https://answers.launchpad.net/ubuntu/+question/821539
 # We want to unhold this version for when this image is updated in the future
-RUN apt-mark unhold linux-libc-dev:amd46
+RUN apt-mark unhold linux-libc-dev:amd64

--- a/.docker/focal/arm64/Dockerfile.in
+++ b/.docker/focal/arm64/Dockerfile.in
@@ -10,6 +10,24 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ENV CROSS_COMPILE_ARCHS "arm64"
 
+# Allow us to install packages for cross-compiling architectures
+RUN ARCHS=(${CROSS_COMPILE_ARCHS}) && \
+    ARCHS_LIST=$(IFS=,; echo "${ARCHS[*]}") && \
+    for ARCH in "${ARCHS[@]}"; do dpkg --add-architecture "$ARCH"; done && \
+    sed -i 's/deb /deb [arch=amd64] /' /etc/apt/sources.list && \
+    egrep "^deb " /etc/apt/sources.list | sed "s/amd64/${ARCHS_LIST}/" \
+        | sed 's|http://.*.ubuntu.com/ubuntu/|http://ports.ubuntu.com/|' \
+        >> /etc/apt/sources.list
+
+# Work around issue where linux-libc-dev distributed for amd64 is newer than that for arm64
+# by installing the arm64 version of linux-libc-dev for amd64 and then holding that package back from updates
+# https://answers.launchpad.net/ubuntu/+question/821539
+# See also unhold at bottom of Dockerfile
+RUN apt-get update && \
+    apt-get -y install linux-libc-dev:amd64=$(apt-cache policy linux-libc-dev:arm64 | awk '/Candidate:/ {print $2}') && \
+    apt-get -y install linux-libc-dev:arm64 && \
+    apt-mark hold linux-libc-dev:amd64
+
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y --no-install-recommends install \
@@ -19,15 +37,6 @@ RUN apt-get update && \
             dput cdbs \
             gcc-aarch64-linux-gnu \
             && rm -rf /var/lib/apt/lists/*
-
-# Allow us to install packages for cross-compiling architectures
-RUN ARCHS=(${CROSS_COMPILE_ARCHS}) && \
-    ARCHS_LIST=$(IFS=,; echo "${ARCHS[*]}") && \
-    for ARCH in "${ARCHS[@]}"; do dpkg --add-architecture "$ARCH"; done && \
-    sed -i 's/deb /deb [arch=amd64] /' /etc/apt/sources.list && \
-    egrep "^deb " /etc/apt/sources.list | sed "s/amd64/${ARCHS_LIST}/" \
-        | sed 's|http://.*.ubuntu.com/ubuntu/|http://ports.ubuntu.com/|' \
-        >> /etc/apt/sources.list
 
 # Add packages.jaia.tech and signing key for packages.gobysoft.org and packages.jaia.tech
 RUN echo -e "deb http://packages.jaia.tech/ubuntu/${repo}/${version}/ ${distro}/\ndeb http://packages.jaia.tech/ubuntu/gobysoft/${repo}/${version}/ ${distro}/" >> /etc/apt/sources.list.d/jaiabot_${repo}_${version}.list && \
@@ -86,3 +95,8 @@ RUN source $NVM_DIR/nvm.sh \
 # NVM Post Install Setup
 ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
 ENV PATH $NODE_PATH:$PATH
+
+# Work around issue where linux-libc-dev distributed for amd64 is newer than that for arm64
+# https://answers.launchpad.net/ubuntu/+question/821539
+# We want to unhold this version for when this image is updated in the future
+RUN apt-mark unhold linux-libc-dev:amd46


### PR DESCRIPTION
As of today, the Docker build files don't work due to a mismatch in the linux-libc-dev that Ubuntu updates is providing for amd64 and arm64:

```
19.18 The following packages have unmet dependencies:
19.24  libdccl4-dev:arm64 : Depends: libboost-dev:arm64 (>= 1.40~) but it is not going to be installed
19.24                       Depends: libprotobuf-dev:arm64 but it is not going to be installed
19.24                       Depends: libprotoc-dev:arm64 but it is not going to be installed
19.24                       Depends: liblua5.3-dev:arm64 but it is not going to be installed
19.24  libgoby3-dev:arm64 : Depends: libboost-dev:arm64 (>= 1.58~) but it is not going to be installed
19.24                       Depends: libboost-system-dev:arm64 (>= 1.58~) but it is not going to be installed
19.24                       Depends: libboost-date-time-dev:arm64 (>= 1.58~) but it is not going to be installed
19.24                       Depends: libboost-program-options-dev:arm64 (>= 1.58~) but it is not going to be installed
19.24                       Depends: libboost-filesystem-dev:arm64 (>= 1.58~) but it is not going to be installed
19.24                       Depends: libncurses5-dev:arm64 (>= 6.0~)
19.24                       Depends: libprotobuf-dev:arm64 (>= 2.6.1~) but it is not going to be installed
19.24                       Depends: libprotoc-dev:arm64 (>= 2.6.1~) but it is not going to be installed
19.24                       Depends: libsqlite3-dev:arm64 (>= 3.11.0~) but it is not going to be installed
19.24                       Depends: libzmq3-dev:arm64 (>= 4.1.4~) but it is not going to be installed
19.24                       Depends: libhdf5-dev:arm64 (>= 1.8.16~) but it is not going to be installed
19.24                       Depends: libproj-dev:arm64 (>= 4.9.2~) but it is not going to be installed
19.24                       Recommends: libmavlink-dev:arm64 (>= 1.0.12~) but it is not installable
19.24                       Recommends: goby3-clang-tool:arm64 (= 3.1.5-0~ubuntu20.04.1)
19.24                       Recommends: goby3-interfaces:arm64 (= 3.1.5-0~ubuntu20.04.1) but it is not installable
19.24  libgoby3-gui-dev:arm64 : Depends: libwt-dev:arm64 (>= 3.3.12~) but it is not going to be installed
19.24                           Depends: libwtdbo-dev:arm64 (>= 3.3.12~) but it is not going to be installed
19.24                           Depends: libwtdbosqlite-dev:arm64 (>= 3.3.12~) but it is not going to be installed
19.24                           Depends: libwthttp-dev:arm64 (>= 3.3.12~) but it is not going to be installed
19.25 E: Unable to correct problems, you have held broken packages.
```

See my post on https://answers.launchpad.net/ubuntu/+question/821539

This update works around it.