### PR TITLE
task/2.y/add-kernel-upgrades-to-cloud-images/jaia-1976

### DIFF
--- a/config/ansible/upgrade-all.yml
+++ b/config/ansible/upgrade-all.yml
@@ -34,6 +34,10 @@
     - name: Remount firmware read-only
       shell: "mount -o remount,ro /boot/firmware"
 
-    - name: Restore update-grub
-      shell: "mv /usr/sbin/update-grub.tmp /usr/sbin/update-grub"
+    - name: Restore update-grub and Update linux-image-virtual in read-only underlay
+      shell: |
+        mv /usr/sbin/update-grub.tmp /usr/sbin/update-grub
+        mount -o bind /dev /media/root-ro/dev
+        overlayroot-chroot /bin/bash -c "apt-get update && apt-get -y install linux-image-virtual"
+        umount /media/root-ro/dev
       when: ansible_architecture == "x86_64"


### PR DESCRIPTION
Changes upgrade-all.yml to update kernel image in read-only rootfs when using amd64 images (cloud/VirtualBox).  This has to be done in the read-only rootfs as it affects grub's config, which is used prior to creating the overlayfs.

Tested on new Cloudhub fleet5

This has been lacking for a while but is more important as we roll out cloud machines more widely and want to ensure they get kernel updates/security fixes.

https://jaia-innovation.atlassian.net/browse/JAIA-1976