### PR TITLE
Fix 2.y AWS upgrades to use correct destination repo (release, beta, etc.)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
+        - "bug/2.y/aws-packer-upgrade-uses-wrong-repo"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -194,6 +195,7 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
     branches:
       only:
         - "2.y"
+        - "bug/2.y/aws-packer-upgrade-uses-wrong-repo"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
@@ -203,6 +205,7 @@ filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
     branches:
       only:
         - "2.y"
+        - "bug/2.y/aws-packer-upgrade-uses-wrong-repo"
 
 # which branches to build Docker simulator
 filter-template-docker-sim-builds: &filter-template-docker-sim-builds
@@ -622,7 +625,7 @@ jobs:
 
             AMI_NAME=$(echo $IMAGE_NAME | sed 's/+/[plus]/g' | sed 's/~/[tilde]/g')
 
-            rootfs/cloud/aws/packer/packer-create-ami-by-upgrade.sh "${AMI_NAME}"
+            rootfs/cloud/aws/packer/packer-create-ami-by-upgrade.sh "${AMI_NAME}" "${JAIABOT_ROOTFS_GEN_REPO}"
             
             echo "export JAIABOT_IMAGE_NAME=${IMAGE_NAME}" >> $BASH_ENV
             echo "export JAIABOT_AMI_NAME=${AMI_NAME}" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
-        - "bug/2.y/aws-packer-upgrade-uses-wrong-repo"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -195,7 +194,6 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
     branches:
       only:
         - "2.y"
-        - "bug/2.y/aws-packer-upgrade-uses-wrong-repo"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
@@ -205,7 +203,6 @@ filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
     branches:
       only:
         - "2.y"
-        - "bug/2.y/aws-packer-upgrade-uses-wrong-repo"
 
 # which branches to build Docker simulator
 filter-template-docker-sim-builds: &filter-template-docker-sim-builds

--- a/rootfs/cloud/aws/packer/packer-create-ami-by-upgrade.sh
+++ b/rootfs/cloud/aws/packer/packer-create-ami-by-upgrade.sh
@@ -1,18 +1,22 @@
 #!/bin/bash
 
+# usage ./packer-create-ami-by-upgrade.sh <ami_name> <upgrade repo: release, beta, etc.>
+
 set -u -e
 
 REGION=us-east-1
 JAIA_AWS_ACCOUNT=120512385734
-BASE_REPO=test
+
+# change to release once 1.20.0 is released
+BASE_REPO=continuous
 BASE_VERSION=1.y
 
-UPGRADE_REPO=test
+UPGRADE_REPO=${2}
 UPGRADE_VERSION=2.y
 
 SCRIPT_PATH=$(dirname "$0")
 
-UPGRADE_AMI_NAME=${1:-"TEST-packer-ami-jaia-${UPGRADE_REPO}-${UPGRADE_VERSION}"}
+UPGRADE_AMI_NAME=${1}
 JAIA_UPGRADE_ISO_SOURCE=${JAIA_UPGRADE_ISO_SOURCE:-"s3"}
 JAIA_UPGRADE_ISO_LOCAL_DIR=${JAIA_UPGRADE_ISO_LOCAL_DIR:-""}
 


### PR DESCRIPTION
Previously rootfs/cloud/aws/packer/packer-create-ami-by-upgrade.sh was only creating output AWS AMIs that had the `test` repo enabled.  This meant even when I created a "continuous" repo Cloudhub, I got one with the `test` Debian repo enabled.

This was an oversight, which is fixed here.

Tested that this still build correctly on `test`. Obviously I can't test other repos until it is merged.