### PR TITLE
bug/cicrleci-amd-focal-failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ job-template-amd64: &job-template-amd64
           [[ "${TARGET_ARCH}" == "amd64" ]] && apt-get install -y goby3-clang-tool dccl4-apps || true
     - run: &run-build
         name: Build
-        command: mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -Denable_testing=ON -Dbuild_web=OFF .. && cmake --build . -- -j4 && cmake -Dbuild_web=ON .. && cmake --build . -- -j4
+        command: mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -Denable_testing=ON .. && cmake --build . -- -j4
     - run: &run-tests
         name: Run tests
         command: |
@@ -188,6 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
+        - "bug/cicrleci-amd-focal-failing"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "bug/cicrleci-amd-focal-failing"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,10 @@ endif()
 # add the code
 add_subdirectory(src)
 
+add_custom_target(jaiabot_core)
+foreach(app_target ${PROJECT_APP_LIST})
+  add_dependencies(jaiabot_core ${app_target})
+endforeach()
 
 if(export_goby_interfaces)
   # remove splines= when https://gitlab.com/graphviz/graphviz/-/issues/1408 fix is available (2.y)?

--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_command(OUTPUT ${intermediate_web_dir}/node_modules
 
 add_custom_target(npm_dependencies
   ALL
-  DEPENDS ${intermediate_web_dir}/package-lock.json ${intermediate_web_dir}/node_modules
+  DEPENDS ${intermediate_web_dir}/package-lock.json ${intermediate_web_dir}/node_modules jaiabot_core
   )
 
 ###############################################################################


### PR DESCRIPTION
## Description

Build web code last.

### Reason

CircleCi failed on this:

```
make[2]: *** [src/web/CMakeFiles/jcc_jed.dir/build.make:149: share/jaiabot/web/jcc/client.js] Error 137
Error 137 in Unix-based systems typically means the process was killed due to out-of-memory (OOM)
```

This failure occurred while building the web frontend (jcc_jed target):

Likely where Webpack or Babel was running and consumed too much memory.

So, I changed it to build the c++ code first then build the web code after.

