### PR TITLE
task/send-activate-all-command-to-hub

### DIFF
--- a/src/web/components/ActivateAllButton/ActivateAllButton.tsx
+++ b/src/web/components/ActivateAllButton/ActivateAllButton.tsx
@@ -7,8 +7,8 @@ import { Button } from "@mui/material";
 import { mdiCheckboxMarkedCirclePlusOutline } from "@mdi/js";
 
 import Bot from "../../data/bots/bot";
-import { CommandType } from "../../types/protobuf-types";
-import { isCommandAvailable } from "../../utils/commands";
+import { Command, CommandType } from "../../types/protobuf-types";
+import { isCommandAvailable, sendBotCommand } from "../../utils/commands";
 import { microsecondsToSeconds } from "../../utils/conversions";
 import { NO_COMMS_STATUS_AGE } from "../../utils/constants";
 
@@ -78,7 +78,13 @@ export default function ActivateAllButton(props: Props) {
         setIsDialogVisible(false);
 
         if (dialogAction === DialogActions.CONFIRMED) {
-            // Send activate command for available Bots
+            for (const botID of availableBotIDs) {
+                const activateCommand: Command = {
+                    bot_id: botID,
+                    type: CommandType.ACTIVATE,
+                };
+                sendBotCommand(activateCommand);
+            }
         }
     };
 


### PR DESCRIPTION
### Summary
Complete activate all integration by sending the `ACTIVATE` command to the server.

### Testing
Issued the command to 5 Bots in simulation, all 5 Bots acted on the command as expected.