### PR TITLE
task/add-functionality-to-next-task-button

### DIFF
--- a/src/web/components/ActivateAllButton/ActivateAllButton.tsx
+++ b/src/web/components/ActivateAllButton/ActivateAllButton.tsx
@@ -7,8 +7,8 @@ import { Button } from "@mui/material";
 import { mdiCheckboxMarkedCirclePlusOutline } from "@mdi/js";
 
 import Bot from "../../data/bots/bot";
-import { CommandType } from "../../types/protobuf-types";
-import { isCommandAvailable } from "../../utils/commands";
+import { Command, CommandType } from "../../types/protobuf-types";
+import { isCommandAvailable, sendBotCommand } from "../../utils/commands";
 import { microsecondsToSeconds } from "../../utils/conversions";
 import { NO_COMMS_STATUS_AGE } from "../../utils/constants";
 
@@ -78,7 +78,13 @@ export default function ActivateAllButton(props: Props) {
         setIsDialogVisible(false);
 
         if (dialogAction === DialogActions.CONFIRMED) {
-            // Send activate command for available Bots
+            for (const botID of availableBotIDs) {
+                const activateCommand: Command = {
+                    bot_id: botID,
+                    type: CommandType.ACTIVATE,
+                };
+                sendBotCommand(activateCommand);
+            }
         }
     };
 

--- a/src/web/components/NextTaskButton/NextTaskButton.tsx
+++ b/src/web/components/NextTaskButton/NextTaskButton.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+
+import { NextTaskDialog, DialogActions } from "./NextTaskDialog";
+import { DisabledCodes } from "./next-task-messages";
+
+import { Icon } from "@mdi/react";
+import { Button } from "@mui/material";
+import { mdiSkipNext } from "@mdi/js";
+
+import Bot from "../../data/bots/bot";
+import { Command, CommandType } from "../../types/protobuf-types";
+import { isCommandAvailable, sendBotCommand } from "../../utils/commands";
+
+interface Props {
+    bot: Bot;
+}
+
+/**
+ * Produces the next task button for an individual Bot.
+ * It manages the alert/confirm dialog that appears when clicking on the button.
+ */
+export default function NextTaskButton(props: Props) {
+    const [isDialogVisible, setIsDialogVisible] = useState(false);
+
+    /**
+     * Forms the style of the button (light if enabled, dark if disabled)
+     *
+     * @returns {string} General class name jaia-button plus enable/disable factor
+     */
+    const getClassName = () => {
+        let className = "jaia-button";
+
+        if (getDisabledCode() !== DisabledCodes.NONE) {
+            className += " disabled";
+        }
+
+        return className;
+    };
+
+    /**
+     * Checks the Bot's state and decides what disabled code (if any) applies based on the button conditions
+     *
+     * @returns {DisabledCodes} The applicable disabled code based on the Bot and button conditions
+     */
+    const getDisabledCode = () => {
+        if (!isCommandAvailable(CommandType.NEXT_TASK, props.bot.getMissionStatus().missionState)) {
+            return DisabledCodes.MISSION_STATE;
+        }
+        return DisabledCodes.NONE;
+    };
+
+    /**
+     * Closes the dialog box then acts based on the type of button clicked
+     *
+     * @param {DialogActions} dialogAction Indicates which button was clicked
+     * @returns {void}
+     */
+    const onDialogClose = (dialogAction: DialogActions) => {
+        setIsDialogVisible(false);
+
+        if (dialogAction === DialogActions.CONFIRMED) {
+            const nextTaskCommand: Command = {
+                bot_id: props.bot.getBotID(),
+                type: CommandType.NEXT_TASK,
+            };
+            sendBotCommand(nextTaskCommand);
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                className={getClassName()}
+                aria-label={"next-task"}
+                onClick={() => setIsDialogVisible(true)}
+            >
+                <Icon path={mdiSkipNext} title="Next Task" />
+            </Button>
+            <NextTaskDialog
+                isVisible={isDialogVisible}
+                disabledCode={getDisabledCode()}
+                onClose={onDialogClose}
+            />
+        </div>
+    );
+}

--- a/src/web/components/NextTaskButton/NextTaskDialog.tsx
+++ b/src/web/components/NextTaskButton/NextTaskDialog.tsx
@@ -1,0 +1,95 @@
+import { DisabledCodes, messages } from "./next-task-messages";
+
+interface DialogProps {
+    isVisible: boolean;
+    disabledCode: DisabledCodes;
+    onClose: (dialogAction: DialogActions) => void;
+}
+
+interface TitleProps {
+    disabledCode: DisabledCodes;
+}
+
+interface ButtonRowProps {
+    disabledCode: DisabledCodes;
+    onClose: (dialogAction: DialogActions) => void;
+}
+
+export enum DialogActions {
+    NONE = 0,
+    CONFIRMED = 1,
+}
+
+/**
+ * Produces the dialog box that appears when clicking on the next task button.
+ * This dialog will be an alert if the command cannot be
+ * sent or a confirmation prior to sending the command.
+ */
+export function NextTaskDialog(props: DialogProps) {
+    /**
+     * Forms the class name with a base of "jaia-dialog" and adds
+     * "alert" when the disabled code does not equal NONE.
+     *
+     * @returns {string} General class name jaia-dialog plus confirm/alert type
+     */
+    const getClassName = () => {
+        return `jaia-dialog ${props.disabledCode !== DisabledCodes.NONE ? "alert" : ""}`;
+    };
+
+    if (!props.isVisible) {
+        return <div></div>;
+    }
+
+    return (
+        <div className="jaia-dialog-container">
+            <div className="blocking-overlay" onClick={() => {}}>
+                <div className={getClassName()}>
+                    <Title disabledCode={props.disabledCode} />
+                    <p>{messages.get(props.disabledCode)}</p>
+                    <ButtonRow disabledCode={props.disabledCode} onClose={props.onClose} />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Produces the title for the dialog box. If there is nothing blocking the command from
+ * being sent the title will be Confirm, otherwise it will be Alert.
+ */
+function Title(props: TitleProps) {
+    if (props.disabledCode === DisabledCodes.NONE) {
+        return <h1>Confirm</h1>;
+    }
+
+    return <h1>Alert</h1>;
+}
+
+/**
+ * Produces the buttons for the dialox box.
+ * For a confirmation dialog, the buttons will be Cancel and Next Task.
+ * For an alert, the button will be Close.
+ */
+function ButtonRow(props: ButtonRowProps) {
+    if (props.disabledCode === DisabledCodes.NONE) {
+        return (
+            <div className="dialog-button-row">
+                <button className="dialog-button" onClick={() => props.onClose(DialogActions.NONE)}>
+                    Cancel
+                </button>
+                <button
+                    className="dialog-button"
+                    onClick={() => props.onClose(DialogActions.CONFIRMED)}
+                >
+                    Next Task
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <button className="dialog-button" onClick={() => props.onClose(DialogActions.NONE)}>
+            Close
+        </button>
+    );
+}

--- a/src/web/components/NextTaskButton/__tests__/NextTaskButton.test.tsx
+++ b/src/web/components/NextTaskButton/__tests__/NextTaskButton.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+import NextTaskButton from "../NextTaskButton";
+import { DisabledCodes, messages } from "../next-task-messages";
+
+import { bots } from "../../../data/bots/bots";
+import { PortalBotStatus } from "../../../shared/PortalStatus";
+import { MissionState } from "../../../types/protobuf-types";
+
+const botStatusMock1: PortalBotStatus = {
+    bot_id: 1,
+    mission_state: MissionState.IN_MISSION__UNDERWAY__MOVEMENT__TRANSIT,
+};
+
+const botStatusMock2: PortalBotStatus = {
+    bot_id: 2,
+    mission_state: MissionState.PRE_DEPLOYMENT__IDLE,
+};
+
+bots.setBot(botStatusMock1);
+bots.setBot(botStatusMock2);
+
+const originalModule = jest.requireActual("../../../utils/jaia-api");
+originalModule.jaiaAPI.hit = jest
+    .fn()
+    .mockResolvedValue({ code: 200, msg: "Mocked Success", bots: [], hubs: [] });
+
+test("Click next task button in enabled state", async () => {
+    render(<NextTaskButton bot={bots.getBot(1)} />);
+    const button = screen.getByRole("button", { name: "next-task" });
+    await userEvent.click(button);
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+    expect(screen.getAllByText("Next Task")[1]).toBeInTheDocument();
+});
+
+test("Click the Cancel button", async () => {
+    render(<NextTaskButton bot={bots.getBot(1)} />);
+    const button = screen.getByRole("button", { name: "next-task" });
+    await userEvent.click(button);
+    const cancelButton = screen.getByText("Cancel");
+    await userEvent.click(cancelButton);
+    expect(screen.queryByText("Confirm")).toBeNull();
+});
+
+test("Click the Next Task button", async () => {
+    render(<NextTaskButton bot={bots.getBot(1)} />);
+    const button = screen.getByRole("button", { name: "next-task" });
+    await userEvent.click(button);
+    const nextTaskButton = screen.getAllByText("Next Task")[1];
+    await userEvent.click(nextTaskButton);
+    expect(screen.queryByText("Confirm")).toBeNull();
+});
+
+test("Click next task button in disabled state due to mission state", async () => {
+    render(<NextTaskButton bot={bots.getBot(2)} />);
+    const button = screen.getByRole("button", { name: "next-task" });
+    await userEvent.click(button);
+    expect(screen.getByText("Alert")).toBeInTheDocument();
+    expect(screen.getByText(messages.get(DisabledCodes.MISSION_STATE))).toBeInTheDocument();
+    const closeButton = screen.getByText("Close");
+    await userEvent.click(closeButton);
+    expect(screen.queryByText("Alert")).toBeNull();
+});

--- a/src/web/components/NextTaskButton/next-task-messages.ts
+++ b/src/web/components/NextTaskButton/next-task-messages.ts
@@ -1,0 +1,8 @@
+export enum DisabledCodes {
+    NONE = 0,
+    MISSION_STATE = 1,
+}
+export const messages: ReadonlyMap<DisabledCodes, string> = new Map([
+    [DisabledCodes.NONE, ""],
+    [DisabledCodes.MISSION_STATE, "The Bot needs to be in mission to move it to the next task."],
+]);

--- a/src/web/containers/BotDetails/BotDetails.tsx
+++ b/src/web/containers/BotDetails/BotDetails.tsx
@@ -10,8 +10,10 @@ import {
 } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 
-import StopButton from "../../components/StopButton/StopButton";
 import ActivateButton from "../../components/ActivateButton/ActivateButton";
+import StopButton from "../../components/StopButton/StopButton";
+import StartMissionButton from "../../components/StartMissionButton/StartMissionButton";
+import NextTaskButton from "../../components/NextTaskButton/NextTaskButton";
 
 import { MissionStatus } from "../../types/jaia-system-types";
 import { BotAccordionNames } from "../../types/context-types";
@@ -50,7 +52,6 @@ import AccordionDetails from "@mui/material/AccordionDetails";
 
 import rcModeIcon from "../../style/icons/controller.svg";
 import "./BotDetails.less";
-import StartMissionButton from "../../components/StartMissionButton/StartMissionButton";
 
 export default function BotDetails() {
     const jaiaContext: JaiaContextType = useContext(JaiaContext);
@@ -243,9 +244,7 @@ export default function BotDetails() {
                                             title="RC Mode"
                                         ></img>
                                     </Button>
-                                    <Button className="jaia-button">
-                                        <Icon path={mdiSkipNext} title="Next Task" />
-                                    </Button>
+                                    <NextTaskButton bot={bot} />
                                 </div>
                                 <Accordion
                                     expanded={jaiaContext.botAccordionStates.advancedCommands}

--- a/src/web/style/stylesheets/dialog.less
+++ b/src/web/style/stylesheets/dialog.less
@@ -1,3 +1,8 @@
+.jaia-dialog-container {
+    position: fixed;
+    z-index: 2;
+}
+
 .jaia-dialog {
     position: fixed;
     top: 50%;


### PR DESCRIPTION
### Summary
Integrates the next task command into the new button structure. This button lives in the Bot details panel.

### Testing
**Simulation:**
* Observed Bot changing into transit state midway through a dive. This indicates the reception of the command.

**Unit Tests:**
* Enabled/disabled states
* Clicking of all buttons