### PR TITLE
task/add-back-system-power-buttons

### DIFF
--- a/src/web/components/StopButton/__tests__/StopButton.test.tsx
+++ b/src/web/components/StopButton/__tests__/StopButton.test.tsx
@@ -8,12 +8,12 @@ import { bots } from "../../../data/bots/bots";
 import { PortalBotStatus } from "../../../shared/PortalStatus";
 import { MissionState } from "../../../types/protobuf-types";
 
-type testParams = {
+interface TestParams {
     missionState: MissionState;
     buttonAvailable: boolean;
-};
+}
 
-const testCases: testParams[] = [
+const testCases: TestParams[] = [
     { missionState: MissionState.PRE_DEPLOYMENT__STARTING_UP, buttonAvailable: false },
     { missionState: MissionState.IN_MISSION__UNDERWAY__MOVEMENT__TRANSIT, buttonAvailable: true },
     { missionState: MissionState.IN_MISSION__UNDERWAY__TASK__STATION_KEEP, buttonAvailable: true },

--- a/src/web/components/SystemButton/SystemButton.tsx
+++ b/src/web/components/SystemButton/SystemButton.tsx
@@ -81,7 +81,7 @@ export default function SystemButton(props: Props) {
             case SystemButtonTypes.SHUTDOWN:
                 return "Shutdown";
             case SystemButtonTypes.REBOOT:
-                return "Restart";
+                return "Reboot";
             case SystemButtonTypes.RESTART_SERVICES:
                 return "Restart Services";
         }

--- a/src/web/components/SystemButton/SystemButton.tsx
+++ b/src/web/components/SystemButton/SystemButton.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+
+import { SystemDialog, DialogActions } from "./SystemDialog";
+import { DisabledCodes } from "./system-messages";
+
+import { Icon } from "@mdi/react";
+import { Button } from "@mui/material";
+import { mdiPower, mdiRestart, mdiRestartAlert } from "@mdi/js";
+
+import Bot from "../../data/bots/bot";
+import { SystemButtonTypes } from "../../types/jaia-system-types";
+import { Command, CommandType } from "../../types/protobuf-types";
+import { isCommandAvailable, sendBotCommand } from "../../utils/commands";
+
+interface Props {
+    bot: Bot;
+    type: SystemButtonTypes;
+}
+
+/**
+ * Produces a system button for an individual Bot (Shutdown, Reboot, Restart Services).
+ * It manages the alert/confirm dialog that appears when clicking on the button.
+ */
+export default function SystemButton(props: Props) {
+    const [isDialogVisible, setIsDialogVisible] = useState(false);
+
+    /**
+     * Forms the style of the button (light if enabled, dark if disabled)
+     *
+     * @returns {string} General class name jaia-button plus enable/disable factor
+     */
+    const getClassName = () => {
+        let className = "jaia-button";
+
+        if (getDisabledCode() !== DisabledCodes.NONE) {
+            className += " disabled";
+        }
+
+        return className;
+    };
+
+    /**
+     * Provides the aria label based on system button type
+     *
+     * @returns {string} Aria label for the button
+     */
+    const getAriaLabel = () => {
+        switch (props.type) {
+            case SystemButtonTypes.SHUTDOWN:
+                return "shutdown-individual-bot";
+            case SystemButtonTypes.REBOOT:
+                return "reboot-individual-bot";
+            case SystemButtonTypes.RESTART_SERVICES:
+                return "restart-services-individual-bot";
+        }
+    };
+
+    /**
+     * Provides the icon path based on system button type
+     *
+     * @returns {string} Icon path for the button
+     */
+    const getIconPath = () => {
+        switch (props.type) {
+            case SystemButtonTypes.SHUTDOWN:
+                return mdiPower;
+            case SystemButtonTypes.REBOOT:
+                return mdiRestartAlert;
+            case SystemButtonTypes.RESTART_SERVICES:
+                return mdiRestart;
+        }
+    };
+
+    /**
+     * Provides the tool tip label based on system button type
+     *
+     * @returns {string} Title for the button
+     */
+    const getIconTitle = () => {
+        switch (props.type) {
+            case SystemButtonTypes.SHUTDOWN:
+                return "Shutdown";
+            case SystemButtonTypes.REBOOT:
+                return "Restart";
+            case SystemButtonTypes.RESTART_SERVICES:
+                return "Restart Services";
+        }
+    };
+
+    /**
+     * Provides the CommandType based on system button type
+     *
+     * @returns {CommandType} Command that maps to the button
+     */
+    const getCommandType = () => {
+        switch (props.type) {
+            case SystemButtonTypes.SHUTDOWN:
+                return CommandType.SHUTDOWN;
+            case SystemButtonTypes.REBOOT:
+                return CommandType.REBOOT_COMPUTER;
+            case SystemButtonTypes.RESTART_SERVICES:
+                return CommandType.RESTART_ALL_SERVICES;
+        }
+    };
+
+    /**
+     * Checks the Bot's state and decides what disabled code (if any) applies based on the button conditions
+     *
+     * @returns {DisabledCodes} The applicable disabled code based on the Bot and button conditions
+     */
+    const getDisabledCode = () => {
+        if (!isCommandAvailable(getCommandType(), props.bot.getMissionStatus().missionState)) {
+            return DisabledCodes.MISSION_STATE;
+        }
+        return DisabledCodes.NONE;
+    };
+
+    /**
+     * Closes the dialog box then acts based on the type of button clicked
+     *
+     * @param {DialogActions} dialogAction Indicates which button was clicked
+     * @returns {void}
+     */
+    const onDialogClose = (dialogAction: DialogActions) => {
+        setIsDialogVisible(false);
+
+        if (dialogAction === DialogActions.CONFIRMED) {
+            const command: Command = {
+                bot_id: props.bot.getBotID(),
+                type: getCommandType(),
+            };
+            sendBotCommand(command);
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                className={getClassName()}
+                aria-label={getAriaLabel()}
+                onClick={() => setIsDialogVisible(true)}
+            >
+                <Icon path={getIconPath()} title={getIconTitle()} />
+            </Button>
+            <SystemDialog
+                isVisible={isDialogVisible}
+                disabledCode={getDisabledCode()}
+                onClose={onDialogClose}
+                systemButton={props.type}
+            />
+        </div>
+    );
+}

--- a/src/web/components/SystemButton/SystemDialog.tsx
+++ b/src/web/components/SystemButton/SystemDialog.tsx
@@ -54,7 +54,7 @@ export function SystemDialog(props: DialogProps) {
             case SystemButtonTypes.SHUTDOWN:
                 return "The shutdown " + endMsg;
             case SystemButtonTypes.REBOOT:
-                return "The restart " + endMsg;
+                return "The reboot " + endMsg;
             case SystemButtonTypes.RESTART_SERVICES:
                 return "The restart services " + endMsg;
         }
@@ -104,7 +104,7 @@ function ButtonRow(props: ButtonRowProps) {
             case SystemButtonTypes.SHUTDOWN:
                 return "Shutdown";
             case SystemButtonTypes.REBOOT:
-                return "Restart";
+                return "Reboot";
             case SystemButtonTypes.RESTART_SERVICES:
                 return "Restart Services";
         }

--- a/src/web/components/SystemButton/SystemDialog.tsx
+++ b/src/web/components/SystemButton/SystemDialog.tsx
@@ -1,0 +1,134 @@
+import { SystemButtonTypes } from "../../types/jaia-system-types";
+import { DisabledCodes } from "./system-messages";
+
+interface DialogProps {
+    isVisible: boolean;
+    disabledCode: DisabledCodes;
+    onClose: (dialogAction: DialogActions) => void;
+    systemButton: SystemButtonTypes;
+}
+
+interface TitleProps {
+    disabledCode: DisabledCodes;
+}
+
+interface ButtonRowProps {
+    disabledCode: DisabledCodes;
+    onClose: (dialogAction: DialogActions) => void;
+    systemButton: SystemButtonTypes;
+}
+
+export enum DialogActions {
+    NONE = 0,
+    CONFIRMED = 1,
+}
+
+/**
+ * Produces the dialog box that appears when clicking one of the system buttons.
+ * This dialog will be an alert if the command cannot be
+ * sent or a confirmation prior to sending the command.
+ */
+export function SystemDialog(props: DialogProps) {
+    /**
+     * Forms the class name with a base of "jaia-dialog" and adds
+     * "alert" when the disabled code does not equal NONE.
+     *
+     * @returns {string} General class name jaia-dialog plus confirm/alert type
+     */
+    const getClassName = () => {
+        return `jaia-dialog ${props.disabledCode !== DisabledCodes.NONE ? "alert" : ""}`;
+    };
+
+    /**
+     * Creates the alert message for each system button type
+     *
+     * @returns {string} Alert message when the button is not available
+     */
+    const generateAlertMessage = () => {
+        if (props.disabledCode === DisabledCodes.NONE) {
+            return "";
+        }
+
+        const endMsg = "command cannot be sent because the Bot needs to be stopped.";
+        switch (props.systemButton) {
+            case SystemButtonTypes.SHUTDOWN:
+                return "The shutdown " + endMsg;
+            case SystemButtonTypes.REBOOT:
+                return "The restart " + endMsg;
+            case SystemButtonTypes.RESTART_SERVICES:
+                return "The restart services " + endMsg;
+        }
+    };
+
+    if (!props.isVisible) {
+        return <div></div>;
+    }
+
+    return (
+        <div>
+            <div className="blocking-overlay" onClick={() => {}}>
+                <div className={getClassName()}>
+                    <Title disabledCode={props.disabledCode} />
+                    <p>{generateAlertMessage()}</p>
+                    <ButtonRow
+                        disabledCode={props.disabledCode}
+                        onClose={props.onClose}
+                        systemButton={props.systemButton}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Produces the title for the dialog box. If there is nothing blocking the command from
+ * being sent the title will be Confirm, otherwise it will be Alert.
+ */
+function Title(props: TitleProps) {
+    if (props.disabledCode === DisabledCodes.NONE) {
+        return <h1>Confirm</h1>;
+    }
+
+    return <h1>Alert</h1>;
+}
+
+/**
+ * Produces the buttons for the dialox box.
+ * For a confirmation dialog, the buttons will be Cancel and [Shutdown, Reboot, Restart Services].
+ * For an alert, the button will be Close.
+ */
+function ButtonRow(props: ButtonRowProps) {
+    const getButtonText = () => {
+        switch (props.systemButton) {
+            case SystemButtonTypes.SHUTDOWN:
+                return "Shutdown";
+            case SystemButtonTypes.REBOOT:
+                return "Restart";
+            case SystemButtonTypes.RESTART_SERVICES:
+                return "Restart Services";
+        }
+    };
+
+    if (props.disabledCode === DisabledCodes.NONE) {
+        return (
+            <div className="dialog-button-row">
+                <button className="dialog-button" onClick={() => props.onClose(DialogActions.NONE)}>
+                    Cancel
+                </button>
+                <button
+                    className="dialog-button"
+                    onClick={() => props.onClose(DialogActions.CONFIRMED)}
+                >
+                    {getButtonText()}
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <button className="dialog-button" onClick={() => props.onClose(DialogActions.NONE)}>
+            Close
+        </button>
+    );
+}

--- a/src/web/components/SystemButton/__tests__/SystemButton.test.tsx
+++ b/src/web/components/SystemButton/__tests__/SystemButton.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+import SystemButton from "../SystemButton";
+
+import { bots } from "../../../data/bots/bots";
+import { PortalBotStatus } from "../../../shared/PortalStatus";
+import { MissionState } from "../../../types/protobuf-types";
+import { SystemButtonTypes } from "../../../types/jaia-system-types";
+
+const originalModule = jest.requireActual("../../../utils/jaia-api");
+originalModule.jaiaAPI.hit = jest
+    .fn()
+    .mockResolvedValue({ code: 200, msg: "Mocked Success", bots: [], hubs: [] });
+
+const mockBotStatus1: PortalBotStatus = {
+    bot_id: 1,
+    mission_state: MissionState.IN_MISSION__UNDERWAY__RECOVERY__STOPPED,
+};
+
+const mockBotStatus2: PortalBotStatus = {
+    bot_id: 2,
+    mission_state: MissionState.IN_MISSION__UNDERWAY__MOVEMENT__TRANSIT,
+};
+
+bots.setBot(mockBotStatus1);
+bots.setBot(mockBotStatus2);
+
+interface TestParams {
+    type: SystemButtonTypes;
+    ariaLabel: string;
+    buttonText: string;
+}
+
+const testCases: TestParams[] = [
+    {
+        type: SystemButtonTypes.SHUTDOWN,
+        ariaLabel: "shutdown-individual-bot",
+        buttonText: "Shutdown",
+    },
+    { type: SystemButtonTypes.REBOOT, ariaLabel: "reboot-individual-bot", buttonText: "Restart" },
+    {
+        type: SystemButtonTypes.RESTART_SERVICES,
+        ariaLabel: "restart-services-individual-bot",
+        buttonText: "Restart Services",
+    },
+];
+
+test.each(testCases)(
+    "Click system button in enabled state",
+    async ({ type, ariaLabel, buttonText }) => {
+        render(<SystemButton bot={bots.getBot(1)} type={type} />);
+        const button = screen.getByLabelText(ariaLabel);
+        await userEvent.click(button);
+        expect(screen.getByText("Confirm"));
+        expect(screen.getByText("Cancel"));
+        expect(screen.getAllByText(buttonText));
+    },
+);
+
+test.each(testCases)("Click system button in enabled state", async ({ type, ariaLabel }) => {
+    render(<SystemButton bot={bots.getBot(2)} type={type} />);
+    const button = screen.getByLabelText(ariaLabel);
+    await userEvent.click(button);
+    expect(screen.getByText("Alert"));
+    expect(screen.getByText("Close"));
+});
+
+test.each(testCases)("Click the Cancel button", async ({ type, ariaLabel }) => {
+    render(<SystemButton bot={bots.getBot(1)} type={type} />);
+    const button = screen.getByLabelText(ariaLabel);
+    await userEvent.click(button);
+    const cancelButton = screen.getByText("Cancel");
+    await userEvent.click(cancelButton);
+    expect(screen.queryByText("Confirm")).toBeNull();
+});
+
+test.each(testCases)("Click the confirm button", async ({ type, ariaLabel, buttonText }) => {
+    render(<SystemButton bot={bots.getBot(1)} type={type} />);
+    const button = screen.getByLabelText(ariaLabel);
+    await userEvent.click(button);
+    // getAllByText captures tooltip and button
+    const confirmButton = screen.getAllByText(buttonText)[1];
+    await userEvent.click(confirmButton);
+    expect(screen.queryByText("Confirm")).toBeNull();
+});
+
+test.each(testCases)("Click the Close button", async ({ type, ariaLabel }) => {
+    render(<SystemButton bot={bots.getBot(2)} type={type} />);
+    const button = screen.getByLabelText(ariaLabel);
+    await userEvent.click(button);
+    const closeButton = screen.getByText("Close");
+    await userEvent.click(closeButton);
+    expect(screen.queryByText("Alert")).toBeNull();
+});

--- a/src/web/components/SystemButton/__tests__/SystemButton.test.tsx
+++ b/src/web/components/SystemButton/__tests__/SystemButton.test.tsx
@@ -38,7 +38,7 @@ const testCases: TestParams[] = [
         ariaLabel: "shutdown-individual-bot",
         buttonText: "Shutdown",
     },
-    { type: SystemButtonTypes.REBOOT, ariaLabel: "reboot-individual-bot", buttonText: "Restart" },
+    { type: SystemButtonTypes.REBOOT, ariaLabel: "reboot-individual-bot", buttonText: "Reboot" },
     {
         type: SystemButtonTypes.RESTART_SERVICES,
         ariaLabel: "restart-services-individual-bot",

--- a/src/web/components/SystemButton/system-messages.ts
+++ b/src/web/components/SystemButton/system-messages.ts
@@ -1,0 +1,4 @@
+export enum DisabledCodes {
+    NONE = 0,
+    MISSION_STATE = 1,
+}

--- a/src/web/containers/BotDetails/BotDetails.tsx
+++ b/src/web/containers/BotDetails/BotDetails.tsx
@@ -11,9 +11,11 @@ import {
 import { JaiaActions } from "../../context/jaia-actions";
 
 import StopButton from "../../components/StopButton/StopButton";
+import SystemButton from "../../components/SystemButton/SystemButton";
 import ActivateButton from "../../components/ActivateButton/ActivateButton";
+import StartMissionButton from "../../components/StartMissionButton/StartMissionButton";
 
-import { MissionStatus } from "../../types/jaia-system-types";
+import { MissionStatus, SystemButtonTypes } from "../../types/jaia-system-types";
 import { BotAccordionNames } from "../../types/context-types";
 import { DETAILS_DECIMALS, UNASSIGNED_ID } from "../../utils/constants";
 
@@ -38,7 +40,7 @@ import {
 } from "../../shared/Utilities";
 
 // MDI and MUI
-import { mdiPlay, mdiPower, mdiDelete, mdiRestart, mdiSkipNext, mdiRestartAlert } from "@mdi/js";
+import { mdiDelete, mdiSkipNext } from "@mdi/js";
 import { Icon } from "@mdi/react";
 import { ThemeProvider, createTheme } from "@mui/material";
 import Button from "@mui/material/Button";
@@ -50,7 +52,6 @@ import AccordionDetails from "@mui/material/AccordionDetails";
 
 import rcModeIcon from "../../style/icons/controller.svg";
 import "./BotDetails.less";
-import StartMissionButton from "../../components/StartMissionButton/StartMissionButton";
 
 export default function BotDetails() {
     const jaiaContext: JaiaContextType = useContext(JaiaContext);
@@ -262,15 +263,12 @@ export default function BotDetails() {
                                     </AccordionSummary>
 
                                     <AccordionDetails className="accordion-details-buttons advanced-commands">
-                                        <Button className="jaia-button">
-                                            <Icon path={mdiPower} title="Shutdown" />
-                                        </Button>
-                                        <Button className="jaia-button">
-                                            <Icon path={mdiRestartAlert} title="Reboot" />
-                                        </Button>
-                                        <Button className="jaia-button">
-                                            <Icon path={mdiRestart} title="Restart Services" />
-                                        </Button>
+                                        <SystemButton bot={bot} type={SystemButtonTypes.SHUTDOWN} />
+                                        <SystemButton bot={bot} type={SystemButtonTypes.REBOOT} />
+                                        <SystemButton
+                                            bot={bot}
+                                            type={SystemButtonTypes.RESTART_SERVICES}
+                                        />
                                     </AccordionDetails>
                                 </Accordion>
                             </AccordionDetails>

--- a/src/web/types/jaia-system-types.ts
+++ b/src/web/types/jaia-system-types.ts
@@ -48,3 +48,9 @@ export interface TaskParameterPair {
     key: TaskParameterKeys;
     value: number;
 }
+
+export enum SystemButtonTypes {
+    SHUTDOWN = 1,
+    REBOOT = 2,
+    RESTART_SERVICES = 3,
+}

--- a/src/web/utils/commands.ts
+++ b/src/web/utils/commands.ts
@@ -12,11 +12,6 @@ const commandStates: Map<CommandType, RegExp[]> = new Map<CommandType, RegExp[]>
         CommandType.REBOOT_COMPUTER,
         [/^IN_MISSION__UNDERWAY__RECOVERY__STOPPED$/, /^PRE_DEPLOYMENT.+$/, /^POST_DEPLOYMENT.+$/],
     ],
-    [CommandType.NEXT_TASK, [/^IN_MISSION__(?!REMOTE_CONTROL).+$/]],
-    [
-        CommandType.REBOOT_COMPUTER,
-        [/^IN_MISSION__UNDERWAY__RECOVERY__STOPPED$/, /^PRE_DEPLOYMENT.+$/, /^POST_DEPLOYMENT.+$/],
-    ],
     [CommandType.RECOVERED, [/^PRE_DEPLOYMENT.+$/, /^IN_MISSION__UNDERWAY__RECOVERY__STOPPED$/]],
     [
         CommandType.REMOTE_CONTROL_TASK,


### PR DESCRIPTION
### Summary
Continuing to add back buttons to the JCC that follow the new structure. I grouped together the shutdown, reboot, and restart services buttons into a system button category. The button structure slightly varies from the other buttons because the warning messages are not defined in the file `system-messages.ts`. They are defined in `SystemDialog` so they can be modified based on the system button type. I think the benefit of grouping these three buttons together outweighs the slight deviation from the structure.

### Testing
Automated tests cover:
* Clicking the system button in its enabled and disabled states
* Clicking the close button
* Clicking the cancel button
* Clicking the confirm button