### PR TITLE
feature/local-storage-task-packets-jaia-1992

### DIFF
--- a/src/web/containers/CommandControl/CommandControl.tsx
+++ b/src/web/containers/CommandControl/CommandControl.tsx
@@ -2322,7 +2322,7 @@ export default class CommandControl extends React.Component {
                     end_time: { value: endTime.toLocaleString(), units: "" },
                 };
 
-                this.setTaskPacketInterval(driftFeature, "drfit");
+                this.setTaskPacketInterval(driftFeature, "drift");
 
                 this.setState(
                     {

--- a/src/web/containers/CommandControl/CommandControl.tsx
+++ b/src/web/containers/CommandControl/CommandControl.tsx
@@ -36,6 +36,7 @@ import { MissionLibraryLocalStorage } from "../../utils/mission-library";
 import { playDisconnectReconnectSounds } from "../../style/audio/disconnect-sounds";
 import { error, success, warning, info } from "../../notifications/notifications";
 import { CustomAlert, CustomAlertProps } from "../../shared/CustomAlert";
+import { readLocalStorage, writeLocalStorage } from "../../shared/LocalStorage";
 import {
     MissionSettingsPanel,
     MissionSettings,
@@ -593,6 +594,14 @@ export default class CommandControl extends React.Component {
                 );
             }
         });
+
+        // Load taskPacketsTimeline
+        this.setState({
+            taskPacketsTimeline: readLocalStorage(
+                "taskPacketsTimeline",
+                this.state.taskPacketsTimeline,
+            ),
+        });
     }
 
     /**
@@ -685,6 +694,11 @@ export default class CommandControl extends React.Component {
             prevState.visiblePanel != PanelType.SETTINGS
         ) {
             this.setupMapLayersPanel();
+        }
+
+        // Persist the task taskPacketsTimeline, if changed
+        if (prevState.taskPacketsTimeline != this.state.taskPacketsTimeline) {
+            writeLocalStorage("taskPacketsTimeline", this.state.taskPacketsTimeline);
         }
     }
 

--- a/src/web/data/task_packets/task-packets.ts
+++ b/src/web/data/task_packets/task-packets.ts
@@ -19,6 +19,7 @@ import * as turf from "@turf/turf";
 import { Units } from "@turf/turf";
 import { getMapCoordinate } from "../../shared/Utilities";
 import { Geometry, LineString } from "ol/geom";
+import { persistVisibility } from "../../openlayers/map/layers/visible-layer-persistance";
 
 // Constants
 const POLL_INTERVAL = 5000;
@@ -53,6 +54,7 @@ export class TaskData {
             style: this.createClusterIconStyle.bind(this),
             visible: false,
         });
+        persistVisibility(this.divePacketLayer);
 
         this.driftPacketLayer = new VectorLayer({
             properties: {
@@ -64,6 +66,7 @@ export class TaskData {
             style: this.createClusterIconStyle.bind(this),
             visible: false,
         });
+        persistVisibility(this.driftPacketLayer);
 
         this.driftMapLayer = new VectorLayer({
             properties: {
@@ -75,6 +78,7 @@ export class TaskData {
             visible: false,
             style: Styles.driftMapStyle,
         });
+        persistVisibility(this.driftMapLayer);
 
         this.contourLayer = new VectorLayer({
             properties: {
@@ -85,6 +89,7 @@ export class TaskData {
             source: null,
             visible: false,
         });
+        persistVisibility(this.contourLayer);
     }
 
     /**

--- a/src/web/shared/LocalStorage.ts
+++ b/src/web/shared/LocalStorage.ts
@@ -1,0 +1,21 @@
+export function readLocalStorage<T>(name: string, defaultValue: T): T {
+    const stringValue = localStorage.getItem(name);
+    if (stringValue == null) {
+        return defaultValue;
+    }
+
+    try {
+        return JSON.parse(stringValue);
+    } catch (error) {
+        console.warn(error);
+        return defaultValue;
+    }
+}
+
+export function writeLocalStorage<T>(name: string, new_value: T) {
+    try {
+        localStorage.setItem(name, JSON.stringify(new_value));
+    } catch (error) {
+        console.warn(error);
+    }
+}


### PR DESCRIPTION
Persist both the measurement layer visibilities and the task packet timelines, (previously two PRs).
