### PR TITLE
task/sensor-pressure-uniform-output-python-and-stm32/JAIA-1991

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/sensor-pressure-uniform-output-python-and-stm32/JAIA-1991"
        
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
+        - "task/sensor-pressure-uniform-output-python-and-stm32/JAIA-1991"
        
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/src/bin/sensors/drivers/blue_robotics_bar30.cpp
+++ b/src/bin/sensors/drivers/blue_robotics_bar30.cpp
@@ -68,7 +68,7 @@ void jaiabot::apps::BlueRoboticsBar30Driver::receive_data(
 
     if (bar30_data.has_pressure())
     {
-        pressure_temperature_data.set_pressure_raw_with_units(bar30_data.pressure() * si::deci *
+        pressure_temperature_data.set_pressure_raw_with_units(bar30_data.pressure() * si::milli *
                                                               goby::util::seawater::bar);
     }
 


### PR DESCRIPTION
## Description

Uniform how we are handling pressure readings between stm32 and python libs.

## Test

Performed a test on bot 2 fleet 0

![image](https://github.com/user-attachments/assets/6b09847d-6244-4829-92f2-7e69e4ea62f9)

## Requires

https://github.com/jaiarobotics/stm32/pull/27
