### PR TITLE
bug/protoc-python-and-salinity-requires

### DIFF
--- a/src/lib/messages/sensor/salinity.proto
+++ b/src/lib/messages/sensor/salinity.proto
@@ -14,5 +14,5 @@ message SalinityData
     required double conductivity = 2;
     required double total_dissolved_solids = 3;
     required double salinity_raw = 4;
-    required double salinity = 5;
+    optional double salinity = 5;
 }

--- a/src/lib/messages/sensor/salinity.proto
+++ b/src/lib/messages/sensor/salinity.proto
@@ -10,9 +10,9 @@ message SalinityData
         unit_system: "si"
     };
 
-    required double conductivity_raw = 1;
-    required double conductivity = 2;
-    required double total_dissolved_solids = 3;
-    required double salinity_raw = 4;
+    optional double conductivity_raw = 1;
+    optional double conductivity = 2;
+    optional double total_dissolved_solids = 3;
+    optional double salinity_raw = 4;
     optional double salinity = 5;
 }

--- a/src/python/pressure_sensor/jaiabot_pressure_sensor.py
+++ b/src/python/pressure_sensor/jaiabot_pressure_sensor.py
@@ -5,7 +5,7 @@ import argparse
 import socket
 import logging
 import time
-from jaiabot.messages.pressure_temperature_pb2 import PressureTemperatureData
+from jaiabot.messages.sensor.pressure_temperature_pb2 import PressureTemperatureData
 
 parser = argparse.ArgumentParser(description='Read temperature and pressure from a Bar30 sensor, and publish them over UDP port')
 parser.add_argument('-rp', '--receive_port', metavar='receive_port', default=20001, type=int, help='port to receive data')

--- a/src/python/pyjaiaprotobuf/build_messages.sh
+++ b/src/python/pyjaiaprotobuf/build_messages.sh
@@ -37,7 +37,12 @@ ln -sf /usr/lib/python3/dist-packages/proto/nanopb.proto ${PROTO_INCLUDE}/nanopb
 # Create output directory
 mkdir -p $PYTHON_OUT_DIR
 
-protoc -I${PROTO_INCLUDE} --python_out=${PYTHON_OUT_DIR} ${PROTO_INCLUDE}/dccl/option_extensions.proto ${PROTO_INCLUDE}/goby/middleware/protobuf/*.proto ${PROTO_INCLUDE}/jaiabot/messages/*.proto ${PROTO_INCLUDE}/nanopb.proto
+protoc -I${PROTO_INCLUDE} --python_out=${PYTHON_OUT_DIR} \
+    ${PROTO_INCLUDE}/dccl/option_extensions.proto \
+    ${PROTO_INCLUDE}/goby/middleware/protobuf/*.proto \
+    ${PROTO_INCLUDE}/jaiabot/messages/*.proto \
+    ${PROTO_INCLUDE}/jaiabot/messages/sensor/*.proto \
+    ${PROTO_INCLUDE}/nanopb.proto
 
 # Remove the temporary proto_include directory
 rm -rf ${PROTO_INCLUDE}


### PR DESCRIPTION
## Description

Updated protoc command to include sensor folder, salinity field is now optional, updated jaiabot_pressure_sesnor to point to the correct location for the proto message