### PR TITLE
task/add-back-stop-all-button

### DIFF
--- a/src/web/components/StartAllMissionsButton/__tests__/StartAllMissionsButton.test.tsx
+++ b/src/web/components/StartAllMissionsButton/__tests__/StartAllMissionsButton.test.tsx
@@ -19,7 +19,7 @@ const botStatusMock1: PortalBotStatus = {
     battery_percent: 75,
 };
 
-// Status age Error
+// Status age error
 const botStatusMock2: PortalBotStatus = {
     bot_id: 2,
     mission_state: MissionState.PRE_DEPLOYMENT__WAIT_FOR_MISSION_PLAN,
@@ -80,7 +80,7 @@ test("0 Bots ready to start a mission", async () => {
     const button = screen.getByRole("button", { name: "start-all-missions" });
     await userEvent.click(button);
 
-    expect(screen.getByText("Alert"));
+    expect(screen.getByText("Alert")).toBeInTheDocument();
     expect(
         screen.getByText(
             "Cannot send mission to Bot: 2 because it does not have comms with the Hub.",
@@ -113,7 +113,7 @@ test("1 Bot ready to start a mission", async () => {
     const button = screen.getByRole("button", { name: "start-all-missions" });
     await userEvent.click(button);
 
-    expect(screen.getByText("Confirm"));
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
     expect(screen.getByText("Send mission to Bot: 1")).toBeInTheDocument();
     expect(
         screen.getByText(
@@ -149,7 +149,7 @@ test("2 Bots ready to start missions", async () => {
     const button = screen.getByRole("button", { name: "start-all-missions" });
     await userEvent.click(button);
 
-    expect(screen.getByText("Confirm"));
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
     expect(screen.getByText("Send missions to Bots: 1, 6")).toBeInTheDocument();
     expect(
         screen.getByText(
@@ -191,7 +191,7 @@ test("All Bots ready to start missions", async () => {
     const button = screen.getByRole("button", { name: "start-all-missions" });
     await userEvent.click(button);
 
-    expect(screen.getByText("Confirm"));
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
     expect(screen.getByText("Send missions to Bots: 1, 6")).toBeInTheDocument();
     expect(
         screen.queryByText(

--- a/src/web/components/StopAllBots/StopAllBotsButton.tsx
+++ b/src/web/components/StopAllBots/StopAllBotsButton.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+
+import { StopAllBotsDialog, DialogActions } from "./StopAllBotsDialog";
+import { DisabledCodes } from "../StopButton/stop-messages";
+
+import { Icon } from "@mdi/react";
+import { Button } from "@mui/material";
+import { mdiStop } from "@mdi/js";
+
+import Bot from "../../data/bots/bot";
+
+import { Command, CommandType } from "../../types/protobuf-types";
+import { isCommandAvailable, sendBotCommand } from "../../utils/commands";
+import { microsecondsToSeconds } from "../../utils/conversions";
+import { NO_COMMS_STATUS_AGE } from "../../utils/constants";
+
+import "../../style/stylesheets/util.less";
+
+interface Props {
+    bots: Map<number, Bot>;
+}
+
+type DisabledCodeGroup = [DisabledCodes, number[]];
+
+/**
+ * Produces the button to stop all Bots.
+ * It manages the alert/confirm dialog that appears when clicking on the button.
+ */
+export default function StopAllBotsButton(props: Props) {
+    const [isDialogVisible, setIsDialogVisible] = useState(false);
+    const [botReadyStates, setBotReadyStates] = useState(
+        new Map<DisabledCodes, number[]>(initBotReadyStates()),
+    );
+
+    /**
+     * Loops through the connected Bots and categorizes them based on their
+     * ability to be stopped. This sets the foundation for creating the correct
+     * alert/confirm message.
+     *
+     * @returns {void}
+     */
+    const groupBotsByReadyState = () => {
+        const updatedBotReadyStates = new Map<DisabledCodes, number[]>(initBotReadyStates());
+
+        for (const [botID, bot] of props.bots.entries()) {
+            if (isCommsDropped(bot.getStatusAge())) {
+                updatedBotReadyStates.get(DisabledCodes.NO_COMMS).push(botID);
+            } else if (!isCommandAvailable(CommandType.STOP, bot.getMissionStatus().missionState)) {
+                updatedBotReadyStates.get(DisabledCodes.MISSION_STATE).push(botID);
+            } else {
+                updatedBotReadyStates.get(DisabledCodes.NONE).push(botID);
+            }
+        }
+
+        setBotReadyStates(updatedBotReadyStates);
+    };
+
+    /**
+     * Triggers the state to open the alert/confirm dialog box with the Bots
+     * categorized to produce the correct alert/confirm message
+     *
+     * @returns {void}
+     */
+    const handleClick = () => {
+        setIsDialogVisible(true);
+        groupBotsByReadyState();
+    };
+
+    /**
+     * Closes the dialog box and follows up on the operator's action
+     *
+     * @param {DialogActions} dialogAction The operators action on the dialog box
+     * @returns {void}
+     */
+    const onDialogClose = (dialogAction: DialogActions) => {
+        setIsDialogVisible(false);
+
+        if (dialogAction === DialogActions.CONFIRMED) {
+            for (const botID of botReadyStates.get(DisabledCodes.NONE)) {
+                const stopCommand: Command = {
+                    bot_id: botID,
+                    type: CommandType.STOP,
+                };
+                sendBotCommand(stopCommand);
+            }
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                className={"jaia-button stop"}
+                aria-label={"stop-all-bots"}
+                onClick={() => handleClick()}
+            >
+                <Icon path={mdiStop} title="Stop All Bots" />
+            </Button>
+            <StopAllBotsDialog
+                isVisible={isDialogVisible}
+                botReadyStates={botReadyStates}
+                numBots={props.bots.size}
+                onClose={onDialogClose}
+            />
+        </div>
+    );
+}
+
+/**
+ * Maps each disabled code to an empty array to prevent undefined behavior
+ *
+ * @returns {Map<DisabledCodes, number[]>} Disabled codes mapped to an empty array for Bot IDs
+ */
+function initBotReadyStates() {
+    const botReadyStates: DisabledCodeGroup[] = [
+        [DisabledCodes.NONE, []],
+        [DisabledCodes.NO_COMMS, []],
+        [DisabledCodes.MISSION_STATE, []],
+    ];
+    return botReadyStates;
+}
+
+/**
+ * Checks the supplied status age against the no comms threshold
+ *
+ * @param {number} statusAge Bot's status age in microseconds
+ * @returns {boolean} True if the Bot does not have comms with the Hub
+ */
+function isCommsDropped(statusAge: number) {
+    return microsecondsToSeconds(statusAge) > NO_COMMS_STATUS_AGE;
+}

--- a/src/web/components/StopAllBots/StopAllBotsDialog.tsx
+++ b/src/web/components/StopAllBots/StopAllBotsDialog.tsx
@@ -1,4 +1,4 @@
-import { DisabledCodes } from "../StartMissionButton/start-mission-messages";
+import { DisabledCodes } from "../StopButton/stop-messages";
 
 interface DialogProps {
     isVisible: boolean;
@@ -22,11 +22,11 @@ export enum DialogActions {
 }
 
 /**
- * Produces the dialog box that appears when clicking on the start all missions button.
+ * Produces the dialog box that appears when clicking on the stop all Bots button.
  * This dialog will be a confirmation if at least one Bot can accept the command.
  * It will describe the reason(s) the other Bots cannot accept the command.
  */
-export function StartAllMissionsDialog(props: DialogProps) {
+export function StopAllBotsDialog(props: DialogProps) {
     /**
      * Applies the base class "jaia-dialog" and appends "alert"
      * if at least one Bot cannot receive the command to adjust spacing
@@ -73,9 +73,9 @@ export function StartAllMissionsDialog(props: DialogProps) {
 
         // Message start
         if (disabledCode === DisabledCodes.NONE) {
-            subMessage += `Send mission${botIDs.length > 1 ? "s" : ""} to Bot${botIDs.length > 1 ? "s: " : ": "}`;
+            subMessage += `Stop Bot${botIDs.length > 1 ? "s: " : ": "}`;
         } else {
-            subMessage += `Cannot send mission${botIDs.length > 1 ? "s" : ""} to Bot${botIDs.length > 1 ? "s: " : ": "}`;
+            subMessage += `Cannot stop Bot${botIDs.length > 1 ? "s: " : ": "}`;
         }
 
         // Adding Bot IDs to message
@@ -93,16 +93,7 @@ export function StartAllMissionsDialog(props: DialogProps) {
                 subMessage += `because ${botIDs.length > 1 ? "they do not have comms with the Hub." : "it does not have comms with the Hub."}`;
                 break;
             case DisabledCodes.MISSION_STATE:
-                subMessage += `because ${botIDs.length > 1 ? "they need to be activated to receive a mission." : "it needs to be activated to receive a mission."}`;
-                break;
-            case DisabledCodes.NO_MISSION_ASSIGNED:
-                subMessage += `because ${botIDs.length > 1 ? "they do not have an assigned mission." : "it does not have an assigned mission."}`;
-                break;
-            case DisabledCodes.DOWNLOAD_QUEUE:
-                subMessage += `because ${botIDs.length > 1 ? "they are in the download queue." : "it is in the download queue."}`;
-                break;
-            case DisabledCodes.LOW_BATTERY:
-                subMessage += `because ${botIDs.length > 1 ? "they have a crtically low battery." : "it has a critically low battery."}`;
+                subMessage += `because ${botIDs.length > 1 ? "they are not in a mission." : "it is not in a mission."}`;
                 break;
         }
 
@@ -152,7 +143,7 @@ function Title(props: TitleProps) {
 
 /**
  * Produces the buttons for the dialox box.
- * For a confirmation dialog, the buttons will be Cancel and Start Missions.
+ * For a confirmation dialog, the buttons will be Cancel and Stop Bots.
  * For an alert, the button will be Close.
  */
 function ButtonRow(props: ButtonRowProps) {
@@ -167,7 +158,7 @@ function ButtonRow(props: ButtonRowProps) {
                     className="dialog-button"
                     onClick={() => props.onClose(DialogActions.CONFIRMED)}
                 >
-                    {`${numReadyBots > 1 ? "Start Missions" : "Start Mission"}`}
+                    {`${numReadyBots > 1 ? "Stop Bots" : "Stop Bot"}`}
                 </button>
             </div>
         );

--- a/src/web/components/StopAllBots/StopAllBotsDialog.tsx
+++ b/src/web/components/StopAllBots/StopAllBotsDialog.tsx
@@ -29,7 +29,7 @@ export enum DialogActions {
 export function StopAllBotsDialog(props: DialogProps) {
     /**
      * Applies the base class "jaia-dialog" and appends "alert"
-     * if at least one Bot cannot receive the command to adjust spacing
+     * if at least one Bot cannot receive the command
      *
      * @returns {string} The class name for the dialog div
      */

--- a/src/web/components/StopAllBots/__tests__/StopAllBots.test.tsx
+++ b/src/web/components/StopAllBots/__tests__/StopAllBots.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+import StopAllBotsButton from "../StopAllBotsButton";
+
+import { bots } from "../../../data/bots/bots";
+
+import { PortalBotStatus } from "../../../shared/PortalStatus";
+import { MissionState } from "../../../types/protobuf-types";
+
+// Ready
+const botStatusMock1: PortalBotStatus = {
+    bot_id: 1,
+    mission_state: MissionState.IN_MISSION__UNDERWAY__MOVEMENT__TRANSIT,
+    portalStatusAge: 1_000_000, // microseconds
+    battery_percent: 75,
+};
+
+// Status age error
+const botStatusMock2: PortalBotStatus = {
+    bot_id: 2,
+    mission_state: MissionState.PRE_DEPLOYMENT__WAIT_FOR_MISSION_PLAN,
+    portalStatusAge: 40_000_000, // microseconds
+};
+
+// Mission state error
+const botStatusMock3: PortalBotStatus = {
+    bot_id: 3,
+    mission_state: MissionState.PRE_DEPLOYMENT__IDLE,
+    portalStatusAge: 1_000_000, // microseconds
+};
+
+const botStatusMock4: PortalBotStatus = {
+    bot_id: 4,
+    mission_state: MissionState.IN_MISSION__UNDERWAY__TASK__DIVE__DIVE_PREP,
+    portalStatusAge: 1_000_000, // microseconds
+    battery_percent: 75,
+};
+
+bots.setBot(botStatusMock2);
+bots.setBot(botStatusMock3);
+
+// Mock Jaia API
+const originalModule = jest.requireActual("../../../utils/jaia-api");
+originalModule.jaiaAPI.hit = jest
+    .fn()
+    .mockResolvedValue({ code: 200, msg: "Mocked Success", bots: [], hubs: [] });
+
+test("0 Bots accepting stop commands", async () => {
+    render(<StopAllBotsButton bots={bots.getBots()} />);
+    const button = screen.getByRole("button", { name: "stop-all-bots" });
+    await userEvent.click(button);
+
+    expect(screen.getByText("Alert")).toBeInTheDocument();
+    expect(
+        screen.getByText("Cannot stop Bot: 2 because it does not have comms with the Hub."),
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText("Cannot stop Bot: 3 because it is not in a mission."),
+    ).toBeInTheDocument();
+
+    // Close dialog
+    const closeButton = screen.getByText("Close");
+    await userEvent.click(closeButton);
+    expect(screen.queryByText("Alert")).toBeNull();
+});
+
+test("1 Bot accepting stop commands", async () => {
+    bots.setBot(botStatusMock1);
+
+    render(<StopAllBotsButton bots={bots.getBots()} />);
+    const button = screen.getByRole("button", { name: "stop-all-bots" });
+    await userEvent.click(button);
+
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+    expect(screen.getByText("Stop Bot: 1")).toBeInTheDocument();
+    expect(
+        screen.getByText("Cannot stop Bot: 2 because it does not have comms with the Hub."),
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText("Cannot stop Bot: 3 because it is not in a mission."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Stop Bot")).toBeInTheDocument();
+
+    // Cancel dialog
+    const cancelButton = screen.getByText("Cancel");
+    await userEvent.click(cancelButton);
+    expect(screen.queryByText("Confirm")).toBeNull();
+});
+
+test("2 Bots accepting stop commands", async () => {
+    bots.setBot(botStatusMock4);
+
+    render(<StopAllBotsButton bots={bots.getBots()} />);
+    const button = screen.getByRole("button", { name: "stop-all-bots" });
+    await userEvent.click(button);
+
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+    expect(screen.getByText("Stop Bots: 1, 4")).toBeInTheDocument();
+    expect(
+        screen.getByText("Cannot stop Bot: 2 because it does not have comms with the Hub."),
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText("Cannot stop Bot: 3 because it is not in a mission."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Stop Bots")).toBeInTheDocument();
+
+    // Stop Bots
+    const stopButton = screen.getByText("Stop Bots");
+    await userEvent.click(stopButton);
+    expect(screen.queryByText("Confirm")).toBeNull();
+});
+
+test("All Bots accepting stop commands", async () => {
+    bots.getBots().clear();
+    bots.setBot(botStatusMock1);
+    bots.setBot(botStatusMock4);
+
+    render(<StopAllBotsButton bots={bots.getBots()} />);
+    const button = screen.getByRole("button", { name: "stop-all-bots" });
+    await userEvent.click(button);
+
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+    expect(screen.getByText("Stop Bots: 1, 4")).toBeInTheDocument();
+    expect(
+        screen.queryByText("Cannot stop Bot: 2 because it does not have comms with the Hub."),
+    ).toBeNull();
+    expect(screen.getByText("Stop Bots")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+});

--- a/src/web/components/StopButton/stop-messages.ts
+++ b/src/web/components/StopButton/stop-messages.ts
@@ -1,8 +1,10 @@
 export enum DisabledCodes {
-    NONE = 0,
-    MISSION_STATE = 1,
+    NONE = 1,
+    NO_COMMS = 2,
+    MISSION_STATE = 3,
 }
 export const messages: ReadonlyMap<DisabledCodes, string> = new Map([
     [DisabledCodes.NONE, ""],
+    [DisabledCodes.NO_COMMS, "The Bot does not have comms with the Hub."],
     [DisabledCodes.MISSION_STATE, "The Bot can only be stopped while it is performing a mission."],
 ]);

--- a/src/web/components/TopButtonList/TopButtonList.tsx
+++ b/src/web/components/TopButtonList/TopButtonList.tsx
@@ -2,9 +2,10 @@ import { useContext } from "react";
 import { JaiaContext, JaiaDispatchContext } from "../../context/JaiaContext";
 
 import ActivateAllButton from "../ActivateAllButton/ActivateAllButton";
+import StopAllBotsButton from "../StopAllBots/StopAllBotsButton";
+import StartAllMissionsButton from "../StartAllMissionsButton/StartAllMissionsButton";
 
 import { Button } from "@mui/material";
-import StartAllMissionsButton from "../StartAllMissionsButton/StartAllMissionsButton";
 
 /**
  * Displays the buttons located at the top of the JCC
@@ -20,7 +21,7 @@ export default function TopButtonList() {
     return (
         <div className="button-list top">
             <ActivateAllButton bots={jaiaContext.bots} />
-            <Button className="jaia-button"></Button>
+            <StopAllBotsButton bots={jaiaContext.bots} />
             <StartAllMissionsButton bots={jaiaContext.bots} missions={jaiaContext.missions} />
             <Button className="jaia-button"></Button>
             <Button className="jaia-button"></Button>

--- a/src/web/style/stylesheets/button.less
+++ b/src/web/style/stylesheets/button.less
@@ -40,3 +40,7 @@
 .jaia-button.disabled {
     background-color: @disabled-color !important;
 }
+
+.jaia-button.stop {
+    background-color: @error-color !important;
+}


### PR DESCRIPTION
### Summary
Re-instates the stop all button following the structure of the start all missions button.

### Testing
**Unit tests cover:**
* 0 Bots accepting the stop command
* 1 Bot accepting the stop command
* 2 Bots accepting the stop command
* All Bots accepting the stop command

**Simulation tests covered:**
* Stopping various Bots (based on command conditions) while they conducted missions