### PR TITLE
bug/missing-jdv-dep-dataclasses

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -8,6 +8,7 @@ Adafruit-PlatformDetect==3.75.0
 Adafruit-PureIO==1.1.11
 binho-host-adapter==0.1.6
 cmocean==4.0.3
+dataclasses-json==0.6.7
 turfpy==0.0.7
 ./pyjaia
 ./pyjaiaprotobuf


### PR DESCRIPTION
This addresses #1209 and adds a dependency of dataclasses-json to requirements.txt
