### PR TITLE
task/log-info-for-taskpacket-version-change

### DIFF
--- a/src/python/pyjaia/src/pyjaia/task_packet_database.py
+++ b/src/python/pyjaia/src/pyjaia/task_packet_database.py
@@ -185,7 +185,7 @@ class TaskPacketDatabase:
             int: The version of the set of TaskPackets
         """
         with self._lock:
-            l.warning('getting task packet version')
+            l.info('getting task packet version')
             return self.task_packets_version
 
 


### PR DESCRIPTION
## Description

Change to info for getting task packet version instead of a warning.

## Test

This was tested in sim.