### PR TITLE
bug/ec-driver-warning-in-sim

### DIFF
--- a/src/bin/drivers/atlas_scientific_ezo_ec/app.cpp
+++ b/src/bin/drivers/atlas_scientific_ezo_ec/app.cpp
@@ -201,15 +201,7 @@ void jaiabot::apps::AtlasSalinityPublisher::health(goby::middleware::protobuf::T
     auto health_state = goby::middleware::protobuf::HEALTH__OK;
 
     //Check to see if the atlas_salinity is responding
-    if (cfg().atlas_salinity_report_in_simulation())
-    {
-        if (helm_ivp_in_mission_)
-        {
-            glog.is_debug1() && glog << "Simulation Sensor Check" << std::endl;
-            check_last_report(health, health_state);
-        }
-    }
-    else
+    if (!cfg().atlas_salinity_report_in_simulation())
     {
         check_last_report(health, health_state);
     }

--- a/src/bin/drivers/atlas_scientific_ezo_ec/app.cpp
+++ b/src/bin/drivers/atlas_scientific_ezo_ec/app.cpp
@@ -201,7 +201,15 @@ void jaiabot::apps::AtlasSalinityPublisher::health(goby::middleware::protobuf::T
     auto health_state = goby::middleware::protobuf::HEALTH__OK;
 
     //Check to see if the atlas_salinity is responding
-    if (!cfg().atlas_salinity_report_in_simulation())
+    if (cfg().atlas_salinity_report_in_simulation())
+    {
+        if (helm_ivp_in_mission_)
+        {
+            glog.is_debug1() && glog << "Simulation Sensor Check" << std::endl;
+            check_last_report(health, health_state);
+        }
+    }
+    else
     {
         check_last_report(health, health_state);
     }

--- a/src/bin/drivers/atlas_scientific_ezo_ec/app.cpp
+++ b/src/bin/drivers/atlas_scientific_ezo_ec/app.cpp
@@ -87,23 +87,6 @@ int main(int argc, char* argv[])
 
 double loop_freq = 10;
 
-// for string delimiter
-std::vector<std::string> split (std::string s, std::string delimiter) {
-    size_t pos_start = 0, pos_end, delim_len = delimiter.length();
-    std::string token;
-    std::vector<std::string> res;
-
-    while ((pos_end = s.find (delimiter, pos_start)) != std::string::npos) {
-        token = s.substr (pos_start, pos_end - pos_start);
-        pos_start = pos_end + delim_len;
-        res.push_back (token);
-    }
-
-    res.push_back (s.substr (pos_start));
-    return res;
-}
-
-
 jaiabot::apps::AtlasSalinityPublisher::AtlasSalinityPublisher()
     : zeromq::MultiThreadApplication<config::AtlasSalinityPublisher>(loop_freq * si::hertz)
 {
@@ -114,29 +97,14 @@ jaiabot::apps::AtlasSalinityPublisher::AtlasSalinityPublisher()
 
     interprocess().subscribe<atlas_salinity_udp_in>(
         [this](const goby::middleware::protobuf::IOData& data) {
-            auto s = std::string(data.data());
-            auto fields = split(s, ",");
-            if (fields.size() < 5)
-            {
-                glog.is_warn() && glog << group("main") << "Did not receive enough fields: " << s
-                                       << std::endl;
-                return;
-            }
-
-            int index = 0;
-
-            auto date_string = fields[index++];
-
-            jaiabot::protobuf::SalinityData output;
-
-            const double conductivity_raw = std::stod(fields[index++]);
-            output.set_conductivity_raw(conductivity_raw);
+            jaiabot::protobuf::SalinityData salinity_data;
+            salinity_data.ParseFromString(data.data());
 
             if (last_pressure_temperature_data_.has_temperature())
             {
                 const double specific_conductivity = calculate_specific_conductivity(
-                    output.conductivity_raw(), last_pressure_temperature_data_.temperature());
-                output.set_conductivity(specific_conductivity);
+                    salinity_data.conductivity_raw(), last_pressure_temperature_data_.temperature());
+                salinity_data.set_conductivity(specific_conductivity);
             }
 
             if (last_pressure_temperature_data_.has_temperature() &&
@@ -144,18 +112,15 @@ jaiabot::apps::AtlasSalinityPublisher::AtlasSalinityPublisher()
             {
                 const double ATMOSPHERIC_PRESSURE_DECIBARS = 10.1325;
                 const double salinity = calculate_derived_salinity(
-                    conductivity_raw, last_pressure_temperature_data_.temperature(),
+                    salinity_data.conductivity_raw(), last_pressure_temperature_data_.temperature(),
                     last_pressure_adjusted_data_.pressure_adjusted() +
                         ATMOSPHERIC_PRESSURE_DECIBARS);
-                output.set_salinity(salinity);
+                salinity_data.set_salinity(salinity);
             }
 
-            output.set_total_dissolved_solids(std::stod(fields[index++]));
-            output.set_salinity_raw(std::stod(fields[index++]));
+            glog.is_debug1() && glog << "=> " << salinity_data.ShortDebugString() << std::endl;
 
-            glog.is_debug1() && glog << "=> " << output.ShortDebugString() << std::endl;
-
-            interprocess().publish<groups::salinity>(output);
+            interprocess().publish<groups::salinity>(salinity_data);
 
             last_atlas_salinity_report_time_ = goby::time::SteadyClock::now();
         });

--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -424,8 +424,8 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
         salinity += salinity_distribution_(generator_);
 
         auto msg = jaiabot::protobuf::SalinityData();
+        // We only set the raw values here, because the derived values are calculated elsewhere, after the data comes in from the sensor.
         msg.set_conductivity_raw(45000.0);
-        msg.set_salinity_raw(salinity);
         msg.set_salinity_raw(salinity);
         msg.set_total_dissolved_solids(0.0);
 

--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -49,6 +49,7 @@
 #include "jaiabot/messages/jaia_dccl.pb.h"
 #include "jaiabot/messages/low_control.pb.h"
 #include "jaiabot/messages/sensor/pressure_temperature.pb.h"
+#include "jaiabot/messages/sensor/salinity.pb.h"
 #include "jaiabot/messages/simulator.pb.h"
 #include <goby/middleware/gpsd/groups.h>
 #include <goby/middleware/protobuf/gpsd.pb.h>
@@ -422,18 +423,14 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
         // randomize salinity
         salinity += salinity_distribution_(generator_);
 
-        // omit in sim
-        std::string time = "";
-        std::string conductivity = "45000.0";
-        std::string dissolved_solids = "0.0";
-        std::string specific_gravity = "0.0";
-
-        // date_string, conductivity, dissolved solids, salinity
-        ss << std::setprecision(std::numeric_limits<double>::digits10) << time << ","
-           << conductivity << "," << dissolved_solids << "," << salinity << "," << specific_gravity;
+        auto msg = jaiabot::protobuf::SalinityData();
+        msg.set_conductivity_raw(45000.0);
+        msg.set_salinity_raw(salinity);
+        msg.set_salinity_raw(salinity);
+        msg.set_total_dissolved_solids(0.0);
 
         auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
-        io_data->set_data(ss.str());
+        io_data->set_data(msg.SerializeAsString());
         interthread().publish<salinity_udp_out>(io_data);
     }
 

--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -426,10 +426,11 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
         std::string time = "";
         std::string conductivity = "45000.0";
         std::string dissolved_solids = "0.0";
+        std::string specific_gravity = "0.0";
 
         // date_string, conductivity, dissolved solids, salinity
         ss << std::setprecision(std::numeric_limits<double>::digits10) << time << ","
-           << conductivity << "," << dissolved_solids << "," << salinity;
+           << conductivity << "," << dissolved_solids << "," << salinity << "," << specific_gravity;
 
         auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
         io_data->set_data(ss.str());

--- a/src/python/atlas_scientific_ezo_ec/atlas_oem.py
+++ b/src/python/atlas_scientific_ezo_ec/atlas_oem.py
@@ -2,8 +2,12 @@
 
 try:
     from smbus import SMBus
-except:
-    from smbus2 import SMBus
+except ImportError:
+    try:
+        from smbus2 import SMBus
+    except ImportError:
+        print('Could not import smbus module.  No physical device is available.')
+
 
 class AtlasOEM:
 

--- a/src/python/atlas_scientific_ezo_ec/jaiabot_as-ezo-ec.py
+++ b/src/python/atlas_scientific_ezo_ec/jaiabot_as-ezo-ec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from time import sleep
 from datetime import datetime
 import random
@@ -7,6 +7,7 @@ import argparse
 import socket
 import logging
 import atlas_oem
+from jaiabot.messages.sensor.salinity_pb2 import SalinityData
 
 parser = argparse.ArgumentParser(description=\
     '''Read salinity from an Atlas Scientific EC EZO sensor, and publish over UDP port.  The data is published as a comma-separated series on one line.  These are the fields, in the order they will appear:
@@ -43,17 +44,17 @@ class Sensor:
             self.is_setup = True
             log.info(f'Salinity sensor I2C address: 0x{args.address:02x}')
 
-    def read(self):
+    def read(self) -> SalinityData:
         if not self.is_setup:
             self.setup()
 
         if self.device.newReadingAvailable():
-            EC = self.device.EC()
-            TDS = self.device.TDS()
-            S = self.device.salinity()
-            SG = 0.0
+            msg = SalinityData()
+            msg.conductivity_raw = self.device.EC()
+            msg.total_dissolved_solids = self.device.TDS()
+            msg.salinity_raw = self.device.salinity()
 
-            return [EC, TDS, S, SG]
+            return msg
         else:
             raise SensorError()
 
@@ -66,8 +67,12 @@ class SensorSimulator:
     def setup(self):
         pass
 
-    def read(self):
-        return [0, 0, 0, 0]
+    def read(self) -> SalinityData:
+        msg = SalinityData()
+        msg.conductivity_raw = 0.0
+        msg.total_dissolved_solids = 0.0
+        msg.salinity_raw = 0.0
+        return msg
 
 # Setup the device
 if args.simulator:
@@ -93,8 +98,5 @@ while True:
         log.warning(f'Exception on sensor.read(): {e}')
         continue
 
-    now = datetime.utcnow()
-    line = '%s,%9.2f,%9.2f,%9.2f,%9.2f\n' % (now.strftime('%Y-%m-%dT%H:%M:%SZ'), data[0], data[1], data[2], data[3])
-
-    sock.sendto(line.encode('utf8'), addr)
-    log.debug(f'Sent: {line}')
+    sock.sendto(data.SerializeToString(), addr)
+    log.debug(f'Sent: {data}')


### PR DESCRIPTION
So, the pipeline during runtime (non-simulation) for salinity data goes like this:
1.  `jaiabot_as-ezo-ec.py` sends the comma-delimited data over UDP
2.  `jaiabot_atlas_scientific_ezo_ec_driver` receives the comma-delimited data, parses it, then publishes the salinity message over Goby

During simulation, the simulated comma-delimited line of data is missing one of the new fields, and so the  `jaiabot_atlas_scientific_ezo_ec_driver` cannot process it.

I added in the missing field during simulation.