### PR TITLE
Add socat to runtime tools

### DIFF
--- a/scripts/setup-tools-runtime.sh
+++ b/scripts/setup-tools-runtime.sh
@@ -3,7 +3,7 @@
 echo "Removing timesyncd (conflicts with ntp)"
 sudo apt remove systemd-timesyncd
 echo "Installing apt packages"
-sudo apt-get install -y goby3-apps goby3-gui goby3-moos parallel moos-ivp-apps moos-ivp-gui libmoos-ivp opencpn i2c-tools libgoby3-moos libgoby3-moos-dev libxcb-xinerama0 ntp screen python3-dateutil python3-plotly python3-pyqt5 python3-h5py python3-geopandas python3-matplotlib python3-flask python3-networkx
+sudo apt-get install -y goby3-apps goby3-gui goby3-moos parallel moos-ivp-apps moos-ivp-gui libmoos-ivp opencpn i2c-tools libgoby3-moos libgoby3-moos-dev libxcb-xinerama0 ntp screen python3-dateutil python3-plotly python3-pyqt5 python3-h5py python3-geopandas python3-matplotlib python3-flask python3-networkx socat
 echo "Creating /etc/jaiabot directory"
 sudo install -d -m 0755 -o $USER /etc/jaiabot
 echo "Creating /var/log/jaiabot directory"


### PR DESCRIPTION
This is causing the docker sim to fail.

Also in https://github.com/jaiarobotics/jaiabot/pull/1241/files#diff-78917d91dba0eafcab2a0e0dcf8a1fe147f83959ae016f04e3a1d781cb6f13ddL6 but we can easily fix this now rather than wait until that is reviewed.