### PR TITLE
task/refactor-download-queue-2.y

### DIFF
--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -513,6 +513,9 @@ void jaiabot::apps::HubManager::loop()
         bots_pending_data_offload_.pop_front();
     }
 
+    for (int bot_id : bots_pending_data_offload_)
+    { latest_hub_status_.mutable_bot_offload()->add_bots_pending(bot_id); }
+
     if (last_health_report_time_ + std::chrono::seconds(cfg().health_report_timeout_seconds()) <
         goby::time::SteadyClock::now())
     {

--- a/src/lib/messages/hub.proto
+++ b/src/lib/messages/hub.proto
@@ -43,8 +43,9 @@ message HubStatus
     message BotOffloadData
     {
         required uint32 bot_id = 1;
-        optional int32 data_offload_percentage = 2;
+        optional uint32 data_offload_percentage = 2;
         optional bool offload_succeeded = 3;
+        repeated uint32 bots_pending = 4;
     }
     optional BotOffloadData bot_offload = 13;
 

--- a/src/web/components/ButtonList/ButtonList.tsx
+++ b/src/web/components/ButtonList/ButtonList.tsx
@@ -2,17 +2,18 @@ import { useContext } from "react";
 import { JaiaContext, JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 
+import RallyButton from "../RallyButton/RallyButton";
 import ActivateAllButton from "../ActivateAllButton/ActivateAllButton";
 import StopAllBotsButton from "../StopAllBots/StopAllBotsButton";
+import DataOffloadAllButton from "../DataOfffloadAllButton/DataOffloadAllButton";
 import StartAllMissionsButton from "../StartAllMissionsButton/StartAllMissionsButton";
-import RallyButton from "../RallyButton/RallyButton";
 
 import { ButtonNames, ButtonTypes } from "../../types/context-types";
 import { ButtonListTypes } from "../../types/jaia-system-types";
 
 import Icon from "@mdi/react";
 import { Button } from "@mui/material";
-import { mdiHelp, mdiViewList } from "@mdi/js";
+import { mdiHelp, mdiProgressDownload, mdiViewList } from "@mdi/js";
 
 import JaiaLogo from "../../style/icons/jaia-logo.svg";
 
@@ -65,6 +66,7 @@ export default function ButtonList(props: Props) {
                 <ActivateAllButton bots={jaiaContext.bots} />
                 <StopAllBotsButton bots={jaiaContext.bots} />
                 <StartAllMissionsButton bots={jaiaContext.bots} missions={jaiaContext.missions} />
+                <DataOffloadAllButton bots={jaiaContext.bots} />
                 <RallyButton />
                 <Button className="jaia-button"></Button>
                 <Button
@@ -97,7 +99,15 @@ export default function ButtonList(props: Props) {
                 >
                     <Icon path={mdiViewList} title="Missions Panel" />
                 </Button>
-                <Button className="jaia-button"></Button>
+                <Button
+                    className={getSelectedClassName(ButtonNames.DATA_OFFLOAD_PANEL)}
+                    aria-label="data-offload-panel"
+                    onClick={() =>
+                        handleButtonClick(ButtonTypes.PANEL, ButtonNames.DATA_OFFLOAD_PANEL)
+                    }
+                >
+                    <Icon path={mdiProgressDownload} title="Data Offload Panel" />
+                </Button>
                 <Button className="jaia-button"></Button>
                 <Button className="jaia-button"></Button>
             </div>

--- a/src/web/components/DataOfffloadAllButton/DataOffloadAllButton.tsx
+++ b/src/web/components/DataOfffloadAllButton/DataOffloadAllButton.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+
+import { DataOffloadAllDialog, DialogActions } from "./DataOffloadAllDialog";
+import { DisabledCodes } from "../DataOffloadButton/data-offload-messages";
+
+import { Icon } from "@mdi/react";
+import { Button } from "@mui/material";
+import { mdiDownloadMultiple } from "@mdi/js";
+
+import Bot from "../../data/bots/bot";
+
+import { NO_COMMS_STATUS_AGE } from "../../utils/constants";
+import { Command, CommandType } from "../../types/protobuf-types";
+import { microsecondsToSeconds } from "../../utils/conversions";
+import { isCommandAvailable, sendBotCommand } from "../../utils/commands";
+
+interface Props {
+    bots: Map<number, Bot>;
+}
+
+type DisabledCodeGroup = [DisabledCodes, number[]];
+
+/**
+ * Produces the button to offload data for all Bots.
+ * It manages the alert/confirm dialog that appears when clicking on the button.
+ */
+export default function DataOffloadAllButton(props: Props) {
+    const [isDialogVisible, setIsDialogVisible] = useState(false);
+    const [botReadyStates, setBotReadyStates] = useState(
+        new Map<DisabledCodes, number[]>(initBotReadyStates()),
+    );
+
+    /**
+     * Loops through the connected Bots and categorizes them based on their
+     * ability to offload data. This sets the foundation for creating the correct
+     * alert/confirm message.
+     *
+     * @returns {void}
+     */
+    const groupBotsByReadyState = () => {
+        const updatedBotReadyStates = new Map<DisabledCodes, number[]>(initBotReadyStates());
+
+        for (const [botID, bot] of props.bots.entries()) {
+            if (isCommsDropped(bot.getStatusAge())) {
+                updatedBotReadyStates.get(DisabledCodes.NO_COMMS).push(botID);
+            } else if (
+                !isCommandAvailable(CommandType.RECOVERED, bot.getMissionStatus().missionState)
+            ) {
+                updatedBotReadyStates.get(DisabledCodes.MISSION_STATE).push(botID);
+            } else if (!bot.getWifiLinkQuality()) {
+                updatedBotReadyStates.get(DisabledCodes.WIFI_QUALITY).push(botID);
+            } else {
+                updatedBotReadyStates.get(DisabledCodes.NONE).push(botID);
+            }
+        }
+
+        setBotReadyStates(updatedBotReadyStates);
+    };
+
+    /**
+     * Triggers the state to open the alert/confirm dialog box with the Bots
+     * categorized to produce the correct alert/confirm message
+     *
+     * @returns {void}
+     */
+    const handleClick = () => {
+        setIsDialogVisible(true);
+        groupBotsByReadyState();
+    };
+
+    /**
+     * Closes the dialog box and follows up on the operator's action
+     *
+     * @param {DialogActions} dialogAction The operators action on the dialog box
+     * @returns {void}
+     */
+    const onDialogClose = (dialogAction: DialogActions) => {
+        setIsDialogVisible(false);
+
+        if (dialogAction === DialogActions.CONFIRMED) {
+            for (const botID of botReadyStates.get(DisabledCodes.NONE)) {
+                const dataOffloadCommand: Command = {
+                    bot_id: botID,
+                    type: CommandType.RECOVERED,
+                };
+                sendBotCommand(dataOffloadCommand);
+            }
+        }
+    };
+
+    return (
+        <div>
+            <Button
+                className={"jaia-button"}
+                aria-label={"data-offload-all-bots"}
+                onClick={() => handleClick()}
+            >
+                <Icon path={mdiDownloadMultiple} title="Data Offload All" />
+            </Button>
+            <DataOffloadAllDialog
+                isVisible={isDialogVisible}
+                botReadyStates={botReadyStates}
+                numBots={props.bots.size}
+                onClose={onDialogClose}
+            />
+        </div>
+    );
+}
+
+/**
+ * Maps each disabled code to an empty array to prevent undefined behavior
+ *
+ * @returns {Map<DisabledCodes, number[]>} Disabled codes mapped to an empty array for Bot IDs
+ */
+function initBotReadyStates() {
+    const botReadyStates: DisabledCodeGroup[] = [
+        [DisabledCodes.NONE, []],
+        [DisabledCodes.NO_COMMS, []],
+        [DisabledCodes.MISSION_STATE, []],
+        [DisabledCodes.WIFI_QUALITY, []],
+        [DisabledCodes.DOWNLOAD_QUEUE, []],
+    ];
+    return botReadyStates;
+}
+
+/**
+ * Checks the supplied status age against the no comms threshold
+ *
+ * @param {number} statusAge Bot's status age in microseconds
+ * @returns {boolean} True if the Bot does not have comms with the Hub
+ */
+function isCommsDropped(statusAge: number) {
+    return microsecondsToSeconds(statusAge) > NO_COMMS_STATUS_AGE;
+}

--- a/src/web/components/DataOfffloadAllButton/DataOffloadAllDialog.tsx
+++ b/src/web/components/DataOfffloadAllButton/DataOffloadAllDialog.tsx
@@ -1,0 +1,177 @@
+import { DisabledCodes } from "../DataOffloadButton/data-offload-messages";
+
+interface DialogProps {
+    isVisible: boolean;
+    botReadyStates: Map<DisabledCodes, number[]>;
+    numBots: number;
+    onClose: (dialogAction: DialogActions) => void;
+}
+
+interface TitleProps {
+    botReadyStates: Map<DisabledCodes, number[]>;
+}
+
+interface ButtonRowProps {
+    botReadyStates: Map<DisabledCodes, number[]>;
+    onClose: (dialogAction: DialogActions) => void;
+}
+
+export enum DialogActions {
+    NONE = 0,
+    CONFIRMED = 1,
+}
+
+/**
+ * Produces the dialog box that appears when clicking on the data offload all button.
+ * This dialog will be a confirmation if at least one Bot can accept the command.
+ * It will describe the reason(s) the other Bots cannot accept the command.
+ */
+export function DataOffloadAllDialog(props: DialogProps) {
+    /**
+     * Applies the base class "jaia-dialog" and appends "alert"
+     * if at least one Bot cannot receive the command
+     *
+     * @returns {string} The class name for the dialog div
+     */
+    const getClassName = () => {
+        return `jaia-dialog ${props.botReadyStates.get(DisabledCodes.NONE).length !== props.numBots ? "alert" : ""}`;
+    };
+
+    /**
+     * Places each sub message to be displayed in the dialox box in an array.
+     * The messages depend on the state of the Bot and the requirments of the command.
+     *
+     * @returns {string[]} The messages to be displayed in the dialog box
+     */
+    const generateMessage = () => {
+        const message: string[] = [];
+
+        // Halve the length to only count the names
+        const disabledCodesLength = Object.keys(DisabledCodes).length / 2;
+
+        for (let i = 1; i <= disabledCodesLength; i++) {
+            message.push(generateSubMessage(i));
+        }
+
+        return message;
+    };
+
+    /**
+     * Produces the messages that appear in the dialog box. These messages describe
+     * which Bot(s) can accept the command and which Bot(s) cannot.
+     *
+     * @returns {string} Sub message to display to an operator in the dialog box
+     */
+    const generateSubMessage = (disabledCode: DisabledCodes) => {
+        const botIDs = props.botReadyStates.get(disabledCode);
+
+        if (botIDs.length === 0) {
+            return "";
+        }
+
+        let subMessage = "";
+
+        // Message start
+        if (disabledCode === DisabledCodes.NONE) {
+            subMessage += `Offload data for Bot${botIDs.length > 1 ? "s: " : ": "}`;
+        } else {
+            subMessage += `Cannot send command to Bot${botIDs.length > 1 ? "s: " : ": "}`;
+        }
+
+        // Adding Bot IDs to message
+        for (let i = 0; i < botIDs.length; i++) {
+            if (i + 1 < botIDs.length) {
+                subMessage += botIDs[i] + ", ";
+            } else {
+                subMessage += botIDs[i] + " ";
+            }
+        }
+
+        // Message end
+        switch (disabledCode) {
+            case DisabledCodes.NO_COMMS:
+                subMessage += `because ${botIDs.length > 1 ? "they do not have comms with the Hub." : "it does not have comms with the Hub."}`;
+                break;
+            case DisabledCodes.MISSION_STATE:
+                subMessage += `because ${botIDs.length > 1 ? "they are not in an idle state." : "it is not in an idle state."}`;
+                break;
+            case DisabledCodes.WIFI_QUALITY:
+                subMessage += `because ${botIDs.length > 1 ? "they are not connected to the Hub Wi-Fi network." : "it is not connected to the Hub Wi-Fi network."}`;
+                break;
+            case DisabledCodes.DOWNLOAD_QUEUE:
+                subMessage += `because ${botIDs.length > 1 ? "they are in the data offload queue." : "it is in the data offload queue."}`;
+                break;
+        }
+
+        return subMessage;
+    };
+
+    /**
+     * Converts the message into an array of paragraph elements for React to render
+     *
+     * @returns {JSX.Element[]} Paragraph elements containing alert messages
+     */
+    const formatMessage = () => {
+        return generateMessage().map((subMessage, index) => {
+            if (subMessage !== "") {
+                return <p key={index}>{subMessage}</p>;
+            }
+        });
+    };
+
+    if (!props.isVisible) {
+        return <div></div>;
+    }
+
+    return (
+        <div className="jaia-dialog-container">
+            <div className="blocking-overlay" onClick={() => {}}></div>
+            <div className={getClassName()}>
+                <Title botReadyStates={props.botReadyStates} />
+                {formatMessage()}
+                <ButtonRow botReadyStates={props.botReadyStates} onClose={props.onClose} />
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Produces the title for the dialog box. If there is nothing blocking the command from
+ * being sent to at least one Bot the title will be Confirm, otherwise it will be Alert.
+ */
+function Title(props: TitleProps) {
+    if (props.botReadyStates.get(DisabledCodes.NONE).length > 0) {
+        return <h1>Confirm</h1>;
+    }
+
+    return <h1>Alert</h1>;
+}
+
+/**
+ * Produces the buttons for the dialox box.
+ * For a confirmation dialog, the buttons will be Cancel and Offload Data.
+ * For an alert, the button will be Close.
+ */
+function ButtonRow(props: ButtonRowProps) {
+    const numReadyBots = props.botReadyStates.get(DisabledCodes.NONE).length;
+    if (numReadyBots > 0) {
+        return (
+            <div className="dialog-button-row">
+                <button className="dialog-button" onClick={() => props.onClose(DialogActions.NONE)}>
+                    Cancel
+                </button>
+                <button
+                    className="dialog-button"
+                    onClick={() => props.onClose(DialogActions.CONFIRMED)}
+                >
+                    Offload Data
+                </button>
+            </div>
+        );
+    }
+    return (
+        <button className="dialog-button" onClick={() => props.onClose(DialogActions.NONE)}>
+            Close
+        </button>
+    );
+}

--- a/src/web/components/DataOffloadButton/DataOffloadButton.tsx
+++ b/src/web/components/DataOffloadButton/DataOffloadButton.tsx
@@ -8,10 +8,8 @@ import { Button } from "@mui/material";
 import { mdiDownload } from "@mdi/js";
 
 import Bot from "../../data/bots/bot";
-import { CommandType } from "../../types/protobuf-types";
-import { isCommandAvailable } from "../../utils/commands";
-
-import "../../style/stylesheets/util.less";
+import { Command, CommandType } from "../../types/protobuf-types";
+import { isCommandAvailable, sendBotCommand } from "../../utils/commands";
 
 interface Props {
     bot: Bot;
@@ -72,7 +70,11 @@ export default function DataOffloadButton(props: Props) {
         setIsDialogVisible(false);
 
         if (dialogAction === DialogActions.CONFIRMED) {
-            // Send data offload command
+            const dataOffloadCommand: Command = {
+                bot_id: props.bot.getBotID(),
+                type: CommandType.RECOVERED,
+            };
+            sendBotCommand(dataOffloadCommand);
         }
     };
 

--- a/src/web/components/DataOffloadButton/DataOffloadDialog.tsx
+++ b/src/web/components/DataOffloadButton/DataOffloadDialog.tsx
@@ -66,7 +66,7 @@ function Title(props: TitleProps) {
 
 /**
  * Produces the buttons for the dialox box.
- * For a confirmation dialog, the buttons will be Cancel and Start Data Offload.
+ * For a confirmation dialog, the buttons will be Cancel and Offload Data.
  * For an alert, the button will be Close.
  */
 function ButtonRow(props: ButtonRowProps) {
@@ -80,7 +80,7 @@ function ButtonRow(props: ButtonRowProps) {
                     className="dialog-button"
                     onClick={() => props.onClose(DialogActions.CONFIRMED)}
                 >
-                    Start Data Offload
+                    Offload Data
                 </button>
             </div>
         );

--- a/src/web/components/DataOffloadButton/__tests__/DataOffloadButton.test.tsx
+++ b/src/web/components/DataOffloadButton/__tests__/DataOffloadButton.test.tsx
@@ -53,5 +53,5 @@ test("Click data offload button in enabled state", async () => {
     await userEvent.click(button);
     expect(screen.getByText("Confirm")).toBeInTheDocument();
     expect(screen.getByText("Cancel")).toBeInTheDocument();
-    expect(screen.getByText("Start Data Offload")).toBeInTheDocument();
+    expect(screen.getByText("Offload Data")).toBeInTheDocument();
 });

--- a/src/web/components/DataOffloadButton/data-offload-messages.ts
+++ b/src/web/components/DataOffloadButton/data-offload-messages.ts
@@ -1,12 +1,14 @@
 export enum DisabledCodes {
-    NONE = 0,
-    MISSION_STATE = 1,
-    WIFI_QUALITY = 2,
-    DOWNLOAD_QUEUE = 3,
+    NONE = 1,
+    NO_COMMS = 2,
+    MISSION_STATE = 3,
+    WIFI_QUALITY = 4,
+    DOWNLOAD_QUEUE = 5,
 }
 
 export const messages = new Map<DisabledCodes, string>([
     [DisabledCodes.NONE, ""],
+    [DisabledCodes.NO_COMMS, "The Bot does not have comms with the Hub."],
     [
         DisabledCodes.MISSION_STATE,
         "Cannot start a data offload because the Bot is not in an idle state. Try sending the stop command first.",

--- a/src/web/components/DataOffloadPanel/DataOffloadPanel.less
+++ b/src/web/components/DataOffloadPanel/DataOffloadPanel.less
@@ -1,0 +1,5 @@
+.data-offload-panel {
+    display: flex;
+    flex-direction: column;
+    row-gap: 15px;
+}

--- a/src/web/components/DataOffloadPanel/DataOffloadPanel.tsx
+++ b/src/web/components/DataOffloadPanel/DataOffloadPanel.tsx
@@ -1,0 +1,26 @@
+import DataOffloadQueue from "../DataOffloadQueue/DataOffloadQueue";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
+
+import "./DataOffloadPanel.less";
+
+/**
+ * Displays the data offload queue and buttons to download task packet data
+ */
+export default function DataOffloadPanel() {
+    return (
+        <div className="jaia-panel data-offload-panel">
+            <div className="jaia-panel-title">Data Offload</div>
+            <div>
+                <Accordion className="accordion-container">
+                    <AccordionSummary className="accordion-summary" expandIcon={<ExpandMoreIcon />}>
+                        Progress Queue
+                    </AccordionSummary>
+                    <AccordionDetails>
+                        <DataOffloadQueue />
+                    </AccordionDetails>
+                </Accordion>
+            </div>
+        </div>
+    );
+}

--- a/src/web/components/DataOffloadQueue/DataOffloadQueue.less
+++ b/src/web/components/DataOffloadQueue/DataOffloadQueue.less
@@ -1,0 +1,29 @@
+@import "../../style/stylesheets/vars.less";
+
+.data-offload-queue {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+
+    width: 240px;
+
+    padding: 9px;
+}
+
+.queue-item {
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+    gap: 15px;
+
+    background-color: @cc-accordian-color;
+    color: @cc-text-color-light;
+
+    border: 1px solid @cc-accordian-color;
+    border-radius: 3px;
+
+    font-size: 1.05rem;
+    font-weight: 600;
+
+    padding: 6px;
+}

--- a/src/web/components/DataOffloadQueue/DataOffloadQueue.tsx
+++ b/src/web/components/DataOffloadQueue/DataOffloadQueue.tsx
@@ -1,0 +1,72 @@
+import CircularProgress from "@mui/joy/CircularProgress";
+import { useContext } from "react";
+import { JaiaContext } from "../../context/JaiaContext";
+import { DEFAULT_HUB_ID } from "../../utils/constants";
+import "./DataOffloadQueue.less";
+
+interface Props {
+    botID: number;
+    offloadPercentage: number;
+}
+
+/**
+ * Displays which Bots will offload data and the progress
+ */
+export default function DataOffloadQueue() {
+    const jaiaContext = useContext(JaiaContext);
+    if (jaiaContext === null) {
+        return;
+    }
+
+    const hub = jaiaContext.hubs.get(DEFAULT_HUB_ID);
+    if (!hub) {
+        return;
+    }
+
+    /**
+     * Creates a QueueItem component for each Bot pending a data offload
+     *
+     * @returns {QueueItem[]} QueueItem elements for Bots pending data offload
+     */
+    const renderBotsPending = () => {
+        const botsPending = hub.getBotOffload().bots_pending;
+        if (botsPending) {
+            return botsPending.map((botID) => (
+                <QueueItem botID={botID} offloadPercentage={0} key={botID} />
+            ));
+        }
+        return;
+    };
+
+    const botOffload = hub.getBotOffload();
+    if (botOffload) {
+        return (
+            <div className="data-offload-queue">
+                <QueueItem
+                    botID={botOffload.bot_id}
+                    offloadPercentage={botOffload.data_offload_percentage}
+                    key={botOffload.bot_id}
+                />
+                {renderBotsPending()}
+            </div>
+        );
+    }
+
+    return <div className="data-offload-queue"></div>;
+}
+
+/**
+ * Creates structure for Bots in the process of or awaiting a data offload
+ */
+function QueueItem(props: Props) {
+    if (props.offloadPercentage === 100) {
+        return;
+    }
+
+    return (
+        <div className="queue-item">
+            <div>Bot {props.botID}</div>
+            <CircularProgress determinate value={props.offloadPercentage} color="danger" />
+        </div>
+    );
+}

--- a/src/web/containers/BotDetails/BotDetails.tsx
+++ b/src/web/containers/BotDetails/BotDetails.tsx
@@ -15,6 +15,7 @@ import StopButton from "../../components/StopButton/StopButton";
 import SystemButton from "../../components/SystemButton/SystemButton";
 import ActivateButton from "../../components/ActivateButton/ActivateButton";
 import NextTaskButton from "../../components/NextTaskButton/NextTaskButton";
+import DataOffloadButton from "../../components/DataOffloadButton/DataOffloadButton";
 import StartMissionButton from "../../components/StartMissionButton/StartMissionButton";
 import RemoteControlButton from "../../components/RemoteControlButton/RemoteControlButton";
 
@@ -35,7 +36,7 @@ import {
 } from "./bot-details";
 
 import { DEFAULT_HUB_ID } from "../../utils/constants";
-import { addDropdownListener } from "../../utils/style";
+import { accordionTheme, addDropdownListener } from "../../utils/style";
 import {
     formatLatitude,
     formatLongitude,
@@ -44,7 +45,7 @@ import {
 } from "../../shared/Utilities";
 
 // MDI and MUI
-import { ThemeProvider, createTheme } from "@mui/material";
+import { ThemeProvider } from "@mui/material";
 import Button from "@mui/material/Button";
 import Accordion from "@mui/material/Accordion";
 import Typography from "@mui/material/Typography";
@@ -54,12 +55,6 @@ import AccordionDetails from "@mui/material/AccordionDetails";
 
 import rcModeIcon from "../../style/icons/controller.svg";
 import "./BotDetails.less";
-
-const accordionTheme = createTheme({
-    transitions: {
-        create: () => "none",
-    },
-});
 
 export default function BotDetails() {
     const jaiaContext: JaiaContextType = useContext(JaiaContext);
@@ -242,6 +237,7 @@ export default function BotDetails() {
                             <AccordionDetails>
                                 <div className="accordion-details-buttons bot-commands">
                                     <ActivateButton bot={bot} />
+                                    <DataOffloadButton bot={bot} />
                                     <RemoteControlButton bot={bot} />
                                     <NextTaskButton bot={bot} />
                                 </div>

--- a/src/web/containers/BotDetails/bot-details.ts
+++ b/src/web/containers/BotDetails/bot-details.ts
@@ -81,7 +81,10 @@ export function getBotOffloadPercent(botID: number, hub: Hub) {
     let botOffloadPercentage = "";
 
     if (botID === hub.getBotOffload()?.bot_id) {
-        botOffloadPercentage = " " + hub.getBotOffload().data_offload_percentage + "%";
+        const data_offload_percentage = hub.getBotOffload().data_offload_percentage;
+        if (data_offload_percentage && data_offload_percentage !== 100) {
+            botOffloadPercentage = " " + data_offload_percentage + "%";
+        }
     }
 
     return botOffloadPercentage;

--- a/src/web/containers/HubDetails/HubDetails.tsx
+++ b/src/web/containers/HubDetails/HubDetails.tsx
@@ -10,7 +10,7 @@ import {
     formatLongitude,
 } from "../../shared/Utilities";
 import { DEFAULT_HUB_ID } from "../../utils/constants";
-import { addDropdownListener } from "../../utils/style";
+import { accordionTheme, addDropdownListener } from "../../utils/style";
 import { getIPPrefix } from "../../shared/IPPrefix";
 import { HubAccordionNames } from "../../types/context-types";
 
@@ -21,7 +21,7 @@ import Typography from "@mui/material/Typography";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
-import { ThemeProvider, createTheme } from "@mui/material";
+import { ThemeProvider } from "@mui/material";
 import { Icon } from "@mdi/react";
 import {
     mdiPower,
@@ -33,12 +33,6 @@ import {
 } from "@mdi/js";
 
 import "./HubDetails.less";
-
-const accordionTheme = createTheme({
-    transitions: {
-        create: () => "none",
-    },
-});
 
 export default function HubDetails() {
     const jaiaContext = useContext(JaiaContext);

--- a/src/web/containers/LayerSwitcherMenu/LayerSwitcherMenu.tsx
+++ b/src/web/containers/LayerSwitcherMenu/LayerSwitcherMenu.tsx
@@ -5,6 +5,7 @@ import { JaiaActions } from "../../context/jaia-actions";
 import { layers } from "../../openlayers/layers/layers";
 import { LayerTitles } from "../../types/openlayers-types";
 import { MapLayerAccordionNames } from "../../types/context-types";
+import { accordionTheme } from "../../utils/style";
 
 import Accordion from "@mui/material/Accordion";
 import Typography from "@mui/material/Typography";
@@ -12,7 +13,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import Checkbox from "@mui/material/Checkbox";
-import { Radio, ThemeProvider, createTheme } from "@mui/material";
+import { Radio, ThemeProvider } from "@mui/material";
 import { grey } from "@mui/material/colors";
 
 import "./LayerSwitcherMenu.less";
@@ -65,13 +66,6 @@ export default function LayerSwitcherMenu() {
 
     const [layerCheckedStates, setLayerCheckedStates] = useState(getDefaultLayerCheckedStates());
     const [checkedBaseMap, setCheckedBaseMap] = useState(getDefaultBaseMapLayerCheckedState());
-    const [accordionTheme, setAccordionTheme] = useState(
-        createTheme({
-            transitions: {
-                create: () => "none",
-            },
-        }),
-    );
 
     /**
      * Notifies Context which accordion the operator clicked on. This data lives in Context

--- a/src/web/containers/MissionsPanel/MissionsList/MissionsList.tsx
+++ b/src/web/containers/MissionsPanel/MissionsList/MissionsList.tsx
@@ -9,7 +9,7 @@ import DeleteMissionButton from "../../../components/DeleteMissionButton/DeleteM
 
 import { missionsManager } from "../../../data/missions_manager/missions-manager";
 import { UNASSIGNED_ID } from "../../../utils/constants";
-import { addDropdownListener, scrollMissionsList } from "../../../utils/style";
+import { accordionTheme, addDropdownListener, scrollMissionsList } from "../../../utils/style";
 import JaiaToggle from "../../../components/JaiaToggle/JaiaToggle";
 
 // MUI | MDI
@@ -22,7 +22,6 @@ import {
     AccordionSummary,
     Button,
     ThemeProvider,
-    createTheme,
 } from "@mui/material";
 
 import "./MissionsList.less";
@@ -30,9 +29,6 @@ import "./MissionsList.less";
 interface MissionAccordionTitleProps {
     missionID: number;
 }
-
-// Disable animations from MUI accordions because of lag experienced by operators
-const accordionTheme = createTheme({ transitions: { create: () => "none" } });
 
 export default function MissionsList() {
     const jaiaContext = useContext(JaiaContext);

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -13,6 +13,7 @@ import ButtonList from "../components/ButtonList/ButtonList";
 import HelpWindow from "../components/HelpWindow/HelpWindow";
 import MissionsPanel from "../containers/MissionsPanel/MissionsPanel";
 import WaypointPanel from "../components/WaypointPanel/WaypointPanel";
+import DataOffloadPanel from "../components/DataOffloadPanel/DataOffloadPanel";
 import RemoteControlPanel from "../components/RemoteControlPanel/RemoteControlPanel";
 
 import "./App.less";
@@ -75,6 +76,8 @@ function Panel() {
             return <HelpWindow />;
         case ButtonNames.JAIA_ABOUT_PANEL:
             return <JaiaAbout />;
+        case ButtonNames.DATA_OFFLOAD_PANEL:
+            return <DataOffloadPanel />;
         default:
             return <div></div>;
     }

--- a/src/web/types/context-types.ts
+++ b/src/web/types/context-types.ts
@@ -55,6 +55,7 @@ export const enum ButtonTypes {
 export const enum ButtonNames {
     NONE = "none",
     ADD_RALLY = "add_rally",
+    DATA_OFFLOAD_PANEL = "data_offload_panel",
     HELP_PANEL = "help_panel",
     JAIA_ABOUT_PANEL = "jaia_about_panel",
     MISSIONS_PANEL = "missions_panel",

--- a/src/web/types/protobuf-types.ts
+++ b/src/web/types/protobuf-types.ts
@@ -1204,6 +1204,7 @@ export interface BotOffloadData {
     bot_id: number;
     data_offload_percentage?: number;
     offload_succeeded?: boolean;
+    bots_pending?: number[];
 }
 
 export interface ContactStatus {

--- a/src/web/utils/style.ts
+++ b/src/web/utils/style.ts
@@ -1,4 +1,5 @@
 import { SCROLL_DELAY } from "./constants";
+import { createTheme } from "@mui/material";
 
 interface XYCoordinate {
     x: number;
@@ -9,6 +10,9 @@ export enum MapIconColors {
     SELECTED = "turquoise",
     DEFAULT = "white",
 }
+
+// Disable animations from MUI accordions because of lag experienced by operators
+export const accordionTheme = createTheme({ transitions: { create: () => "none" } });
 
 export enum Cursors {
     DEFAULT = "default",


### PR DESCRIPTION
Apply changes from #1243 to the 2.y baselined developer friendly jcc branch

```
git switch feature/2.y/developer-friendly-jcc
git pull
git switch -c task/refactor-download-queue-2.y
git cherry-pick -m 1 829486e
```
original PR

=============================================================================

* Add bots pending data offload to hub status message

* Add Bot offload button to Bot details

* Create DataOffloadAll button + send queue from Hub

* Create minimal data offload queue

* Style queue items

* Create data offload panel

* Move accordion theme to util file

* Remove percentage when last offload completes

* Remove test cases

* Update expected output for test