### PR TITLE
bug/oms-srp-with-no-constant-heading

### DIFF
--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -452,11 +452,13 @@ jaiabot::statechart::inmission::underway::task::Dive::Dive(typename StateBase::m
     imu_command.set_type(IMUCommand::START_BOTTOM_TYPE_SAMPLING);
     this->interprocess().template publish<jaiabot::groups::imu>(imu_command);
 
+    boost::optional<protobuf::MissionTask> current_task = context<Task>().current_task();
     // Is this an echo task?
-    bool start_echo_sensor = context<Task>().current_task()->start_echo();
+    bool start_echo_sensor = current_task ? current_task->start_echo() : false;
 
     if (start_echo_sensor)
     {
+        context<InMission>().set_is_echo_recording(start_echo_sensor);
         // Start echo recording
         auto echo_command = EchoCommand();
         echo_command.set_type(EchoCommand::CMD_START);
@@ -496,8 +498,8 @@ jaiabot::statechart::inmission::underway::task::Dive::~Dive()
     imu_command.set_type(IMUCommand::STOP_BOTTOM_TYPE_SAMPLING);
     this->interprocess().template publish<jaiabot::groups::imu>(imu_command);
 
-    // Is this an echo task?
-    bool stop_echo_sensor = context<Task>().current_task()->start_echo();
+    // Is echo recording?
+    bool stop_echo_sensor = context<InMission>().is_echo_recording();
 
     if (stop_echo_sensor)
     {
@@ -505,7 +507,7 @@ jaiabot::statechart::inmission::underway::task::Dive::~Dive()
         auto echo_command = EchoCommand();
         echo_command.set_type(EchoCommand::CMD_STOP);
         this->interprocess().template publish<jaiabot::groups::echo>(echo_command);
-    }
+    }   
 }
 
 // Task::Dive::DivePrep

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -828,8 +828,7 @@ struct InMission
                         goby::glog << group("goal")
                                    << "CONSTANT_HEADING was the last goal. Proceeding to recovery."
                                    << std::endl;
-                    set_mission_complete();
-                    goal_index_ = RECOVERY_GOAL_INDEX;
+                    set_goal_index_to_final_goal();
                 }
                 // Stop after handling the first CONSTANT_HEADING
                 return;
@@ -840,9 +839,7 @@ struct InMission
         goby::glog.is_warn() &&
             goby::glog << group("goal") << "No CONSTANT_HEADING task found from goal index "
                        << goal_index_ << " onward. Proceeding to recovery." << std::endl;
-
-        set_mission_complete();
-        goal_index_ = RECOVERY_GOAL_INDEX;
+        set_goal_index_to_final_goal();
     }
     void set_goal_index_to_recovery()
     {
@@ -859,6 +856,13 @@ struct InMission
 
     bool use_heading_constant_pid() const { return use_heading_constant_pid_; }
 
+    void set_is_echo_recording(const bool& is_echo_recording)
+    {
+        is_echo_recording_ = is_echo_recording;
+    }
+
+    bool is_echo_recording() const { return is_echo_recording_; }
+
     using reactions = boost::mpl::list<
         boost::statechart::transition<EvNewMission, inmission::underway::Replan>,
         boost::statechart::transition<EvRecovered, PostDeployment>,
@@ -870,6 +874,7 @@ struct InMission
     int repeat_index_{0};
     bool mission_complete_{false};
     bool use_heading_constant_pid_{false};
+    bool is_echo_recording_{false};
 };
 
 namespace inmission
@@ -1388,6 +1393,7 @@ struct SurfaceDriftTaskCommon : boost::statechart::state<Derived, Parent>,
 
         if (start_echo_sensor)
         {
+            this->template context<InMission>().set_is_echo_recording(start_echo_sensor);
             // Start echo recording
             auto echo_command = EchoCommand();
             echo_command.set_type(EchoCommand::CMD_START);
@@ -1441,8 +1447,8 @@ struct SurfaceDriftTaskCommon : boost::statechart::state<Derived, Parent>,
             imu_command.set_type(IMUCommand::STOP_WAVE_HEIGHT_SAMPLING);
             this->interprocess().template publish<jaiabot::groups::imu>(imu_command);
 
-            // Is this an echo task?
-            bool stop_echo_sensor = this->template context<Task>().current_task()->start_echo();
+            // Is echo recording?
+            bool stop_echo_sensor = this->template context<InMission>().is_echo_recording();
 
             if (stop_echo_sensor)
             {


### PR DESCRIPTION
## Description

Fix bug where the mission manager crashed when the bot finished srp during a line survey mission. This was introduced in the last release 1.20.0. 

## Testing

One Lane

* No end task with SRP
* Dive end task with SRP
* Surface end task with SRP
* Station keep end task with SRP
* Constant heading end task with SRP

Multilane

* No end task with SRP
* Dive end task with SRP
* Surface end task with SRP
* Station keep end task with SRP
* Constant heading end task with SRP
* No end task echo turned on with Dives and had an set SRP
* Dive end task echo turned on with Dives and had an set SRP