### PR TITLE
task/prevent-credential-push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,8 @@ __pycache__
 
 # SSH keys
 id_ecdsa
-id_ecdsa.pub
 id_ed25519
-id_ed25519.pub
 id_rsa
-id_rsa.pub
 
 # GPG keys
 *.gpg

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,3 @@ __pycache__
 id_ecdsa
 id_ed25519
 id_rsa
-
-# GPG keys
-*.gpg
-*.asc

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,27 @@ build/*
 config/launch/simulation/all.launch
 __pycache__
 .vscode
+
+# === private files ===
+
+*.key
+*.rsa
+
+# SSL
+*.cer
+*.crt
+*.der
+*.pem
+*.p12
+
+# SSH keys
+id_ecdsa
+id_ecdsa.pub
+id_ed25519
+id_ed25519.pub
+id_rsa
+id_rsa.pub
+
+# GPG keys
+*.gpg
+*.asc

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -17,7 +17,7 @@ credentials_phrases=(
 )
 
 for phrase in "${credentials_phrases[@]}"; do
-  if git diff --cached | grep -q "$phrase"; then
+  if git diff --cached | grep -Fq "$phrase"; then
     echo "Aborting commit due to inclusion of phrase '$phrase'"
     exit 1
   fi

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -6,4 +6,21 @@ scripts/git-hooks/clang-format-hooks/git-pre-commit-format
 # prettier
 scripts/git-hooks/prettier/write.sh
 
+# prevent secure credentials from being committed
+credentials_phrases=(
+  "SECURITY KEY"
+  "PRIVATE KEY"
+  "BEGIN RSA"
+  "BEGIN TRUSTED CERTIFICATE"
+  "BEGIN CERTIFICATE"
+  "BEGIN ENCRYPTED PRIVATE KEY"
+)
+
+for phrase in "${credentials_phrases[@]}"; do
+  if git diff --cached | grep -q "$phrase"; then
+    echo "Aborting commit due to inclusion of phrase '$phrase'"
+    exit 1
+  fi
+done
+
 exit 0


### PR DESCRIPTION
This PR introduces entries in the main .gitignore to prevent addition of files with extensions known to be associated with secret credentials. It also adds a pre-commit husky hook to prevent committing files containing certain phrases (case-sensitive) common to secret credential files.

How to test:
- Check text files with certain phrases are prevented from being committed