### PR TITLE
task/2.y/add-back-edit-mode-to-waypoint-panel/JAIA-2002 (#1251)

### DIFF
--- a/src/web/components/TaskParameters/TaskParameters.tsx
+++ b/src/web/components/TaskParameters/TaskParameters.tsx
@@ -14,15 +14,18 @@ import "./TaskParameters.less";
 
 interface Props {
     task: Task;
+    isDisabled: boolean;
 }
 
 interface SubProps {
     task: Task;
+    isDisabled: boolean;
     onChange: (evt: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 interface DiveParameterProps {
     task: Task;
+    isDisabled: boolean;
     handleBottomDiveClick: () => void;
     onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -64,14 +67,27 @@ export default function TaskParameters(props: Props) {
             return (
                 <DiveParameters
                     task={props.task}
+                    isDisabled={props.isDisabled}
                     onChange={onParameterChange}
                     handleBottomDiveClick={handleBottomDiveClick}
                 />
             );
         case TaskType.SURFACE_DRIFT:
-            return <DriftParameters task={props.task} onChange={onParameterChange} />;
+            return (
+                <DriftParameters
+                    task={props.task}
+                    isDisabled={props.isDisabled}
+                    onChange={onParameterChange}
+                />
+            );
         case TaskType.CONSTANT_HEADING:
-            return <ConstantHeading task={props.task} onChange={onParameterChange} />;
+            return (
+                <ConstantHeading
+                    task={props.task}
+                    isDisabled={props.isDisabled}
+                    onChange={onParameterChange}
+                />
+            );
         default:
             return <div></div>;
     }
@@ -88,6 +104,7 @@ function DiveParameters(props: DiveParameterProps) {
             <div className="dive-parameters">
                 <BottomDiveToggle
                     task={props.task}
+                    isDisabled={props.isDisabled}
                     handleBottomDiveClick={props.handleBottomDiveClick}
                 />
                 <div className="task-parameters">
@@ -98,6 +115,7 @@ function DiveParameters(props: DiveParameterProps) {
                         value={formatNumericalInput(props.task.getDriftParameters().drift_time)}
                         className="jaia-input"
                         autoComplete="off"
+                        disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
                     <div className="units">s</div>
@@ -109,6 +127,7 @@ function DiveParameters(props: DiveParameterProps) {
             <div className="dive-parameters">
                 <BottomDiveToggle
                     task={props.task}
+                    isDisabled={props.isDisabled}
                     handleBottomDiveClick={props.handleBottomDiveClick}
                 />
 
@@ -120,6 +139,7 @@ function DiveParameters(props: DiveParameterProps) {
                         value={formatNumericalInput(diveParameters.max_depth)}
                         className="jaia-input"
                         autoComplete="off"
+                        disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
                     <div className="units">m</div>
@@ -131,6 +151,7 @@ function DiveParameters(props: DiveParameterProps) {
                         value={formatNumericalInput(diveParameters.depth_interval)}
                         className="jaia-input"
                         autoComplete="off"
+                        disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
                     <div className="units">m</div>
@@ -142,6 +163,7 @@ function DiveParameters(props: DiveParameterProps) {
                         value={formatNumericalInput(diveParameters.hold_time)}
                         className="jaia-input"
                         autoComplete="off"
+                        disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
                     <div className="units">s</div>
@@ -153,6 +175,7 @@ function DiveParameters(props: DiveParameterProps) {
                         value={formatNumericalInput(props.task.getDriftParameters().drift_time)}
                         className="jaia-input"
                         autoComplete="off"
+                        disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
                     <div className="units">s</div>
@@ -175,6 +198,7 @@ function DriftParameters(props: SubProps) {
                 value={formatNumericalInput(props.task.getDriftParameters().drift_time)}
                 className="jaia-input"
                 autoComplete="off"
+                disabled={props.isDisabled}
                 onChange={(evt) => props.onChange(evt)}
             />
             <div className="units">s</div>
@@ -196,6 +220,7 @@ function ConstantHeading(props: SubProps) {
                 value={formatNumericalInput(constantHeadingParameters.constant_heading)}
                 className="jaia-input"
                 autoComplete="off"
+                disabled={props.isDisabled}
                 onChange={(evt) => props.onChange(evt)}
             />
             <div className="units">deg</div>
@@ -207,6 +232,7 @@ function ConstantHeading(props: SubProps) {
                 value={formatNumericalInput(constantHeadingParameters.constant_heading_time)}
                 className="jaia-input"
                 autoComplete="off"
+                disabled={props.isDisabled}
                 onChange={(evt) => props.onChange(evt)}
             />
             <div className="units">s</div>
@@ -218,6 +244,7 @@ function ConstantHeading(props: SubProps) {
                 value={formatNumericalInput(constantHeadingParameters.constant_heading_speed)}
                 className="jaia-input"
                 autoComplete="off"
+                disabled={props.isDisabled}
                 onChange={(evt) => props.onChange(evt)}
             />
             <div className="units">m/s</div>
@@ -244,6 +271,7 @@ function BottomDiveToggle(props: DiveParameterProps) {
             <JaiaToggle
                 checked={() => props.task.getIsBottomDive()}
                 onClick={() => props.handleBottomDiveClick()}
+                disabled={() => props.isDisabled}
             />
         </div>
     );

--- a/src/web/components/TaskParameters/__tests__/TaskParameters.test.tsx
+++ b/src/web/components/TaskParameters/__tests__/TaskParameters.test.tsx
@@ -9,7 +9,7 @@ const mockTask: Task = new Task();
 
 test("Render dive + drift parameters", () => {
     mockTask.setType(TaskType.DIVE);
-    render(<TaskParameters task={mockTask} />);
+    render(<TaskParameters task={mockTask} isDisabled={false} />);
     const depthParams = screen.getAllByDisplayValue(
         jaiaGlobal.getDefaultTaskParameters().dive.max_depth,
     );
@@ -24,7 +24,7 @@ test("Render dive + drift parameters", () => {
 
 test("Render drift parameters", () => {
     mockTask.setType(TaskType.SURFACE_DRIFT);
-    render(<TaskParameters task={mockTask} />);
+    render(<TaskParameters task={mockTask} isDisabled={false} />);
     const driftParams = screen.getByDisplayValue(
         jaiaGlobal.getDefaultTaskParameters().drift.drift_time,
     );
@@ -33,7 +33,7 @@ test("Render drift parameters", () => {
 
 test("Render constant heading parameters", () => {
     mockTask.setType(TaskType.CONSTANT_HEADING);
-    render(<TaskParameters task={mockTask} />);
+    render(<TaskParameters task={mockTask} isDisabled={false} />);
     const heading = screen.getByDisplayValue(
         jaiaGlobal.getDefaultTaskParameters().constantHeading.constant_heading,
     );

--- a/src/web/components/WaypointPanel/WaypointPanel.less
+++ b/src/web/components/WaypointPanel/WaypointPanel.less
@@ -20,6 +20,9 @@
 
     padding: 12px;
 
+    max-height: calc(@panel-max-height - 52px);
+    overflow: auto;
+
     background-color: @cc-background-color;
     font-size: 1.1rem;
 }
@@ -45,14 +48,14 @@
     background-color: #d1d5db;
 }
 
-.tap-to-move-row {
+.toggle-row {
     grid-column: 1 / 3;
     display: flex;
     align-items: center;
     gap: 15px;
 }
 
-.tap-to-move-row div {
+.toggle-row div {
     width: max-content;
 }
 
@@ -66,4 +69,16 @@
 
 .waypoint-panel .task-parameters-container {
     grid-column: 2 / 3;
+}
+
+.waypoint-panel-container .button-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 0 0 0;
+}
+
+.waypoint-panel-container .button-row button {
+    all: unset;
+    padding: 9px;
+    color: @cc-text-color-light;
 }

--- a/src/web/components/WaypointPanel/WaypointPanel.tsx
+++ b/src/web/components/WaypointPanel/WaypointPanel.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useContext, useEffect, useState } from "react";
+import cloneDeep from "lodash/cloneDeep";
 
 import TaskParameters from "../TaskParameters/TaskParameters";
 
@@ -6,12 +7,14 @@ import { JaiaContext, JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 import JaiaToggle from "../JaiaToggle/JaiaToggle";
 
+import Waypoint from "../../data/waypoints/waypoint";
 import { missionsManager } from "../../data/missions_manager/missions-manager";
 
 import { UNASSIGNED_ID } from "../../utils/constants";
 import { validateCoordinate } from "../../utils/input";
 
 import { CoordinateTypes } from "../../types/jaia-system-types";
+import { PanelActions } from "../../types/context-types";
 import { TaskType } from "../../types/protobuf-types";
 
 import Icon from "@mdi/react";
@@ -19,6 +22,8 @@ import { mdiDelete } from "@mdi/js";
 import { Button, FormControl, Select, MenuItem, SelectChangeEvent } from "@mui/material";
 
 import "./WaypointPanel.less";
+
+let originalWaypoint: Waypoint;
 
 /**
  * Displays information about the selected waypoint such as location and task selection
@@ -46,11 +51,10 @@ export default function WaypointPanel() {
 
     const [latInput, setLatInput] = useState(getWaypoint().getLocation().lat.toString());
     const [lonInput, setLonInput] = useState(getWaypoint().getLocation().lon.toString());
+    const isDisabled = jaiaContext.missionIDInEditMode !== jaiaContext.selectedWaypoint.missionID;
 
     useEffect(() => {
-        return () => {
-            jaiaDispatch({ type: JaiaActions.CLOSED_WAYPOINT_PANEL });
-        };
+        originalWaypoint = cloneDeep(getWaypoint());
     }, []);
 
     /**
@@ -143,7 +147,21 @@ export default function WaypointPanel() {
      * @returns {void}
      */
     const handleDeleteWaypointClick = () => {
-        jaiaDispatch({ type: JaiaActions.DELETE_WAYPOINT });
+        if (!isDisabled) {
+            jaiaDispatch({ type: JaiaActions.DELETE_WAYPOINT });
+        }
+    };
+
+    /**
+     * Dispatches action to toggle edit mode
+     *
+     * @returns {void}
+     */
+    const handleEditModeClick = () => {
+        jaiaDispatch({
+            type: JaiaActions.CLICKED_EDIT_MISSION,
+            missionID: jaiaContext.selectedWaypoint.missionID,
+        });
     };
 
     /**
@@ -200,6 +218,28 @@ export default function WaypointPanel() {
         });
     };
 
+    /**
+     * Dispatches action to close the waypoint panel. If the operator
+     * selects cancel, a copy of the waypoint made on the inital render
+     * of the is passed to the reducer.
+     *
+     * @param {PanelActions} panelAction How the panel closed
+     * @returns {void}
+     */
+    const handleClosePanelClick = (panelAction: PanelActions) => {
+        let waypoint: Waypoint;
+
+        if (panelAction === PanelActions.CANCEL) {
+            waypoint = originalWaypoint;
+        }
+
+        jaiaDispatch({
+            type: JaiaActions.CLOSED_WAYPOINT_PANEL,
+            panelAction: panelAction,
+            waypoint: waypoint,
+        });
+    };
+
     return (
         <div className="waypoint-panel-container">
             <div className="waypoint-panel">
@@ -207,7 +247,7 @@ export default function WaypointPanel() {
                 <div className="waypoint-input-container">
                     <div>{jaiaContext.selectedWaypoint.waypointNum}</div>
                     <Button
-                        className="jaia-button delete-waypoint"
+                        className={`jaia-button delete-waypoint ${isDisabled ? "disabled" : ""}`}
                         onClick={() => handleDeleteWaypointClick()}
                     >
                         <Icon path={mdiDelete} title="Delete Waypoint" />
@@ -220,11 +260,23 @@ export default function WaypointPanel() {
                 <div>{formatBotID()}</div>
 
                 <div className="line-break"></div>
+                <div className="toggle-row">
+                    <div className="label">Edit Mission:</div>
+                    <JaiaToggle
+                        checked={() =>
+                            jaiaContext.missionIDInEditMode ===
+                            jaiaContext.selectedWaypoint.waypointNum
+                        }
+                        onClick={() => handleEditModeClick()}
+                    />
+                </div>
 
-                <div className="tap-to-move-row">
+                <div className="line-break"></div>
+                <div className="toggle-row">
                     <div className="label">Tap to Move:</div>
                     <JaiaToggle
                         checked={() => getWaypoint().getIsMovable()}
+                        disabled={() => isDisabled}
                         onClick={() => handleTapToMoveClick()}
                     />
                 </div>
@@ -237,6 +289,7 @@ export default function WaypointPanel() {
                     value={getLatInput()}
                     className="jaia-input coordinate"
                     autoComplete="off"
+                    disabled={isDisabled}
                     onChange={(evt) => handleCoordinateChange(evt)}
                 />
 
@@ -246,6 +299,7 @@ export default function WaypointPanel() {
                     value={getLonInput()}
                     className="jaia-input coordinate"
                     autoComplete="off"
+                    disabled={isDisabled}
                     onChange={(evt) => handleCoordinateChange(evt)}
                 />
 
@@ -256,6 +310,7 @@ export default function WaypointPanel() {
                     <Select
                         value={getWaypoint().getTask().getType()}
                         onChange={(evt: SelectChangeEvent) => handleTaskMenuSelection(evt)}
+                        disabled={isDisabled}
                     >
                         <MenuItem value={TaskType.NONE}>
                             {formatMenuItemText(TaskType.NONE)}
@@ -276,8 +331,12 @@ export default function WaypointPanel() {
                 </FormControl>
 
                 <div className="task-parameters-container">
-                    <TaskParameters task={getWaypoint().getTask()} />
+                    <TaskParameters task={getWaypoint().getTask()} isDisabled={isDisabled} />
                 </div>
+            </div>
+            <div className="button-row">
+                <button onClick={() => handleClosePanelClick(PanelActions.CANCEL)}>Cancel</button>
+                <button onClick={() => handleClosePanelClick(PanelActions.DONE)}>Done</button>
             </div>
         </div>
     );

--- a/src/web/context/JaiaContext.tsx
+++ b/src/web/context/JaiaContext.tsx
@@ -9,6 +9,7 @@ import { missionsManager } from "../data/missions_manager/missions-manager";
 import Bot from "../data/bots/bot";
 import Hub from "../data/hubs/hub";
 import Mission from "../data/missions/mission";
+import Waypoint from "../data/waypoints/waypoint";
 
 import { map } from "../openlayers/maps/map";
 import { botLayer } from "../openlayers/layers/vector/bot-layer";
@@ -45,6 +46,7 @@ import {
     MapLayerAccordionNames,
     ButtonNames,
     ButtonTypes,
+    PanelActions,
 } from "../types/context-types";
 
 export interface JaiaContextType {
@@ -73,6 +75,7 @@ export interface JaiaAction {
     clickedNode?: SelectedNode;
     clickedWaypoint?: SelectedWaypoint;
 
+    waypoint?: Waypoint;
     location?: GeographicCoordinate;
     taskType?: TaskType;
     taskParameterPair?: TaskParameterPair;
@@ -80,6 +83,7 @@ export interface JaiaAction {
     hubAccordionName?: HubAccordionNames;
     botAccordionName?: BotAccordionNames;
     mapLayerAccordionName?: MapLayerAccordionNames;
+    panelAction?: PanelActions;
     buttonType?: ButtonTypes;
     buttonName?: ButtonNames;
     isMissionAccordionExpanded?: boolean;
@@ -187,7 +191,7 @@ function jaiaReducer(state: JaiaContextType, action: JaiaAction) {
             return handleClosedDetails(mutableState);
 
         case JaiaActions.CLOSED_WAYPOINT_PANEL:
-            return handleClosedWaypointPanel(mutableState);
+            return handleClosedWaypointPanel(mutableState, action.panelAction, action.waypoint);
 
         case JaiaActions.CLICKED_NODE:
             return handleClickedNode(mutableState, action.clickedNode);
@@ -578,21 +582,33 @@ function handleClosedDetails(mutableState: JaiaContextType) {
 }
 
 /**
- * Handles cleanup when a waypoint panel closes
+ * Handles cleanup when a waypoint panel closes. If the operator selects
+ * cancel, the waypoint data reverts to its state when the panel opened.
  *
  * @param {JaiaContextType} mutableState State object ref for making modifications
+ * @param {PanelActions} panelAction How the panel closes
+ * @param {Waypoint} serializedWaypoint Waypoint data at time the panel opened
  * @returns {JaiaContextType} Updated mutable state object
+ *
+ * @notes
+ * When the waypoint is passed through the dispatch function it is serialized. To restore
+ * its methods, we use Object.setPrototypeOf.
  */
-function handleClosedWaypointPanel(mutableState: JaiaContextType) {
-    const waypoint = getWaypoint();
-
-    // When waypoint is not deleted, disable movable property
-    if (waypoint) {
-        waypoint.setIsMovable(false);
+function handleClosedWaypointPanel(
+    mutableState: JaiaContextType,
+    panelAction: PanelActions,
+    serializedWaypoint?: Waypoint,
+) {
+    if (panelAction === PanelActions.CANCEL) {
+        const originalWaypoint = Object.setPrototypeOf(serializedWaypoint, Waypoint.prototype);
+        const waypoints = missions
+            .getMission(jaiaGlobal.getSelectedWaypoint().missionID)
+            .getWaypoints();
+        waypoints[jaiaGlobal.getSelectedWaypoint().waypointNum - 1] = originalWaypoint;
+        missionLayer.updateFeatures();
     }
-
-    jaiaGlobal.setSelectedWaypoint({ waypointNum: UNASSIGNED_ID, missionID: UNASSIGNED_ID });
-    mutableState.selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
+    resetSelectedWaypoint(mutableState);
+    mutableState.visiblePanel = ButtonNames.NONE;
     return mutableState;
 }
 
@@ -795,6 +811,7 @@ function handleClickedButton(mutableState: JaiaContextType, type: ButtonTypes, n
             if (mutableState.visiblePanel !== name) {
                 visiblePanel = name;
             }
+            resetSelectedWaypoint(mutableState);
             break;
     }
 
@@ -905,4 +922,21 @@ function getWaypoint() {
     if (mission) {
         return mission.getWaypoint(selectedWaypoint.waypointNum);
     }
+}
+
+/**
+ * Sets the selected waypoint to its default settings
+ *
+ * @param {JaiaContextType} mutableState State object ref for making modifications
+ * @returns {void}
+ */
+function resetSelectedWaypoint(mutableState: JaiaContextType) {
+    const waypoint = getWaypoint();
+
+    if (waypoint) {
+        waypoint.setIsMovable(false);
+    }
+
+    jaiaGlobal.setSelectedWaypoint({ waypointNum: UNASSIGNED_ID, missionID: UNASSIGNED_ID });
+    mutableState.selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
 }

--- a/src/web/types/context-types.ts
+++ b/src/web/types/context-types.ts
@@ -68,3 +68,8 @@ export enum DialogActions {
     NONE = 1,
     CONFIRMED = 2,
 }
+
+export enum PanelActions {
+    CANCEL = 1,
+    DONE = 2,
+}


### PR DESCRIPTION
### Summary
Cherry picks commit 3f626158170d1bb1562230355b6da701012b55fe (task/add-back-edit-mode-to-waypoint-panel/JAIA-2002 (#1251)) to be able to cleanly merge into `feature/2.y/developer-friendly-jcc`

* Add close + done buttons to bottom of waypoint panel

* Add functionality to cancel button

* Handle cancel + close + open new panel scenarios

* Disable + hide fields when mission not in edit mode

* Add edit toggle to waypoint panel

---------