### PR TITLE
task/2.y/match-button-order-with-2-y

### DIFF
--- a/src/web/components/ButtonList/ButtonList.tsx
+++ b/src/web/components/ButtonList/ButtonList.tsx
@@ -67,7 +67,6 @@ export default function ButtonList(props: Props) {
                 <StopAllBotsButton bots={jaiaContext.bots} />
                 <StartAllMissionsButton bots={jaiaContext.bots} missions={jaiaContext.missions} />
                 <DataOffloadAllButton bots={jaiaContext.bots} />
-                <RallyButton />
                 <Button className="jaia-button"></Button>
                 <Button
                     className={getSelectedClassName(ButtonNames.HELP_PANEL)}
@@ -99,6 +98,7 @@ export default function ButtonList(props: Props) {
                 >
                     <Icon path={mdiViewList} title="Missions Panel" />
                 </Button>
+                <RallyButton />
                 <Button
                     className={getSelectedClassName(ButtonNames.DATA_OFFLOAD_PANEL)}
                     aria-label="data-offload-panel"

--- a/src/web/style/stylesheets/button-list.less
+++ b/src/web/style/stylesheets/button-list.less
@@ -17,7 +17,8 @@
     top: 0;
 }
 
-.button-list.top img {
+.button-list.top img,
+.button-list.side img {
     width: 36px;
     height: auto;
 }


### PR DESCRIPTION
### Summary
Moves the rally point button to the side list to match the layout of the latest release

<img width="1716" height="1268" alt="image" src="https://github.com/user-attachments/assets/834a3263-0b83-44ab-b0f9-8c8ffdaa0311" />
