### PR TITLE
task/2.y/add-close-button-to-task-packet-panel

### DIFF
--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -50,6 +50,7 @@ export default function Map() {
                     return;
                 case MapFeatureTypes.RALLY_POINT:
                     handleRallyPointClick(feature);
+                    return;
                 case MapFeatureTypes.DIVE:
                     handleTaskPacketClick(feature, MapFeatureTypes.DIVE);
                 default:

--- a/src/web/components/TaskPacketPanel/TaskPacketPanel.less
+++ b/src/web/components/TaskPacketPanel/TaskPacketPanel.less
@@ -41,3 +41,12 @@
     height: 1px;
     background-color: #d1d5db;
 }
+
+.task-packet-panel-container button {
+    all: unset;
+    padding: 9px;
+    color: @cc-text-color-light;
+
+    display: flex;
+    justify-self: center;
+}

--- a/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
+++ b/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useMemo } from "react";
 import { JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 import { TaskPacket } from "../../types/protobuf-types";
+import { PanelActions } from "../../types/context-types";
 import { SelectedTaskPacket } from "../../types/jaia-system-types";
 
 import "./TaskPacketPanel.less";
@@ -54,6 +55,18 @@ export default function TaskPacketPanel(props: Props) {
         };
     }, []);
 
+    /**
+     * Dispatches action to close panel
+     *
+     * @returns {void}
+     */
+    const handleCloseClick = () => {
+        jaiaDispatch({
+            type: JaiaActions.CLOSED_TASK_PACKET_PANEL,
+            panelAction: PanelActions.CLOSE,
+        });
+    };
+
     if (taskPacket.dive) {
         return (
             <div className="task-packet-panel-container">
@@ -76,6 +89,7 @@ export default function TaskPacketPanel(props: Props) {
                     <div className="label">End Time:</div>
                     <div>{endTime}</div>
                 </div>
+                <button onClick={() => handleCloseClick()}>Close</button>
             </div>
         );
     }

--- a/src/web/context/JaiaContext.tsx
+++ b/src/web/context/JaiaContext.tsx
@@ -211,7 +211,7 @@ function jaiaReducer(state: JaiaContextType, action: JaiaAction) {
             return handleClosedWaypointPanel(mutableState, action.panelAction, action.waypoint);
 
         case JaiaActions.CLOSED_TASK_PACKET_PANEL:
-            return handleClosedTaskPacketPanel(mutableState);
+            return handleClosedTaskPacketPanel(mutableState, action.panelAction);
 
         case JaiaActions.CLOSED_RALLY_PANEL:
             return handleClosedRallyPanel(mutableState);
@@ -678,9 +678,16 @@ function handleClosedWaypointPanel(
  * Handles cleanup when the task packet panel closes
  *
  * @param {JaiaContextType} mutableState State object ref for making modifications
+ * @param {PanelActions} panelAction Indicates if a new panel opened or the close button was clicked
  * @returns {JaiaContextType} Updated mutable state object
  */
-function handleClosedTaskPacketPanel(mutableState: JaiaContextType) {
+function handleClosedTaskPacketPanel(mutableState: JaiaContextType, panelAction: PanelActions) {
+    if (panelAction === PanelActions.CLOSE) {
+        mutableState.visiblePanel = ButtonNames.NONE;
+        // useEffect in TaskPacketPanel will be triggered to conduct remaining cleanup
+        return mutableState;
+    }
+
     jaiaGlobal.setSelectedTaskPacket({
         botID: UNASSIGNED_ID,
         startTime: 0,

--- a/src/web/jcc/index.tsx
+++ b/src/web/jcc/index.tsx
@@ -49,7 +49,7 @@ const taskPacketInterval = setInterval(async () => {
             console.error(`Response status: ${response.status}`);
         } else {
             const json = await response.json();
-            taskPackets.setTaskPackets(json);
+            taskPackets.setTaskPackets(json.result.included);
             updateTaskLayers();
         }
     } catch (error) {

--- a/src/web/types/context-types.ts
+++ b/src/web/types/context-types.ts
@@ -74,4 +74,5 @@ export enum DialogActions {
 export enum PanelActions {
     CANCEL = 1,
     DONE = 2,
+    CLOSE = 3,
 }


### PR DESCRIPTION
### Summary
1. Updates path to task packet data from the API endpoint. This change is needed now that the task packet database is being used.
2. Adds a close button the task packet panel.

<img width="1722" height="725" alt="image" src="https://github.com/user-attachments/assets/8321c162-8fa1-44fb-9085-a66a81e45b58" />
