### PR TITLE
bug/rest-api-python-config

### DIFF
--- a/src/web/jcc.conf
+++ b/src/web/jcc.conf
@@ -4,7 +4,7 @@
     Alias /updates /var/www/html/updates
     Alias /reboot-check /var/www/html/reboot-check
 
-    WSGIDaemonProcess rest_api user=jaia group=jaia threads=5 python-path=/usr/share/jaiabot/python/pyjaiaprotobuf home=/usr/share/jaiabot/web/rest_api
+    WSGIDaemonProcess rest_api user=jaia group=jaia threads=5 python-home=/usr/share/jaiabot/python/venv home=/usr/share/jaiabot/web/rest_api
     WSGIDaemonProcess jcc user=jaia group=jaia threads=5 python-home=/usr/share/jaiabot/python/venv home=/usr/share/jaiabot/web/server
     WSGIScriptAlias /jaia/v0 /usr/share/jaiabot/web/server/app.wsgi/jaia/v0 process-group=jcc 
     WSGIScriptAlias /jaia /usr/share/jaiabot/web/rest_api/app.wsgi/jaia process-group=rest_api


### PR DESCRIPTION
## Description

The rest api was failing because it did not have the correct config to access the pyjaia library it needed for the taskpacket database code.

## Testing

This was tested on fleet 6, hubs: 1, 2, and 3.