### PR TITLE
task/2.y/add-back-skeleton-settings-panel/JAIA-2052

### DIFF
--- a/src/web/components/ButtonList/ButtonList.tsx
+++ b/src/web/components/ButtonList/ButtonList.tsx
@@ -13,7 +13,7 @@ import { ButtonListTypes } from "../../types/jaia-system-types";
 
 import Icon from "@mdi/react";
 import { Button } from "@mui/material";
-import { mdiHelp, mdiProgressDownload, mdiViewList } from "@mdi/js";
+import { mdiCog, mdiHelp, mdiProgressDownload, mdiViewList } from "@mdi/js";
 
 import JaiaLogo from "../../style/icons/jaia-logo.svg";
 
@@ -109,7 +109,13 @@ export default function ButtonList(props: Props) {
                     <Icon path={mdiProgressDownload} title="Data Offload Panel" />
                 </Button>
                 <Button className="jaia-button"></Button>
-                <Button className="jaia-button"></Button>
+                <Button
+                    className={getSelectedClassName(ButtonNames.SETTINGS_PANEL)}
+                    aria-label="settings-panel"
+                    onClick={() => handleButtonClick(ButtonTypes.PANEL, ButtonNames.SETTINGS_PANEL)}
+                >
+                    <Icon path={mdiCog} size={1.3} title="Settings Panel" />
+                </Button>
             </div>
         );
     }

--- a/src/web/components/SettingsPanel/SettingsPanel.less
+++ b/src/web/components/SettingsPanel/SettingsPanel.less
@@ -1,0 +1,5 @@
+.settings-panel {
+    display: flex;
+    flex-direction: column;
+    row-gap: 15px;
+}

--- a/src/web/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/web/components/SettingsPanel/SettingsPanel.tsx
@@ -5,6 +5,9 @@ import { Accordion, AccordionDetails, AccordionSummary, Typography } from "@mui/
 
 import "./SettingsPanel.less";
 
+/**
+ * Contains general configurations for the JCC and Jaia System
+ */
 export default function SettingsPanel() {
     return (
         <div className="jaia-panel settings-panel">

--- a/src/web/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/web/components/SettingsPanel/SettingsPanel.tsx
@@ -1,7 +1,45 @@
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { ThemeProvider } from "@emotion/react";
+import { accordionTheme } from "../../utils/style";
+import { Accordion, AccordionDetails, AccordionSummary, Typography } from "@mui/material";
+
+import "./SettingsPanel.less";
+
 export default function SettingsPanel() {
     return (
-        <div className="jaia-panel">
+        <div className="jaia-panel settings-panel">
             <div className="jaia-panel-title">Settings</div>
+            <div className="accordions-container">
+                <ThemeProvider theme={accordionTheme}>
+                    <Accordion className="accordion-container">
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            className="accordion-summary"
+                        >
+                            <Typography>Task Packets</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails></AccordionDetails>
+                    </Accordion>
+                    <Accordion className="accordion-container">
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            className="accordion-summary"
+                        >
+                            <Typography>Map Layers</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails></AccordionDetails>
+                    </Accordion>
+                    <Accordion className="accordion-container">
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            className="accordion-summary"
+                        >
+                            <Typography>Map Layers</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails></AccordionDetails>
+                    </Accordion>
+                </ThemeProvider>
+            </div>
         </div>
     );
 }

--- a/src/web/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/web/components/SettingsPanel/SettingsPanel.tsx
@@ -1,0 +1,7 @@
+export default function SettingsPanel() {
+    return (
+        <div className="jaia-panel">
+            <div className="jaia-panel-title">Settings</div>
+        </div>
+    );
+}

--- a/src/web/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/web/components/SettingsPanel/SettingsPanel.tsx
@@ -34,7 +34,7 @@ export default function SettingsPanel() {
                             expandIcon={<ExpandMoreIcon />}
                             className="accordion-summary"
                         >
-                            <Typography>Map Layers</Typography>
+                            <Typography>Engineering</Typography>
                         </AccordionSummary>
                         <AccordionDetails></AccordionDetails>
                     </Accordion>

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -13,6 +13,7 @@ import ButtonList from "../components/ButtonList/ButtonList";
 import HelpWindow from "../components/HelpWindow/HelpWindow";
 import RallyPanel from "../components/RallyPanel/RallyPanel";
 import MissionsPanel from "../containers/MissionsPanel/MissionsPanel";
+import SettingsPanel from "../components/SettingsPanel/SettingsPanel";
 import WaypointPanel from "../components/WaypointPanel/WaypointPanel";
 import TaskPacketPanel from "../components/TaskPacketPanel/TaskPacketPanel";
 import DataOffloadPanel from "../components/DataOffloadPanel/DataOffloadPanel";
@@ -89,6 +90,8 @@ function Panel() {
             );
         case ButtonNames.DATA_OFFLOAD_PANEL:
             return <DataOffloadPanel />;
+        case ButtonNames.SETTINGS_PANEL:
+            return <SettingsPanel />;
         default:
             return <div></div>;
     }

--- a/src/web/types/context-types.ts
+++ b/src/web/types/context-types.ts
@@ -61,6 +61,7 @@ export const enum ButtonNames {
     JAIA_ABOUT_PANEL = "jaia_about_panel",
     MISSIONS_PANEL = "missions_panel",
     RALLY_PANEL = "rally_panel",
+    SETTINGS_PANEL = "settings_panel",
     START_ALL_MISSIONS = "start_all_missions",
     TASK_PACKET_PANEL = "task_packet_panel",
     WAYPOINT_PANEL = "waypoint_panel",


### PR DESCRIPTION
### Summary
This pull request adds the framing for the settings panel. This includes three empty accordions to be completed in future tickets.

<img width="2156" height="1324" alt="image" src="https://github.com/user-attachments/assets/40b5dce9-1165-4a30-9be6-7db92ce63c06" />

### Testing
1. Settings panel opens and closes when the settings button is pressed.
2. Settings panel closes when another button is pressed.
3. All three accordions open and close on click.
