### PR TITLE
task/move-husky-changes-to-init-script

### DIFF
--- a/scripts/git-hooks/init/pre-commit/pre-commit
+++ b/scripts/git-hooks/init/pre-commit/pre-commit
@@ -6,4 +6,21 @@ scripts/git-hooks/clang-format-hooks/git-pre-commit-format
 # prettier
 scripts/git-hooks/prettier/write.sh
 
+# prevent secure credentials from being committed
+credentials_phrases=(
+  "SECURITY KEY"
+  "PRIVATE KEY"
+  "BEGIN RSA"
+  "BEGIN TRUSTED CERTIFICATE"
+  "BEGIN CERTIFICATE"
+  "BEGIN ENCRYPTED PRIVATE KEY"
+)
+
+for phrase in "${credentials_phrases[@]}"; do
+  if git diff --cached | grep -Fq "$phrase"; then
+    echo "Aborting commit due to inclusion of phrase '$phrase'"
+    exit 1
+  fi
+done
+
 exit 0


### PR DESCRIPTION
### Summary
`run.sh` copied an outdated pre-commit script to the `.husky` folder. This pull request updates the pre-commit template to prevent the file mismatch each time `run.sh` is executed.