### PR TITLE
bug/2.y/tap-to-move-without-edit-mode

### DIFF
--- a/src/web/context/JaiaContext.tsx
+++ b/src/web/context/JaiaContext.tsx
@@ -858,6 +858,8 @@ function handleClickedEditMission(mutableState: JaiaContextType, missionID: numb
         missionSet.setMissionIDInEditMode(missionID);
     } else {
         missionSet.setMissionIDInEditMode(UNASSIGNED_ID);
+        const waypoint = getWaypoint();
+        waypoint.setIsMovable(false);
     }
 
     mutableState.missionIDInEditMode = missionSet.getMissionIDInEditMode();


### PR DESCRIPTION
Bug description:  If a waypoint is selected and the mission is in edit mode and the user toggles on tap to move, the tap to move behavior continues on the waypoint even if edit mode is toggled off or a different mission is put in edit mode.

This fix sets the moveable flag of the currently selected waypoint to false if edit mode is toggled off.  