### PR TITLE
task/2.y/add-back-depth-contour-map

### DIFF
--- a/src/python/pyjaia/src/pyjaia/contours.py
+++ b/src/python/pyjaia/src/pyjaia/contours.py
@@ -168,7 +168,6 @@ def getContourValues(bottomDives: List[BottomDive], contourCount = 10):
     values = [b.depth for b in bottomDives]
     minValue = min(values)
     maxValue = max(values)
-    print(f"minValue: {minValue}    maxValue: {maxValue}")
 
     if minValue == maxValue:
         logging.warning('No contours to display, because all dives reach the same depth')

--- a/src/python/pyjaia/src/pyjaia/contours.py
+++ b/src/python/pyjaia/src/pyjaia/contours.py
@@ -161,13 +161,14 @@ def getContourValues(bottomDives: List[BottomDive], contourCount = 10):
     Returns:
         NDArray[float]: An array of equally-spaced contour values spanning the rand of depths for the `bottomDive` objects.
     """
-    if len(bottomDives) < 1:
+    if len(bottomDives) < 3:
         return [] # No bottom dives, so no contours.
 
     # Get contour values
     values = [b.depth for b in bottomDives]
     minValue = min(values)
     maxValue = max(values)
+    print(f"minValue: {minValue}    maxValue: {maxValue}")
 
     if minValue == maxValue:
         logging.warning('No contours to display, because all dives reach the same depth')

--- a/src/web/jcc/index.tsx
+++ b/src/web/jcc/index.tsx
@@ -1,8 +1,6 @@
 import * as ReactDOM from "react-dom/client";
 import App from "./App";
 
-import { fromLonLat } from "ol/proj";
-
 import { bots } from "../data/bots/bots";
 import { hubs } from "../data/hubs/hubs";
 import { taskPackets } from "../data/task_packets/task-packets";
@@ -12,6 +10,7 @@ import { hubLayer } from "../openlayers/layers/vector/hub-layer";
 import { missionLayer } from "../openlayers/layers/vector/mission-layer";
 import { diveLayer } from "../openlayers/layers/vector/dive-layer";
 import { driftLayer } from "../openlayers/layers/vector/drift-layer";
+import { contourLayer } from "../openlayers/layers/vector/contour-layer";
 import { hubCommsLayer } from "../openlayers/layers/vector/hub-comms-layer";
 import { DATA_MODEL_POLL_TIME, TASK_PACKET_POLL_TIME } from "../utils/constants";
 
@@ -97,6 +96,7 @@ function updateOpenLayers() {
 function updateTaskLayers() {
     diveLayer.updateFeatures();
     driftLayer.updateFeatures();
+    contourLayer.updateFeatures();
 }
 
 let element = document.getElementById("root");

--- a/src/web/openlayers/features/contour-feature.ts
+++ b/src/web/openlayers/features/contour-feature.ts
@@ -1,0 +1,26 @@
+import { GeoJSON } from "ol/format";
+import { view } from "../views/view";
+import { EQUIRECTANGULAR } from "../../utils/constants";
+import { Fill, Stroke, Style } from "ol/style";
+
+export function generateContourFeatures(geoJSON: any) {
+    const features = new GeoJSON().readFeatures(geoJSON);
+
+    features.forEach((feature) => {
+        feature.getGeometry()?.transform(EQUIRECTANGULAR, view.getProjection());
+        const properties = feature.getProperties();
+        const style = new Style();
+
+        if (properties?.fill) {
+            style.setFill(new Fill({ color: properties.fill }));
+        }
+
+        if (properties?.stroke) {
+            style.setStroke(new Stroke({ color: properties.stroke }));
+        }
+
+        feature.setStyle(style);
+    });
+
+    return features;
+}

--- a/src/web/openlayers/layers/layers.ts
+++ b/src/web/openlayers/layers/layers.ts
@@ -10,6 +10,7 @@ import { missionLayer } from "./vector/mission-layer";
 import { rallyLayer } from "./vector/rally-layer";
 import { diveLayer } from "./vector/dive-layer";
 import { driftLayer } from "./vector/drift-layer";
+import { contourLayer } from "./vector/contour-layer";
 import { measureLayer } from "./vector/measure-layer";
 import { hubCommsLayer } from "./vector/hub-comms-layer";
 
@@ -31,6 +32,7 @@ class Layers {
         this.layers.set(LayerTitles.RALLY_LAYER, rallyLayer.getVectorLayer());
         this.layers.set(LayerTitles.DIVE_LAYER, diveLayer.getVectorLayer());
         this.layers.set(LayerTitles.DRIFT_LAYER, driftLayer.getVectorLayer());
+        this.layers.set(LayerTitles.CONTOUR_LAYER, contourLayer.getVectorLayer());
         this.layers.set(LayerTitles.MEASURE_LAYER, measureLayer.getVectorLayer());
         this.layers.set(LayerTitles.HUB_COMMS_LAYER, hubCommsLayer.getVectorLayer());
     }

--- a/src/web/openlayers/layers/vector/contour-layer.ts
+++ b/src/web/openlayers/layers/vector/contour-layer.ts
@@ -1,6 +1,8 @@
 import JaiaVectorLayer from "./jaia-vector-layer";
 import { LayerTitles } from "../../../types/openlayers-types";
 import { layersZIndexes } from "../zindex";
+import { jaiaAPI } from "../../../utils/jaia-api";
+import { generateContourFeatures } from "../../features/contour-feature";
 
 class ContourLayer extends JaiaVectorLayer {
     constructor() {
@@ -8,8 +10,17 @@ class ContourLayer extends JaiaVectorLayer {
     }
 
     override updateFeatures() {
-        let source = this.getVectorLayer().getSource();
-        source.clear();
+        jaiaAPI
+            .getDepthContours()
+            .then((geoJSON) => {
+                const features = generateContourFeatures(geoJSON);
+                const source = this.getVectorLayer().getSource();
+                source.clear();
+                source.addFeatures(features);
+            })
+            .catch((error) => {
+                console.error(error);
+            });
     }
 }
 

--- a/src/web/openlayers/layers/vector/contour-layer.ts
+++ b/src/web/openlayers/layers/vector/contour-layer.ts
@@ -1,0 +1,16 @@
+import JaiaVectorLayer from "./jaia-vector-layer";
+import { LayerTitles } from "../../../types/openlayers-types";
+import { layersZIndexes } from "../zindex";
+
+class ContourLayer extends JaiaVectorLayer {
+    constructor() {
+        super(LayerTitles.CONTOUR_LAYER, layersZIndexes.get(LayerTitles.CONTOUR_LAYER));
+    }
+
+    override updateFeatures() {
+        let source = this.getVectorLayer().getSource();
+        source.clear();
+    }
+}
+
+export const contourLayer = new ContourLayer();

--- a/src/web/openlayers/layers/zindex.ts
+++ b/src/web/openlayers/layers/zindex.ts
@@ -2,12 +2,12 @@ import { LayerTitles } from "../../types/openlayers-types";
 
 export const layersZIndexes = new Map<LayerTitles, number>();
 
-layersZIndexes.set(LayerTitles.MEASURE_LAYER, 7);
-layersZIndexes.set(LayerTitles.BOT_LAYER, 6);
-layersZIndexes.set(LayerTitles.HUB_LAYER, 5);
-layersZIndexes.set(LayerTitles.MISSION_LAYER, 4);
-layersZIndexes.set(LayerTitles.RALLY_LAYER, 3);
-layersZIndexes.set(LayerTitles.DIVE_LAYER, 2);
-layersZIndexes.set(LayerTitles.DRIFT_LAYER, 2);
+layersZIndexes.set(LayerTitles.MEASURE_LAYER, 8);
+layersZIndexes.set(LayerTitles.BOT_LAYER, 7);
+layersZIndexes.set(LayerTitles.HUB_LAYER, 6);
+layersZIndexes.set(LayerTitles.MISSION_LAYER, 5);
+layersZIndexes.set(LayerTitles.RALLY_LAYER, 4);
+layersZIndexes.set(LayerTitles.DIVE_LAYER, 3);
+layersZIndexes.set(LayerTitles.DRIFT_LAYER, 3);
 layersZIndexes.set(LayerTitles.CONTOUR_LAYER, 2);
 layersZIndexes.set(LayerTitles.HUB_COMMS_LAYER, 1);

--- a/src/web/openlayers/layers/zindex.ts
+++ b/src/web/openlayers/layers/zindex.ts
@@ -9,4 +9,5 @@ layersZIndexes.set(LayerTitles.MISSION_LAYER, 4);
 layersZIndexes.set(LayerTitles.RALLY_LAYER, 3);
 layersZIndexes.set(LayerTitles.DIVE_LAYER, 2);
 layersZIndexes.set(LayerTitles.DRIFT_LAYER, 2);
+layersZIndexes.set(LayerTitles.CONTOUR_LAYER, 2);
 layersZIndexes.set(LayerTitles.HUB_COMMS_LAYER, 1);

--- a/src/web/types/openlayers-types.ts
+++ b/src/web/types/openlayers-types.ts
@@ -8,6 +8,7 @@ export enum LayerTitles {
     MISSION_LAYER = "mission-layer",
     DIVE_LAYER = "dive-layer",
     DRIFT_LAYER = "drift-layer",
+    CONTOUR_LAYER = "contour-layer",
     RALLY_LAYER = "rally-layer",
     MEASURE_LAYER = "measure-layer",
 }

--- a/src/web/utils/constants.ts
+++ b/src/web/utils/constants.ts
@@ -16,6 +16,7 @@ export const MIN_LAT = -90;
 export const MAX_LON = 180;
 export const MIN_LON = -180;
 export const MERCATOR = "EPSG:3857";
+export const EQUIRECTANGULAR = "EPSG:4326";
 export const MIN_SPEED = 0.5; // meters per second
 export const MAX_SPEED = 3; // meters per second
 export const HUB_COMMS_INNER_RADIUS = 250; // meters


### PR DESCRIPTION
### Summary
This pull request renders the contour map. Ed designed the contour processing to take place on the backend and made the data available through the contours endpoint. We poll this endpoint every 10 seconds (in unison with the task packet endpoint poll) to gain access to the GeoJSON data on the client side. We then use OpenLayers to convert the data to features and render the contour map.

### Testing
<img width="3838" height="1736" alt="image" src="https://github.com/user-attachments/assets/eda6e0ea-a4a0-4f51-bd35-fbd6086058b8" />
