### PR TITLE
task/2.y/refactor-move-waypoint-structure/JAIA-2076/

### DIFF
--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -118,8 +118,8 @@ export default function Map() {
     const handleWaypointClick = (feature: Feature<Geometry>) => {
         const selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
         if (
-            feature.get("missionID") != selectedWaypoint.missionID ||
-            feature.get("waypointNum") != selectedWaypoint.waypointNum
+            feature.get("missionID") !== selectedWaypoint.missionID ||
+            feature.get("waypointNum") !== selectedWaypoint.waypointNum
         ) {
             jaiaDispatch({
                 type: JaiaActions.CLICKED_WAYPOINT,

--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -3,7 +3,6 @@ import { JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 
 import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
-import { missionSet } from "../../data/mission_set/mission-set";
 
 import { Feature, MapBrowserEvent } from "ol";
 import { Coordinate } from "ol/coordinate";
@@ -15,7 +14,6 @@ import { view } from "../../openlayers/views/view";
 
 import { NodeTypes } from "../../types/jaia-system-types";
 import { MapFeatureTypes, MapModes } from "../../types/openlayers-types";
-import { UNASSIGNED_ID } from "../../utils/constants";
 
 import "./Map.less";
 
@@ -71,7 +69,7 @@ export default function Map() {
             }
         }
 
-        if (isWaypointMovable()) {
+        if (jaiaGlobal.getSelectedWaypoint().isMoveable) {
             handleMoveWaypointClick(event.coordinate);
             return;
         }
@@ -123,6 +121,7 @@ export default function Map() {
             clickedWaypoint: {
                 waypointNum: feature.get("waypointNum"),
                 missionID: feature.get("missionID"),
+                isMoveable: false,
             },
         });
     };
@@ -199,15 +198,7 @@ export default function Map() {
      * @returns {boolean} True if the waypoint is movable, false if not
      */
     const isWaypointMovable = () => {
-        if (jaiaGlobal.getSelectedWaypoint().waypointNum !== UNASSIGNED_ID) {
-            const mission = missionSet.getMission(jaiaGlobal.getSelectedWaypoint().missionID);
-            const waypoint = mission.getWaypoint(jaiaGlobal.getSelectedWaypoint().waypointNum);
-
-            if (waypoint.getIsMovable()) {
-                return true;
-            }
-        }
-        return false;
+        return jaiaGlobal.getSelectedWaypoint().isMoveable;
     };
 
     return <div id="map" data-testid="map"></div>;

--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -192,14 +192,5 @@ export default function Map() {
         });
     };
 
-    /**
-     * Checks to see if the selected waypoint is movable
-     *
-     * @returns {boolean} True if the waypoint is movable, false if not
-     */
-    const isWaypointMovable = () => {
-        return jaiaGlobal.getSelectedWaypoint().isMoveable;
-    };
-
     return <div id="map" data-testid="map"></div>;
 }

--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -116,14 +116,20 @@ export default function Map() {
      * @returns {void}
      */
     const handleWaypointClick = (feature: Feature<Geometry>) => {
-        jaiaDispatch({
-            type: JaiaActions.CLICKED_WAYPOINT,
-            clickedWaypoint: {
-                waypointNum: feature.get("waypointNum"),
-                missionID: feature.get("missionID"),
-                isMoveable: false,
-            },
-        });
+        const selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
+        if (
+            feature.get("missionID") != selectedWaypoint.missionID ||
+            feature.get("waypointNum") != selectedWaypoint.waypointNum
+        ) {
+            jaiaDispatch({
+                type: JaiaActions.CLICKED_WAYPOINT,
+                clickedWaypoint: {
+                    waypointNum: feature.get("waypointNum"),
+                    missionID: feature.get("missionID"),
+                    isMoveable: false,
+                },
+            });
+        }
     };
 
     /**

--- a/src/web/components/WaypointPanel/WaypointPanel.tsx
+++ b/src/web/components/WaypointPanel/WaypointPanel.tsx
@@ -275,7 +275,7 @@ export default function WaypointPanel() {
                 <div className="toggle-row">
                     <div className="label">Tap to Move:</div>
                     <JaiaToggle
-                        checked={() => getWaypoint().getIsMovable()}
+                        checked={() => jaiaContext.selectedWaypoint.isMoveable}
                         disabled={() => isDisabled}
                         onClick={() => handleTapToMoveClick()}
                     />

--- a/src/web/context/JaiaContext.tsx
+++ b/src/web/context/JaiaContext.tsx
@@ -31,7 +31,6 @@ import {
     TaskType,
 } from "../types/protobuf-types";
 import { DATA_MODEL_POLL_TIME, UNASSIGNED_ID } from "../utils/constants";
-import { compareWaypoints } from "../utils/comparisons";
 import { MapModes } from "../types/openlayers-types";
 import { MapFeatureTypes } from "../types/openlayers-types";
 import {
@@ -881,7 +880,6 @@ function handleClickedEditMission(mutableState: JaiaContextType, missionID: numb
 function handleClickedTapToMove(mutableState: JaiaContextType) {
     mutableState.selectedWaypoint.isMoveable = !mutableState.selectedWaypoint.isMoveable;
     jaiaGlobal.setSelectedWaypoint(mutableState.selectedWaypoint);
-    mutableState.selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
     return mutableState;
 }
 

--- a/src/web/context/JaiaContext.tsx
+++ b/src/web/context/JaiaContext.tsx
@@ -480,7 +480,11 @@ function handleAddWaypoint(mutableState: JaiaContextType, location: GeographicCo
 function handleDeleteWaypoint(mutableState: JaiaContextType) {
     const mission = missionSet.getMission(jaiaGlobal.getSelectedWaypoint().missionID);
     mission.deleteWaypoint(jaiaGlobal.getSelectedWaypoint().waypointNum);
-    jaiaGlobal.setSelectedWaypoint({ waypointNum: UNASSIGNED_ID, missionID: UNASSIGNED_ID });
+    jaiaGlobal.setSelectedWaypoint({
+        waypointNum: UNASSIGNED_ID,
+        missionID: UNASSIGNED_ID,
+        isMoveable: false,
+    });
 
     mutableState.selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
     mutableState.visiblePanel = ButtonNames.NONE;
@@ -858,8 +862,7 @@ function handleClickedEditMission(mutableState: JaiaContextType, missionID: numb
         missionSet.setMissionIDInEditMode(missionID);
     } else {
         missionSet.setMissionIDInEditMode(UNASSIGNED_ID);
-        const waypoint = getWaypoint();
-        waypoint.setIsMovable(false);
+        resetSelectedWaypoint(mutableState);
     }
 
     mutableState.missionIDInEditMode = missionSet.getMissionIDInEditMode();
@@ -876,8 +879,9 @@ function handleClickedEditMission(mutableState: JaiaContextType, missionID: numb
  * @returns {JaiaContextType} Updated mutable state object
  */
 function handleClickedTapToMove(mutableState: JaiaContextType) {
-    const waypoint = getWaypoint();
-    waypoint.setIsMovable(!waypoint.getIsMovable());
+    mutableState.selectedWaypoint.isMoveable = !mutableState.selectedWaypoint.isMoveable;
+    jaiaGlobal.setSelectedWaypoint(mutableState.selectedWaypoint);
+    mutableState.selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
     return mutableState;
 }
 
@@ -935,11 +939,6 @@ function handleClickedButton(mutableState: JaiaContextType, type: ButtonTypes, n
  * @returns {JaiaContextType} Updated mutable state object
  */
 function handleClickedWaypoint(mutableState: JaiaContextType, clickedWaypoint: SelectedWaypoint) {
-    const previousWaypoint = getWaypoint();
-    if (previousWaypoint && !compareWaypoints(jaiaGlobal.getSelectedWaypoint(), clickedWaypoint)) {
-        previousWaypoint.setIsMovable(false);
-    }
-
     jaiaGlobal.setSelectedWaypoint(clickedWaypoint);
 
     mutableState.selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
@@ -1064,13 +1063,11 @@ function getWaypoint() {
  * @returns {void}
  */
 function resetSelectedWaypoint(mutableState: JaiaContextType) {
-    const waypoint = getWaypoint();
-
-    if (waypoint) {
-        waypoint.setIsMovable(false);
-    }
-
-    jaiaGlobal.setSelectedWaypoint({ waypointNum: UNASSIGNED_ID, missionID: UNASSIGNED_ID });
+    jaiaGlobal.setSelectedWaypoint({
+        waypointNum: UNASSIGNED_ID,
+        missionID: UNASSIGNED_ID,
+        isMoveable: false,
+    });
     mutableState.selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
 }
 

--- a/src/web/data/jaia_global/jaia-global.ts
+++ b/src/web/data/jaia_global/jaia-global.ts
@@ -33,7 +33,11 @@ class JaiaGlobal {
 
     constructor() {
         this.selectedNode = { type: NodeTypes.NONE, id: UNASSIGNED_ID };
-        this.selectedWaypoint = { waypointNum: UNASSIGNED_ID, missionID: UNASSIGNED_ID };
+        this.selectedWaypoint = {
+            waypointNum: UNASSIGNED_ID,
+            missionID: UNASSIGNED_ID,
+            isMoveable: false,
+        };
         this.selectedTaskPacket = {
             botID: UNASSIGNED_ID,
             startTime: 0,

--- a/src/web/data/waypoints/waypoint.ts
+++ b/src/web/data/waypoints/waypoint.ts
@@ -4,12 +4,10 @@ import { GeographicCoordinate, Goal } from "../../types/protobuf-types";
 
 export default class Waypoint {
     private location: GeographicCoordinate;
-    private isMovable: boolean;
     private task: Task;
 
     constructor() {
         this.task = new Task();
-        this.isMovable = false;
     }
 
     getLocation() {
@@ -18,14 +16,6 @@ export default class Waypoint {
 
     setLocation(location: GeographicCoordinate) {
         this.location = location;
-    }
-
-    getIsMovable() {
-        return this.isMovable;
-    }
-
-    setIsMovable(isMovable: boolean) {
-        this.isMovable = isMovable;
     }
 
     getTask() {

--- a/src/web/types/jaia-system-types.ts
+++ b/src/web/types/jaia-system-types.ts
@@ -21,6 +21,7 @@ export interface SelectedNode {
 export interface SelectedWaypoint {
     waypointNum: number;
     missionID: number;
+    isMoveable: boolean;
 }
 
 export interface SelectedRallyPoint {


### PR DESCRIPTION
Moved the `isMoveable` property from `waypoint` to the `selectedWaypoint` in  `jaiaGlobal`  to be more consistent with our model of tracking UI state in `jaiaGlobal`.  

tested in browser