### PR TITLE
task/jdv-default-layers

### DIFF
--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,9 +1,2 @@
-#!/usr/bin/env bash
-
-# clang-format=hooks
-scripts/git-hooks/clang-format-hooks/git-pre-commit-format
-
-# prettier
-scripts/git-hooks/prettier/write.sh
-
-exit 0
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,2 +1,9 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/h"
+#!/usr/bin/env bash
+
+# clang-format=hooks
+scripts/git-hooks/clang-format-hooks/git-pre-commit-format
+
+# prettier
+scripts/git-hooks/prettier/write.sh
+
+exit 0

--- a/src/web/jdv/client/src/JaiaMap.ts
+++ b/src/web/jdv/client/src/JaiaMap.ts
@@ -244,7 +244,6 @@ export default class JaiaMap {
                 new TileLayer({
                     properties: {
                         title: "OpenStreetMap",
-                        type: "base",
                     },
                     zIndex: 1,
                     source: new OSM(),

--- a/src/web/shared/Layers.ts
+++ b/src/web/shared/Layers.ts
@@ -13,5 +13,6 @@ export function getArcGISSatelliteImageryLayer() {
                 "Tiles © Esri — Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community, ESRI",
             attributionsCollapsible: false,
         }),
+        visible: false,
     });
 }


### PR DESCRIPTION
In JDV:
* Remove OSM as a "base map," which makes it a permanent layer that cannot be disabled
* ArcGIS satellite view layer defaults to invisible