### PR TITLE
Task/2.y/add checksum to major upgrade and fix no disk space bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
+        - "task/2.y/add-checksum-to-major-upgrade"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -185,6 +186,7 @@ filter-template-normal-builds: &filter-template-normal-builds
     branches:
       ignore:
         - "2.y"
+        - "task/2.y/add-checksum-to-major-upgrade"
 
 # which branches to run the pi-zero filesystem builds
 filter-template-pi0-rootfs-builds: &filter-template-pi0-rootfs-builds
@@ -203,6 +205,7 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
     branches:
       only:
         - "2.y"
+        - "task/2.y/add-checksum-to-major-upgrade"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
@@ -212,6 +215,7 @@ filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
     branches:
       only:
         - "2.y"
+        - "task/2.y/add-checksum-to-major-upgrade"
 
 # which branches to build Docker simulator
 filter-template-docker-sim-builds: &filter-template-docker-sim-builds
@@ -516,6 +520,8 @@ jobs:
             major_upgrade_version=$(echo ${rootfs_version} | sed 's/.*-v\([1-9]\+\.[0-9]\+\.[0-9]\+.*\)/\1/')
             major_upgrade_ubuntu_version=$(echo ${DISTRO_RELEASE_VERSION} | sed 's/ubuntu//')
             major_upgrade_arch=${TARGET_ARCH}
+            major_upgrade_rootfs_checksum="sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.rootfs.tar.gz)"
+            major_upgrade_bootfs_checksum="sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.boot.tar.gz)"
             EOF
             
             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,8 +520,8 @@ jobs:
             major_upgrade_version=$(echo ${rootfs_version} | sed 's/.*-v\([1-9]\+\.[0-9]\+\.[0-9]\+.*\)/\1/')
             major_upgrade_ubuntu_version=$(echo ${DISTRO_RELEASE_VERSION} | sed 's/ubuntu//')
             major_upgrade_arch=${TARGET_ARCH}
-            major_upgrade_rootfs_checksum="sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.rootfs.tar.gz | cut -d ' ' -f 1)"
-            major_upgrade_bootfs_checksum="sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.boot.tar.gz | cut -d ' ' -f 1)"
+            major_upgrade_rootfs_checksum=sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.rootfs.tar.gz | cut -d ' ' -f 1)
+            major_upgrade_bootfs_checksum=sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.boot.tar.gz | cut -d ' ' -f 1)
             EOF
             
             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,8 +520,8 @@ jobs:
             major_upgrade_version=$(echo ${rootfs_version} | sed 's/.*-v\([1-9]\+\.[0-9]\+\.[0-9]\+.*\)/\1/')
             major_upgrade_ubuntu_version=$(echo ${DISTRO_RELEASE_VERSION} | sed 's/ubuntu//')
             major_upgrade_arch=${TARGET_ARCH}
-            major_upgrade_rootfs_checksum="sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.rootfs.tar.gz)"
-            major_upgrade_bootfs_checksum="sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.boot.tar.gz)"
+            major_upgrade_rootfs_checksum="sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.rootfs.tar.gz | cut -d ' ' -f 1)"
+            major_upgrade_bootfs_checksum="sha256:$(sha256sum build/bundle/major_upgrade/${rootfs_version}.boot.tar.gz | cut -d ' ' -f 1)"
             EOF
             
             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
-        - "task/2.y/add-checksum-to-major-upgrade"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -186,7 +185,6 @@ filter-template-normal-builds: &filter-template-normal-builds
     branches:
       ignore:
         - "2.y"
-        - "task/2.y/add-checksum-to-major-upgrade"
 
 # which branches to run the pi-zero filesystem builds
 filter-template-pi0-rootfs-builds: &filter-template-pi0-rootfs-builds
@@ -205,7 +203,6 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
     branches:
       only:
         - "2.y"
-        - "task/2.y/add-checksum-to-major-upgrade"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
@@ -215,7 +212,6 @@ filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
     branches:
       only:
         - "2.y"
-        - "task/2.y/add-checksum-to-major-upgrade"
 
 # which branches to build Docker simulator
 filter-template-docker-sim-builds: &filter-template-docker-sim-builds

--- a/config/ansible/major_upgrade/tasks/directory_creation.yml
+++ b/config/ansible/major_upgrade/tasks/directory_creation.yml
@@ -13,3 +13,9 @@
   file:
     path: '{{ upgrade_tmp_dir }}'
     state: directory
+    mode: '1777'
+
+- name: Set ansible_remote_tmp directory
+  set_fact:
+    ansible_remote_tmp: "{{ upgrade_tmp_dir }}"
+

--- a/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
+++ b/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
@@ -5,14 +5,28 @@
 
 - name: Download the upgrade image boot fs using wget
   get_url:
-    url: {{ upgrade_boot_url }}
-    dest: {{ upgrade_dir }}
-    checksum: {{ major_upgrade_bootfs_checksum }}
+    url: "{{ upgrade_boot_url }}"
+    dest: "{{ upgrade_dir }}"
+    checksum: "{{ major_upgrade_bootfs_checksum }}"
+    force: true
+  environment:
+    TMPDIR: "{{ upgrade_tmp_dir }}"
   throttle: 1
+  register: download_result
+  until: download_result is success
+  retries: 3
+  delay: 10
     
 - name: Download the upgrade image rootfs using wget
   get_url:
-    url: {{ upgrade_rootfs_url }}
-    dest: {{ upgrade_dir }}
-    checksum: {{ major_upgrade_rootfs_checksum }}
+    url: "{{ upgrade_rootfs_url }}"
+    dest: "{{ upgrade_dir }}"
+    checksum: "{{ major_upgrade_rootfs_checksum }}"
+    force: true
+  environment:
+    TMPDIR: "{{ upgrade_tmp_dir }}"
   throttle: 1
+  register: download_result
+  until: download_result is success
+  retries: 3
+  delay: 10

--- a/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
+++ b/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
@@ -4,15 +4,15 @@
     upgrade_boot_url: 'http://{{ hub_ip }}/updates/major_upgrade/{{ major_upgrade_rootfs_version }}.boot.tar.gz'    
 
 - name: Download the upgrade image boot fs using wget
-  shell: |
-    wget -c -O "{{ upgrade_dir }}/$(basename {{ upgrade_boot_url }})" "{{ upgrade_boot_url }}"
-  args:
-    creates: "{{ upgrade_dir }}/$(basename {{ upgrade_boot_url }})"
+  get_url:
+    url: {{ upgrade_boot_url }}
+    dest: {{ upgrade_dir }}
+    checksum: {{ major_upgrade_bootfs_checksum }}
   throttle: 1
     
 - name: Download the upgrade image rootfs using wget
-  shell: |
-    wget -c -O "{{ upgrade_dir }}/$(basename {{ upgrade_rootfs_url }})" "{{ upgrade_rootfs_url }}"
-  args:
-    creates: "{{ upgrade_dir }}/$(basename {{ upgrade_rootfs_url }})"
+  get_url:
+    url: {{ upgrade_rootfs_url }}
+    dest: {{ upgrade_dir }}
+    checksum: {{ major_upgrade_rootfs_checksum }}
   throttle: 1

--- a/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
+++ b/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
@@ -3,7 +3,7 @@
     upgrade_rootfs_url: 'http://{{ hub_ip }}/updates/major_upgrade/{{ major_upgrade_rootfs_version }}.rootfs.tar.gz'
     upgrade_boot_url: 'http://{{ hub_ip }}/updates/major_upgrade/{{ major_upgrade_rootfs_version }}.boot.tar.gz'    
 
-- name: Download the upgrade image boot fs using wget
+- name: Download the upgrade image boot fs
   get_url:
     url: "{{ upgrade_boot_url }}"
     dest: "{{ upgrade_dir }}"
@@ -17,7 +17,7 @@
   retries: 3
   delay: 10
     
-- name: Download the upgrade image rootfs using wget
+- name: Download the upgrade image rootfs
   get_url:
     url: "{{ upgrade_rootfs_url }}"
     dest: "{{ upgrade_dir }}"

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -3,6 +3,9 @@
 set -x
 set -e -u
 
+script_path="$(realpath "$0")"
+script_dir="$(dirname "$script_path")"
+
 old_ro_rootfs_mountpoint="/media/root-ro"
 old_rw_overlay_mountpoint="/media/root-rw"
 
@@ -14,37 +17,61 @@ boot_mountpoint="/boot/firmware"
 rootfstype=$(findmnt -n -o fstype /)
 
 if [ "${rootfstype}" = "overlay" ]; then
-    ## in place major upgrade
-    
-    ###############################
-    # Live pivot onto underlay FS #
-    ###############################
+    # first time through the script when upgrading "normal" overlayfs system
 
+
+    ## in place major upgrade:
+    ## - disable overlay,
+    ## - schedule script to run on the underlay using systemd, and
+    ## - reboot
+    
     mount -o remount,rw ${old_ro_rootfs_mountpoint}
-    mkdir -p ${old_ro_rootfs_mountpoint}/oldroot
-    mount --make-rprivate /
-    pivot_root ${old_ro_rootfs_mountpoint} ${old_ro_rootfs_mountpoint}/oldroot
-    for i in dev proc sys run boot/firmware var/log media/root-rw; do mount --move /oldroot/$i /$i; done
-    systemctl daemon-reload
-    cd /
-    umount -l /oldroot
+
+    ###############################
+    # Schedule script to run on boot into underlay
+    ###############################
+    cat <<EOF > ${old_ro_rootfs_mountpoint}/etc/systemd/system/do_major_upgrade.service
+[Unit]
+Description=Run do-major-upgrade on boot
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${script_path}
+StandardOutput=append:${script_dir}/major_upgrade_final.log
+StandardError=append:${script_dir}/major_upgrade_final.log
+
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    # enable systemd job in read-only rootfs
+    overlayroot-chroot systemctl enable do_major_upgrade.service
+    # disable jaiabot service in read-only rootfs to reduce startup churn
+    overlayroot-chroot systemctl disable jaiabot.service
+    # Backup/remove rootfs overlayconf file (so system boots into underlay)
+    overlayroot-chroot mv /etc/overlayroot.conf /etc/overlayroot.conf.bak
+    # reboot into underlay
+    systemctl reboot --force
+    exit 0
 else
-    ## AWS AMI
+    ## second time through when booted on formerly read-only underlay OR
+    ## for AWS AMI
     mount $(blkid -L overlay) ${old_rw_overlay_mountpoint}
 fi
 
-###############################
-# Backup/remove rootfs overlayconf file (so if extraction step fails or is interrupted, will still boot into old underlay).
-###############################
-mv /etc/overlayroot.conf /etc/overlayroot.conf.bak
 
 ###############################
 # Extract new rootfs
 ###############################
 
+# delete everything that was on this old overlay
 rm -rf ${new_ro_rootfs_mountpoint}/*
 sync ${new_ro_rootfs_mountpoint}
-tar --xattrs --xattrs-include="*" -xz -f {{ rootfs_filename }} -C ${new_ro_rootfs_mountpoint}
+
+# untar the new rootfs
+tar --xattrs --xattrs-include="*" -xz -f {{ rootfs_filename }} -C ${new_ro_rootfs_mountpoint} --warning=no-timestamp
 
 if [ "{{ upgrade_type }}" = "embedded" ]; then
     ## in place major upgrade

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -50,6 +50,8 @@ EOF
     overlayroot-chroot systemctl enable do_major_upgrade.service
     # disable jaiabot service in read-only rootfs to reduce startup churn
     overlayroot-chroot systemctl disable jaiabot.service
+    # disable JCU so that UI doesn't refresh until upgrade is complete
+    overlayroot-chroot systemctl disable jaiabot_goby_liaison_standalone.service
     # Backup/remove rootfs overlayconf file (so system boots into underlay)
     overlayroot-chroot mv /etc/overlayroot.conf /etc/overlayroot.conf.bak
     # reboot into underlay

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -26,6 +26,8 @@ if [ "${rootfstype}" = "overlay" ]; then
     pivot_root ${old_ro_rootfs_mountpoint} ${old_ro_rootfs_mountpoint}/oldroot
     for i in dev proc sys run boot/firmware var/log media/root-rw; do mount --move /oldroot/$i /$i; done
     systemctl daemon-reload
+    cd /
+    umount -l /oldroot
 else
     ## AWS AMI
     mount $(blkid -L overlay) ${old_rw_overlay_mountpoint}
@@ -41,6 +43,7 @@ mv /etc/overlayroot.conf /etc/overlayroot.conf.bak
 ###############################
 
 rm -rf ${new_ro_rootfs_mountpoint}/*
+sync ${new_ro_rootfs_mountpoint}
 tar --xattrs --xattrs-include="*" -xz -f {{ rootfs_filename }} -C ${new_ro_rootfs_mountpoint}
 
 if [ "{{ upgrade_type }}" = "embedded" ]; then


### PR DESCRIPTION
## Work performed

1. Fixes bug where major_upgrade ran out of space on former writable "overlay" partition. This is due likely to undefined behavior (see https://docs.kernel.org/filesystems/overlayfs.html) on the writable "overlay" partition when the overlayfs was still mounted. Even though files are deleted, and the fs is `sync`'d, the disk space still wasn't available (some of the time - this seemed to be unpredictable. I guess that's undefined behavior for you!)

The new solution is cleaner and less clever but adds a reboot (not a big deal on a relatively lengthy process already):
- Install do-major-upgrade.sh as new systemd service on rootfs (underlay) partition.
- Disable overlayfs
- Reboot into formerly read-only rootfs (underlay) partition.
- (Automatically, using systemd from the service installed in the first step) run do-major-upgrade.sh again which finishes the installation now that the overlayfs isn't mounted at all. This makes the second pass closer to the use of this script when upgrading an AWS AMI, which is nice.

2. Switched from `wget` to using `get_url` Ansible module with a checksum (SHA256) calculated (and added to the existing `version.txt`) when the major_upgrade ISO is created for both the rootfs and bootfs tarball. This should hopefully catch corrupted downloads as seen on one bot on a recent fleet upgrade. Three retries are made before failing completely.

*Same changes made to `1.y`* in https://github.com/jaiarobotics/jaiabot/pull/1329

## Testing

Upgrading 3-bot 1-hub VirtualBox fleet from 1.20 to this test/2.y branch by 

0. Mimic full overlay fs by writing dummy file to disk:
```
cd /
sudo fallocate -l 6G largefile.img
```
1. Upgrading hub and 1 bot.
2. Using upgraded hub to upgrade 2 other bots.

**Needs testing on Raspi fleet**