### PR TITLE
Task/1.y/add checksum to major upgrade and fix no disk space bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
-        - "task/1.y/add-checksum-to-major-upgrade"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -196,7 +195,6 @@ filter-template-normal-builds: &filter-template-normal-builds
     branches:
       ignore:
         - "1.y"
-        - "task/1.y/add-checksum-to-major-upgrade"
 
 # which branches to run the pi-zero filesystem builds
 filter-template-pi0-rootfs-builds: &filter-template-pi0-rootfs-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "1.y"
+        - "task/1.y/add-checksum-to-major-upgrade"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
@@ -195,6 +196,7 @@ filter-template-normal-builds: &filter-template-normal-builds
     branches:
       ignore:
         - "1.y"
+        - "task/1.y/add-checksum-to-major-upgrade"
 
 # which branches to run the pi-zero filesystem builds
 filter-template-pi0-rootfs-builds: &filter-template-pi0-rootfs-builds

--- a/config/ansible/major_upgrade/tasks/directory_creation.yml
+++ b/config/ansible/major_upgrade/tasks/directory_creation.yml
@@ -13,3 +13,9 @@
   file:
     path: '{{ upgrade_tmp_dir }}'
     state: directory
+    mode: '1777'
+
+- name: Set ansible_remote_tmp directory
+  set_fact:
+    ansible_remote_tmp: "{{ upgrade_tmp_dir }}"
+

--- a/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
+++ b/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
@@ -4,15 +4,29 @@
     upgrade_boot_url: 'http://{{ hub_ip }}/updates/major_upgrade/{{ major_upgrade_rootfs_version }}.boot.tar.gz'    
 
 - name: Download the upgrade image boot fs using wget
-  shell: |
-    wget -c -O "{{ upgrade_dir }}/$(basename {{ upgrade_boot_url }})" "{{ upgrade_boot_url }}"
-  args:
-    creates: "{{ upgrade_dir }}/$(basename {{ upgrade_boot_url }})"
+  get_url:
+    url: "{{ upgrade_boot_url }}"
+    dest: "{{ upgrade_dir }}"
+    checksum: "{{ major_upgrade_bootfs_checksum }}"
+    force: true
+  environment:
+    TMPDIR: "{{ upgrade_tmp_dir }}"
   throttle: 1
+  register: download_result
+  until: download_result is success
+  retries: 3
+  delay: 10
     
 - name: Download the upgrade image rootfs using wget
-  shell: |
-    wget -c -O "{{ upgrade_dir }}/$(basename {{ upgrade_rootfs_url }})" "{{ upgrade_rootfs_url }}"
-  args:
-    creates: "{{ upgrade_dir }}/$(basename {{ upgrade_rootfs_url }})"
+  get_url:
+    url: "{{ upgrade_rootfs_url }}"
+    dest: "{{ upgrade_dir }}"
+    checksum: "{{ major_upgrade_rootfs_checksum }}"
+    force: true
+  environment:
+    TMPDIR: "{{ upgrade_tmp_dir }}"
   throttle: 1
+  register: download_result
+  until: download_result is success
+  retries: 3
+  delay: 10

--- a/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
+++ b/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
@@ -3,7 +3,7 @@
     upgrade_rootfs_url: 'http://{{ hub_ip }}/updates/major_upgrade/{{ major_upgrade_rootfs_version }}.rootfs.tar.gz'
     upgrade_boot_url: 'http://{{ hub_ip }}/updates/major_upgrade/{{ major_upgrade_rootfs_version }}.boot.tar.gz'    
 
-- name: Download the upgrade image boot fs using wget
+- name: Download the upgrade image boot fs
   get_url:
     url: "{{ upgrade_boot_url }}"
     dest: "{{ upgrade_dir }}"
@@ -17,7 +17,7 @@
   retries: 3
   delay: 10
     
-- name: Download the upgrade image rootfs using wget
+- name: Download the upgrade image rootfs
   get_url:
     url: "{{ upgrade_rootfs_url }}"
     dest: "{{ upgrade_dir }}"

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -3,6 +3,9 @@
 set -x
 set -e -u
 
+script_path="$(realpath "$0")"
+script_dir="$(dirname "$script_path")"
+
 old_ro_rootfs_mountpoint="/media/root-ro"
 old_rw_overlay_mountpoint="/media/root-rw"
 
@@ -14,34 +17,61 @@ boot_mountpoint="/boot/firmware"
 rootfstype=$(findmnt -n -o fstype /)
 
 if [ "${rootfstype}" = "overlay" ]; then
-    ## in place major upgrade
-    
-    ###############################
-    # Live pivot onto underlay FS #
-    ###############################
+    # first time through the script when upgrading "normal" overlayfs system
 
+
+    ## in place major upgrade:
+    ## - disable overlay,
+    ## - schedule script to run on the underlay using systemd, and
+    ## - reboot
+    
     mount -o remount,rw ${old_ro_rootfs_mountpoint}
-    mkdir -p ${old_ro_rootfs_mountpoint}/oldroot
-    mount --make-rprivate /
-    pivot_root ${old_ro_rootfs_mountpoint} ${old_ro_rootfs_mountpoint}/oldroot
-    for i in dev proc sys run boot/firmware var/log media/root-rw; do mount --move /oldroot/$i /$i; done
-    systemctl daemon-reload
+
+    ###############################
+    # Schedule script to run on boot into underlay
+    ###############################
+    cat <<EOF > ${old_ro_rootfs_mountpoint}/etc/systemd/system/do_major_upgrade.service
+[Unit]
+Description=Run do-major-upgrade on boot
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${script_path}
+StandardOutput=append:${script_dir}/major_upgrade_final.log
+StandardError=append:${script_dir}/major_upgrade_final.log
+
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    # enable systemd job in read-only rootfs
+    overlayroot-chroot systemctl enable do_major_upgrade.service
+    # disable jaiabot service in read-only rootfs to reduce startup churn
+    overlayroot-chroot systemctl disable jaiabot.service
+    # Backup/remove rootfs overlayconf file (so system boots into underlay)
+    overlayroot-chroot mv /etc/overlayroot.conf /etc/overlayroot.conf.bak
+    # reboot into underlay
+    systemctl reboot --force
+    exit 0
 else
-    ## AWS AMI
+    ## second time through when booted on formerly read-only underlay OR
+    ## for AWS AMI
     mount $(blkid -L overlay) ${old_rw_overlay_mountpoint}
 fi
 
-###############################
-# Backup/remove rootfs overlayconf file (so if extraction step fails or is interrupted, will still boot into old underlay).
-###############################
-mv /etc/overlayroot.conf /etc/overlayroot.conf.bak
 
 ###############################
 # Extract new rootfs
 ###############################
 
+# delete everything that was on this old overlay
 rm -rf ${new_ro_rootfs_mountpoint}/*
-tar --xattrs --xattrs-include="*" -xz -f {{ rootfs_filename }} -C ${new_ro_rootfs_mountpoint}
+sync ${new_ro_rootfs_mountpoint}
+
+# untar the new rootfs
+tar --xattrs --xattrs-include="*" -xz -f {{ rootfs_filename }} -C ${new_ro_rootfs_mountpoint} --warning=no-timestamp
 
 if [ "{{ upgrade_type }}" = "embedded" ]; then
     ## in place major upgrade
@@ -96,7 +126,6 @@ btrfs filesystem label ${new_ro_rootfs_mountpoint} "rootfs"
 
 ###############################
 # Clean up
-
 ###############################
 
 if [ "{{ upgrade_type }}" = "embedded" ]; then

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -50,6 +50,8 @@ EOF
     overlayroot-chroot systemctl enable do_major_upgrade.service
     # disable jaiabot service in read-only rootfs to reduce startup churn
     overlayroot-chroot systemctl disable jaiabot.service
+    # disable JCU so that UI doesn't refresh until upgrade is complete
+    overlayroot-chroot systemctl disable jaiabot_goby_liaison_standalone.service
     # Backup/remove rootfs overlayconf file (so system boots into underlay)
     overlayroot-chroot mv /etc/overlayroot.conf /etc/overlayroot.conf.bak
     # reboot into underlay


### PR DESCRIPTION
1. Identical to https://github.com/jaiarobotics/jaiabot/pull/1328 but for `1.y`. Needs to be in `1.y` so `1.y` hubs can correctly and reliably upgrade themselves and `1.y` bots.