### PR TITLE
bug/rc-throttle-resets-when-rudder-moves/JAIA-2077

### DIFF
--- a/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
+++ b/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
@@ -230,7 +230,9 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
                 <div className="remote-control-panel">
                     <AnalogStick
                         analogStickType={AnalogStickTypes.SINGLE}
-                        handleAnalogStickMove={handleAnalogStickMove}
+                        handleAnalogStickMove={(event) =>
+                            handleAnalogStickMove(event, AnalogStickTypes.SINGLE)
+                        }
                         onAnalogStickStop={onAnalogStickStop}
                     />
                     {RCSelectMenu}
@@ -241,13 +243,17 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
                 <div className="remote-control-panel">
                     <AnalogStick
                         analogStickType={AnalogStickTypes.LEFT}
-                        handleAnalogStickMove={handleAnalogStickMove}
+                        handleAnalogStickMove={(event) =>
+                            handleAnalogStickMove(event, AnalogStickTypes.LEFT)
+                        }
                         onAnalogStickStop={onAnalogStickStop}
                     />
                     {RCSelectMenu}
                     <AnalogStick
                         analogStickType={AnalogStickTypes.RIGHT}
-                        handleAnalogStickMove={handleAnalogStickMove}
+                        handleAnalogStickMove={(event) =>
+                            handleAnalogStickMove(event, AnalogStickTypes.RIGHT)
+                        }
                         onAnalogStickStop={onAnalogStickStop}
                     />
                 </div>

--- a/src/web/jcc/index.tsx
+++ b/src/web/jcc/index.tsx
@@ -15,8 +15,8 @@ import { hubCommsLayer } from "../openlayers/layers/vector/hub-comms-layer";
 import { DATA_MODEL_POLL_TIME, TASK_PACKET_POLL_TIME } from "../utils/constants";
 
 // Sample status messages twice as fast as produced by Bots and Hubs to reduce potential data age issues
-const STATUS_URL = "http://localhost:40001/jaia/v0/status";
-const TASK_PACKET_URL = "http://localhost:40001/jaia/v0/task-packets";
+const STATUS_URL = "/jaia/v0/status";
+const TASK_PACKET_URL = "/jaia/v0/task-packets";
 const HUB_CONNECTION_ERROR = "Connection Dropped To HUB";
 
 const statusInterval = setInterval(async () => {


### PR DESCRIPTION
### Summary
When the throttle and rudder analog sticks were used together, one of the sticks would be reset to 0 by the other. The cause of this problem came from not passing the correct arguments to the event handler for the analog stick movements.

### Solution
Specify which analog stick is being controlled in the call to the event handler.

### Testing
Deployed to the flat fleet Hub and used the RC panel on the tablet. While using both sticks, neither the throttle or rudder reset.

### Additional
This pull request also updates the paths in `index.ts` to hit the correct endpoints locally and while interfacing with the Apache server on the Hub.