### PR TITLE
bug/jdv-plots-jitter

### DIFF
--- a/src/web/jdv/client/src/ui/DataTable.css
+++ b/src/web/jdv/client/src/ui/DataTable.css
@@ -5,13 +5,33 @@
 .dataTable > table {
     width: 100%;
     padding: 10pt;
+    border-collapse: collapse;
+    table-layout: fixed;
 }
 
 .dataTable td {
     width: 50%;
-    overflow-wrap: anywhere;
+    white-space: nowrap;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    scrollbar-gutter: stable;
+    box-sizing: border-box;
+}
+
+.dataTable td::-webkit-scrollbar {
+    height: 8px;
+}
+
+.dataTable td::-webkit-scrollbar-thumb {
+    background-color: #ccc;
+    border-radius: 4px;
+}
+
+.dataTable td::-webkit-scrollbar-track {
+    background-color: transparent;
 }
 
 table > thead {
+    text-align: left;
     background-color: aliceblue;
 }

--- a/src/web/jdv/client/src/ui/DataTable.css
+++ b/src/web/jdv/client/src/ui/DataTable.css
@@ -1,26 +1,42 @@
 .dataTable {
-    margin: 10pt 0pt 0pt 0pt;
+  margin: 10pt 0 0 0;
+  overflow-x: scroll;              /* scroll entire table if content too wide */
+  border: 1px solid #ddd;        /* optional border around panel */
+  border-radius: 6px;
+  padding: 4pt;
 }
 
 .dataTable > table {
-    width: 100%;
-    padding: 10pt;
-    border-collapse: collapse;
-    table-layout: fixed;
+  width: max-content;            /* allow wide content */
+  min-width: 100%;               /* but don't shrink below panel width */
+  border-collapse: collapse;
+  table-layout: auto;
 }
 
 .dataTable td {
-    width: 50%;
-    white-space: nowrap;
-    overflow-x: scroll;
-    overflow-y: hidden;
-    scrollbar-gutter: stable;
-    scrollbar-width: auto;
-    scrollbar-color: #ccc transparent;
-    box-sizing: border-box;
+  padding: 6pt 10pt;
+  white-space: nowrap;
+  overflow: visible;
+  vertical-align: top;
+  box-sizing: border-box;
 }
 
-table > thead {
-    text-align: left;
-    background-color: aliceblue;
+/* Key column smaller */
+.dataTable td:first-child {
+  width: 25%;
+  font-weight: 600;
+  border-right: 1px solid #ccc;  /* divider between key and value */
+  padding-right: 15pt;
+}
+
+/* Value column larger */
+.dataTable td:last-child {
+  width: 75%;
+  padding-left: 15pt;
+}
+
+.dataTable th {
+  text-align: left;
+  background-color: aliceblue;
+  padding: 6pt 10pt;
 }

--- a/src/web/jdv/client/src/ui/DataTable.css
+++ b/src/web/jdv/client/src/ui/DataTable.css
@@ -15,20 +15,9 @@
     overflow-x: scroll;
     overflow-y: hidden;
     scrollbar-gutter: stable;
+    scrollbar-width: auto;
+    scrollbar-color: #ccc transparent;
     box-sizing: border-box;
-}
-
-.dataTable td::-webkit-scrollbar {
-    height: 8px;
-}
-
-.dataTable td::-webkit-scrollbar-thumb {
-    background-color: #ccc;
-    border-radius: 4px;
-}
-
-.dataTable td::-webkit-scrollbar-track {
-    background-color: transparent;
 }
 
 table > thead {

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -185,10 +185,6 @@ export function Plots(props: PlotsProps) {
                 props.delegate.setTime(timestamp_utime);
             });
 
-            plot_div_element.on("plotly_unhover", function (data: Plotly.PlotHoverEvent) {
-                props.delegate.setTime(null);
-            });
-
             // Zooming into plots
             plot_div_element.on("plotly_relayout", function (eventdata: Plotly.PlotRelayoutEvent) {
                 // When autorange, zoom out to the whole set of points

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -186,11 +186,11 @@ export function Plots(props: PlotsProps) {
             });
 
 
-	    plot_div_element.on("plotly_click", function (data) {
-  		let pointIndex = data.points[0].pointIndex;
-  		let timestamp_utime = Number(data.points[0].data.customdata[pointIndex]);
-  		props.delegate.setTime(timestamp_utime);
-	    });
+	    	plot_div_element.on("plotly_click", function (data) {
+  				let pointIndex = data.points[0].pointIndex;
+  				let timestamp_utime = Number(data.points[0].data.customdata[pointIndex]);
+  				props.delegate.setTime(timestamp_utime);
+	    	});
 
             // Zooming into plots
             plot_div_element.on("plotly_relayout", function (eventdata: Plotly.PlotRelayoutEvent) {

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -185,6 +185,13 @@ export function Plots(props: PlotsProps) {
                 props.delegate.setTime(timestamp_utime);
             });
 
+
+	    plot_div_element.on("plotly_click", function (data) {
+  		let pointIndex = data.points[0].pointIndex;
+  		let timestamp_utime = Number(data.points[0].data.customdata[pointIndex]);
+  		props.delegate.setTime(timestamp_utime);
+	    });
+
             // Zooming into plots
             plot_div_element.on("plotly_relayout", function (eventdata: Plotly.PlotRelayoutEvent) {
                 // When autorange, zoom out to the whole set of points


### PR DESCRIPTION
Removes the jitter when scrubbing through certain datasets in JDV. Also aligns the columns and headers of the data table at the bottom of the page so that the data is easier to read while scrubbing through.