### PR TITLE
bug/jdv-log-time-range-reset

### DIFF
--- a/src/web/jdv/client/src/ui/JaiaMap.ts
+++ b/src/web/jdv/client/src/ui/JaiaMap.ts
@@ -386,6 +386,8 @@ export default class JaiaMap {
 
     updatePath() {
         let timeRange = this.timeRange ?? [0, Number.MAX_SAFE_INTEGER];
+        this.tMin = null;
+        this.tMax = null;
 
         // OpenLayers
         this.botPathVectorSource.clear();


### PR DESCRIPTION
When loading another log, the system doesn't reset the tMin and tMax, so the timebar at the bottom had the wrong range.  This fixes that.