### PR TITLE
bug/jdv-remove-old-bots-on-map

### DIFF
--- a/src/web/jdv/client/src/ui/JaiaMap.ts
+++ b/src/web/jdv/client/src/ui/JaiaMap.ts
@@ -357,7 +357,9 @@ export default class JaiaMap {
     setMapDict(botIdToMapSeries: { [key: string]: number[][] }) {
         this.timeRange = null;
         this.botIdToMapSeries = botIdToMapSeries;
+        this.timestamp = null;
         this.updatePath();
+        this.updateBotMarkers();
     }
 
     /**


### PR DESCRIPTION
Reset timestamp to null when loading new logs, and update the bot layer