### PR TITLE
task/2.y/remove-scan-for-all-bots

### DIFF
--- a/src/web/components/ScanForBot/ScanForBot.tsx
+++ b/src/web/components/ScanForBot/ScanForBot.tsx
@@ -50,23 +50,6 @@ export default function ScanForBot() {
     };
 
     /**
-     * Sends the scan for Bot command for each Bot in the Hub's radio file
-     *
-     * @returns {void}
-     */
-    const sendScanForBots = () => {
-        const hub = jaiaContext.hubs.get(DEFAULT_HUB_ID);
-
-        if (!hub || !hub.getBotIDsInRadioFile()) {
-            return;
-        }
-
-        for (const botID of hub.getBotIDsInRadioFile()) {
-            sendScanForBot(botID);
-        }
-    };
-
-    /**
      * Loops through the connected Bots and creates dropdown options
      *
      * @returns {<MenuItem />[]} Array of dropdown option for the select menu
@@ -101,9 +84,6 @@ export default function ScanForBot() {
                 onClick={() => sendScanForBot(Number(selectedBotID))}
             >
                 Scan For Bot
-            </button>
-            <button className="engineering-button" onClick={() => sendScanForBots()}>
-                Scan For All Bots
             </button>
         </div>
     );

--- a/src/web/data/hubs/hub.ts
+++ b/src/web/data/hubs/hub.ts
@@ -19,7 +19,6 @@ export default class Hub {
     private linuxHardwareStatus: LinuxHardwareStatus;
     private botOffload: BotOffloadData;
     private statusAge: number;
-    private botIDsInRadioFile: number[];
 
     constructor() {
         // Init base sensors
@@ -100,13 +99,5 @@ export default class Hub {
 
     setStatusAge(statusAge: number) {
         this.statusAge = statusAge;
-    }
-
-    getBotIDsInRadioFile() {
-        return this.botIDsInRadioFile;
-    }
-
-    setBotIDsInRadioFile(botIDsInRadioFile: number[]) {
-        this.botIDsInRadioFile = botIDsInRadioFile;
     }
 }

--- a/src/web/data/hubs/hubs.ts
+++ b/src/web/data/hubs/hubs.ts
@@ -102,10 +102,6 @@ class Hubs {
             hub.setBotOffload(hubStatus.bot_offload);
         }
 
-        if (hubStatus.bot_ids_in_radio_file) {
-            hub.setBotIDsInRadioFile(hubStatus.bot_ids_in_radio_file);
-        }
-
         // HubSensors
         // GPS
         if (hubStatus.location?.lat) {


### PR DESCRIPTION
### Summary
Since we no longer use the xbee.pb.cfg files for Bot, Hub radio discovery we can remove the scan for all Bots feature that is based on the variable `bot_ids_in_radio_file`