### PR TITLE
task/classify-bottom-dives-based-on-ascent-types

### DIFF
--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -498,6 +498,30 @@ jaiabot::statechart::inmission::underway::task::Dive::~Dive()
     imu_command.set_type(IMUCommand::STOP_BOTTOM_TYPE_SAMPLING);
     this->interprocess().template publish<jaiabot::groups::imu>(imu_command);
 
+    //This logic sets the bottom type based on whether a powered ascent happens, the default is hard as set in jaia_dccl.proto
+    if (dive_packet().has_bottom_dive())
+    {
+        if (context<Dive>().has_bot_performed_powered_ascent_after_bottom())
+        {
+            glog.is_debug1() && glog << "PoweredAscent::depth Setting bottom type to SOFT"
+                                     << "\n"
+                                     << std::endl;
+            // Set the bottom_type Soft
+            dive_packet().set_bottom_type(
+                protobuf::DivePacket::BottomType::DivePacket_BottomType_SOFT);
+        }
+        else
+        {
+            glog.is_debug1() && glog << "Dive::~Dive Setting bottom type to HARD" << "\n"
+                                     << std::endl;
+            // Set the bottom_type Hard
+            dive_packet().set_bottom_type(
+                protobuf::DivePacket::BottomType::DivePacket_BottomType_HARD);
+        }
+        
+    }
+    
+
     // Is echo recording?
     bool stop_echo_sensor = context<InMission>().is_echo_recording();
 
@@ -762,20 +786,21 @@ void jaiabot::statechart::inmission::underway::task::dive::PoweredDescent::depth
             context<Dive>().dive_packet().set_max_acceleration_with_units(
                 this->machine().latest_max_acceleration());
 
-            // Determine Hard/Soft
-            if (this->machine().latest_max_acceleration().value() >=
-                cfg().hard_bottom_type_acceleration())
-            {
-                // Set the bottom_type Hard
-                context<Dive>().dive_packet().set_bottom_type(
-                    protobuf::DivePacket::BottomType::DivePacket_BottomType_HARD);
-            }
-            else
-            {
-                // Set the bottom_type Soft
-                context<Dive>().dive_packet().set_bottom_type(
-                    protobuf::DivePacket::BottomType::DivePacket_BottomType_SOFT);
-            }
+            //Commenting out max acceperation hard/soft determination for bottom type to switch to ascent-based logic
+            // // Determine Hard/Soft
+            // if (this->machine().latest_max_acceleration().value() >=
+            //     cfg().hard_bottom_type_acceleration())
+            // {
+            //     // Set the bottom_type Hard
+            //     context<Dive>().dive_packet().set_bottom_type(
+            //         protobuf::DivePacket::BottomType::DivePacket_BottomType_HARD);
+            // }
+            // else
+            // {
+            //     // Set the bottom_type Soft
+            //     context<Dive>().dive_packet().set_bottom_type(
+            //         protobuf::DivePacket::BottomType::DivePacket_BottomType_SOFT);
+            // }
 
             // used to correct dive rate calculation
             duration_correction_ = (now - last_depth_change_time_);
@@ -1088,6 +1113,7 @@ jaiabot::statechart::inmission::underway::task::dive::PoweredAscent::~PoweredAsc
 
     context<Dive>().dive_packet().set_powered_rise_rate_with_units(rise_rate *
                                                                    boost::units::si::velocity());
+    if( !context<Dive>().has_bot_performed_powered_ascent_after_bottom()) context<Dive>().set_bot_performed_powered_ascent_after_bottom(true);
 }
 
 void jaiabot::statechart::inmission::underway::task::dive::PoweredAscent::loop(const EvLoop&)

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -1643,11 +1643,19 @@ struct Dive : boost::statechart::state<Dive, Task, dive::DivePrep>, AppMethodsAc
 
     const bool has_bot_performed_a_hold() { return bot_performed_hold_; }
 
+    void set_bot_performed_powered_ascent_after_bottom(const bool& bot_performed_powered_ascent_after_bottom)
+    {
+        bot_performed_powered_ascent_after_bottom_ = bot_performed_powered_ascent_after_bottom;
+    }
+
+    const bool has_bot_performed_powered_ascent_after_bottom() { return bot_performed_powered_ascent_after_bottom_; }
+
   private:
     std::deque<boost::units::quantity<boost::units::si::length>> dive_depths_;
     goby::time::MicroTime dive_duration_{0 * boost::units::si::seconds};
     boost::units::quantity<boost::units::si::length> current_depth_{0};
     bool bot_performed_hold_{false};
+    bool bot_performed_powered_ascent_after_bottom_{false};
 };
 namespace dive
 {


### PR DESCRIPTION
### Summary
Previously, the model used maximum acceleration to classify bottom types. However, this metric did not reliably capture differences in dive behavior. The approach has now been updated to use ascent type, which offers a more behaviorally grounded and consistent signal. Specifically, powered ascents are expected to occur after soft bottom impacts, while unpowered ascents typically follow hard bottom impacts.

### Solution
Updated the classification logic to set a dive packet’s bottom type to Soft if a powered ascent occurs during the dive; otherwise, it is classified as Hard.

### Testing
Tested on multiple simulated dives. Verified that bottom type assignments align with ascent behavior and that no misclassifications or runtime errors occur.

