### PR TITLE
task/fix-pyjaiaprotobuf-and-web-dependencies

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -19,7 +19,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/jaia_serial DESTINATION ${project_SHARE_DI
 
 # Building the JaiaBot Goby message python modules into the pyjaiaprotobuf python package
 set(pyjaiaprotobuf_outdir ${project_SHARE_DIR}/jaiabot/python/pyjaiaprotobuf)
-add_custom_command(OUTPUT ${pyjaiaprotobuf_outdir}/dccl/option_extensions_pb2.py
+add_custom_command(OUTPUT ${pyjaiaprotobuf_outdir}/src/jaiabot/messages/jaia_dccl_pb2.py
   COMMAND ${CMAKE_COMMAND} -E env DCCL_DIR=${DCCL_INCLUDE_DIR}/dccl GOBY_DIR=${GOBY_INCLUDE_DIR}/goby ./build_messages.sh
   ARGS ${CMAKE_SOURCE_DIR} ${pyjaiaprotobuf_outdir}
   DEPENDS jaiabot_messages
@@ -28,7 +28,7 @@ add_custom_command(OUTPUT ${pyjaiaprotobuf_outdir}/dccl/option_extensions_pb2.py
   )
 add_custom_target(pyjaiaprotobuf
   ALL
-  DEPENDS ${pyjaiaprotobuf_outdir}/dccl/option_extensions_pb2.py jaiabot_messages
+  DEPENDS ${pyjaiaprotobuf_outdir}/src/jaiabot/messages/jaia_dccl_pb2.py
   )
 
 install(DIRECTORY ${project_SHARE_DIR}/jaiabot/python DESTINATION share/jaiabot USE_SOURCE_PERMISSIONS)

--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -48,6 +48,8 @@ set(web_out_dir ${project_SHARE_DIR}/jaiabot/web)
 add_custom_command(OUTPUT ${web_out_dir}/jcc/client.js ${web_out_dir}/jed/script.js
   COMMAND npx webpack
   ARGS --mode production --env OUTPUT_DIR=${web_out_dir} --stats errors-only
+  COMMAND touch
+  ARGS ${web_out_dir}/jcc/client.js ${web_out_dir}/jed/script.js
   WORKING_DIRECTORY ${intermediate_web_dir}/
   COMMENT "Building jcc and jed"
   DEPENDS npm_dependencies ${jcc_src_files} ${jed_src_files} ${shared_src_files}

--- a/src/web/jdv/CMakeLists.txt
+++ b/src/web/jdv/CMakeLists.txt
@@ -19,6 +19,8 @@ file(GLOB jdv_other_files FOLLOW_SYMLINKS LIST_DIRECTORIES false ${CMAKE_CURRENT
 add_custom_command(OUTPUT ${jdv_client_outdir}/bundle.js
   COMMAND npx webpack
   ARGS --mode production --env TARGET_DIR=${jdv_client_outdir} --stats errors-only
+  COMMAND touch
+  ARGS ${jdv_client_outdir}/bundle.js
   WORKING_DIRECTORY ${intermediate_web_dir}/jdv/client
   COMMENT "Building jdv"
   DEPENDS npm_dependencies ${jdv_src_files}


### PR DESCRIPTION
The web apps and pyjaiaprotobuf package were rebuilding every time the `build.sh` script was run.  This fixes that, so they only rebuild when the real dependencies have changed.  This speeds up dev iteration for those of us using `build.sh`.