### PR TITLE
task/2.y/show-no-dialog-when-zero-bots-connected

### DIFF
--- a/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
+++ b/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
@@ -64,6 +64,10 @@ export default function ActivateAllButton(props: Props) {
      * @returns {void}
      */
     const handleClick = async () => {
+        if (props.bots.size === 0) {
+            return;
+        }
+
         const hasControl = await isControllingClient();
 
         if (!hasControl) {

--- a/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllButton.tsx
+++ b/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllButton.tsx
@@ -66,6 +66,10 @@ export default function DataOffloadAllButton(props: Props) {
      * @returns {void}
      */
     const handleClick = async () => {
+        if (props.bots.size === 0) {
+            return;
+        }
+
         const hasControl = await isControllingClient();
 
         if (!hasControl) {

--- a/src/web/components/__buttons__/StartAllMissionsButton/StartAllMissionsButton.tsx
+++ b/src/web/components/__buttons__/StartAllMissionsButton/StartAllMissionsButton.tsx
@@ -84,6 +84,10 @@ export default function StartAllMissionsButton(props: Props) {
      * @returns {void}
      */
     const handleClick = async () => {
+        if (props.bots.size === 0) {
+            return;
+        }
+
         const hasControl = await isControllingClient();
 
         if (!hasControl) {

--- a/src/web/components/__buttons__/StopAllBotsButton/StopAllBotsButton.tsx
+++ b/src/web/components/__buttons__/StopAllBotsButton/StopAllBotsButton.tsx
@@ -66,6 +66,10 @@ export default function StopAllBotsButton(props: Props) {
      * @returns {void}
      */
     const handleClick = async () => {
+        if (props.bots.size === 0) {
+            return;
+        }
+
         const hasControl = await isControllingClient();
 
         if (!hasControl) {


### PR DESCRIPTION
### Summary
Prevent empty alert from appearing in JCC when a all Bots" button is clicked. We now check the size of the Bots map before rendering the dialog.

### Testing
* No dialog appeared with zero Bots connected to the Hub
* Dialogs appeared as expected with at least 1 Bot connected to the Hub  