### PR TITLE
task/2.y/add-back-simulation-banner/JAIA-2136

### DIFF
--- a/src/web/components/JaiaAbout/JaiaAbout.tsx
+++ b/src/web/components/JaiaAbout/JaiaAbout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { jaiaAPI } from "../../utils/jaia-api";
-import { Metadata } from "../../shared/PortalStatus";
+import { Metadata } from "../../types/protobuf-types";
 
 import JaiaLogo from "../../style/icons/jaia-logo.svg";
 import "./JaiaAbout.less";

--- a/src/web/components/SimulationBanner/SimulationBanner.less
+++ b/src/web/components/SimulationBanner/SimulationBanner.less
@@ -1,0 +1,17 @@
+@import "../../style/stylesheets/vars.less";
+#simulation-banner {
+    position: absolute;
+    bottom: 93px;
+    right: 93px;
+    height: 40px;
+    width: 100px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    background-color: @waypoint-color;
+    color: @cc-text-color;
+
+    font-size: 1rem;
+}

--- a/src/web/components/SimulationBanner/SimulationBanner.less
+++ b/src/web/components/SimulationBanner/SimulationBanner.less
@@ -1,5 +1,6 @@
 @import "../../style/stylesheets/vars.less";
-#simulation-banner {
+
+.simulation-banner {
     position: absolute;
     bottom: 93px;
     right: 93px;

--- a/src/web/components/SimulationBanner/SimulationBanner.tsx
+++ b/src/web/components/SimulationBanner/SimulationBanner.tsx
@@ -1,0 +1,31 @@
+import { METADATA_POLL_TIME } from "../../utils/constants";
+import { useEffect, useState } from "react";
+import { jaiaAPI } from "../../utils/jaia-api";
+import "./SimulationBanner.less";
+
+export default function SimulationBanner() {
+    const [simulationMode, setSimulationMode] = useState(false);
+
+    const fetchSimulationMode = async () => {
+        try {
+            const metadata = await jaiaAPI.getMetadata();
+            setSimulationMode(metadata.is_simulation);
+        } catch (error) {
+            console.error("Error fetching simulation metadata:", error);
+        }
+    };
+
+    useEffect(() => {
+        fetchSimulationMode();
+        const interval = setInterval(fetchSimulationMode, METADATA_POLL_TIME);
+        return () => clearInterval(interval);
+    }, []);
+
+    if (!simulationMode) return null;
+
+    return (
+        <div id="simulation-banner" className="simulation-banner">
+            Simulation
+        </div>
+    );
+}

--- a/src/web/components/SimulationBanner/SimulationBanner.tsx
+++ b/src/web/components/SimulationBanner/SimulationBanner.tsx
@@ -1,31 +1,35 @@
-import { METADATA_POLL_TIME } from "../../utils/constants";
 import { useEffect, useState } from "react";
+import { METADATA_POLL_TIME } from "../../utils/constants";
 import { jaiaAPI } from "../../utils/jaia-api";
 import "./SimulationBanner.less";
 
+/**
+ * Displays the simulation indicator in the JCC
+ */
 export default function SimulationBanner() {
     const [simulationMode, setSimulationMode] = useState(false);
 
+    /**
+     * Retrieves the metadata message from the server to
+     * update the simulationMode property
+     *
+     * @returns {void}
+     */
     const fetchSimulationMode = async () => {
         try {
             const metadata = await jaiaAPI.getMetadata();
             setSimulationMode(metadata.is_simulation);
         } catch (error) {
-            console.error("Error fetching simulation metadata:", error);
+            console.error("Error fetching metadata for simulation banner:", error);
         }
     };
 
     useEffect(() => {
-        fetchSimulationMode();
         const interval = setInterval(fetchSimulationMode, METADATA_POLL_TIME);
         return () => clearInterval(interval);
     }, []);
 
-    if (!simulationMode) return null;
+    if (!simulationMode) return;
 
-    return (
-        <div id="simulation-banner" className="simulation-banner">
-            Simulation
-        </div>
-    );
+    return <div className="simulation-banner">Simulation</div>;
 }

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -21,6 +21,7 @@ import SurveyPlanner from "../components/SurveyPlanner/SurveyPlanner";
 import TaskPacketPanel from "../components/TaskPacketPanel/TaskPacketPanel";
 import DataOffloadPanel from "../components/DataOffloadPanel/DataOffloadPanel";
 import RemoteControlPanel from "../components/RemoteControlPanel/RemoteControlPanel";
+import SimulationBanner from "../components/SimulationBanner/SimulationBanner";
 
 import "./App.less";
 
@@ -38,6 +39,7 @@ export default function App() {
                 <Details />
                 <Panel />
                 <RemoteControl />
+                <SimulationBanner />
             </JaiaContextProvider>
             <div id="connection-warning">Connection to Hub Dropped</div>
         </div>

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -20,8 +20,8 @@ import WaypointPanel from "../components/WaypointPanel/WaypointPanel";
 import SurveyPlanner from "../components/SurveyPlanner/SurveyPlanner";
 import TaskPacketPanel from "../components/TaskPacketPanel/TaskPacketPanel";
 import DataOffloadPanel from "../components/DataOffloadPanel/DataOffloadPanel";
-import RemoteControlPanel from "../components/RemoteControlPanel/RemoteControlPanel";
 import SimulationBanner from "../components/SimulationBanner/SimulationBanner";
+import RemoteControlPanel from "../components/RemoteControlPanel/RemoteControlPanel";
 
 import "./App.less";
 

--- a/src/web/types/protobuf-types.ts
+++ b/src/web/types/protobuf-types.ts
@@ -1213,3 +1213,22 @@ export interface ContactStatus {
     speed_over_ground?: number;
     heading_or_cog?: number;
 }
+
+export interface Version {
+    major: string;
+    minor: string;
+    patch: string;
+    git_hash?: string;
+    git_branch?: string;
+}
+
+export interface Metadata {
+    name?: string;
+    jaiabot_version?: Version;
+    goby_version?: string;
+    moos_version?: string;
+    ivp_version?: string;
+    xbee_node_id?: string;
+    xbee_serial_number?: string;
+    is_simulation?: boolean;
+}

--- a/src/web/utils/constants.ts
+++ b/src/web/utils/constants.ts
@@ -7,6 +7,7 @@ export const TEXT_OFFSET_RADIUS = 11;
 export const NO_COMMS_STATUS_AGE = 30; // seconds
 export const DATA_MODEL_POLL_TIME = 500; // milliseconds
 export const TASK_PACKET_POLL_TIME = 1000; // milliseconds
+export const METADATA_POLL_TIME = 10000; // milliseconds
 export const INITAL_ZOOM_DURATION = 3000; // milliseconds
 export const INITIAL_ZOOM = 15; // OpenLayers zoom level
 export const SCROLL_DELAY = 30; // milliseconds


### PR DESCRIPTION
Added the simulation banner to JCC

The SimulationBanner component sets up it's own state variable and polling to monitor the metadata and displays **Simulation** if in sim mode, returns null otherwise.

Moved declaration of Metadata used by JaiaAbout to protobuff-types

<img width="1287" height="963" alt="image" src="https://github.com/user-attachments/assets/920cd4b3-c7ed-4b60-bf2f-0811e002c3c1" />
