### PR TITLE
bug/2.y/status-age-stops-climbing-on-comms-drop/JAIA-2144

### DIFF
--- a/src/web/jcc/index.tsx
+++ b/src/web/jcc/index.tsx
@@ -28,10 +28,10 @@ const statusInterval = setInterval(async () => {
             const json = await response.json();
             updateBots(json.bots);
             updateHubs(json.hubs);
-            if (json.messages.error) {
-                handleStatusError(json.messages.error);
+            updateOpenLayers();
+            if (json.messages.error && json.messages.error === HUB_CONNECTION_ERROR) {
+                updateDisconnectedWarning(true);
             } else {
-                updateOpenLayers();
                 updateDisconnectedWarning(false);
             }
         }
@@ -55,18 +55,6 @@ const taskPacketInterval = setInterval(async () => {
         console.error(error);
     }
 }, TASK_PACKET_POLL_TIME);
-
-/**
- * Displays the warning coming from the server
- *
- * @param {string} error Error message from the web server
- * @returns {void}
- */
-function handleStatusError(error: string) {
-    if (error === HUB_CONNECTION_ERROR) {
-        updateDisconnectedWarning(true);
-    }
-}
 
 /**
  * Moves Bot data from the server to the client-side data model

--- a/src/web/jcc/index.tsx
+++ b/src/web/jcc/index.tsx
@@ -26,11 +26,11 @@ const statusInterval = setInterval(async () => {
             console.error(`Response status: ${response.status}`);
         } else {
             const json = await response.json();
+            updateBots(json.bots);
+            updateHubs(json.hubs);
             if (json.messages.error) {
                 handleStatusError(json.messages.error);
             } else {
-                updateBots(json.bots);
-                updateHubs(json.hubs);
                 updateOpenLayers();
                 updateDisconnectedWarning(false);
             }


### PR DESCRIPTION
Update bots and hub when we get a response fetching status that includes an error so the status age continues to update.  Note if the web server dies and we do not get a response the ages to not update, this is the same behavior as 2.y