### PR TITLE
feature/heading-uncertainty-threshold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 # require minimum C++ version
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_options(-fmax-errors=5)
 
 # determine version of jaiabot
 include(JaiaVersions)

--- a/cmake/JaiaVersions.cmake
+++ b/cmake/JaiaVersions.cmake
@@ -81,4 +81,4 @@ set(PROJECT_SOVERSION "1")
 
 # increment when DCCL messages change. See also src/lib/messages/CMakeLists.txt
 # start at 1 as 0 would be used prior to introducing this version (goby::middleware::Group::broadcast_group == 0)
-set(PROJECT_INTERVEHICLE_API_VERSION 15)
+set(PROJECT_INTERVEHICLE_API_VERSION 16)

--- a/config/templates/bot/_liaison_load.pb.cfg.in
+++ b/config/templates/bot/_liaison_load.pb.cfg.in
@@ -11,3 +11,10 @@ load_protobuf {
         group: "jaiabot::camera"
     }
 }
+
+load_protobuf {
+    name: "jaiabot.protobuf.SimulatorCommand" 
+    publish_to {
+        group: "jaiabot::simulator_command"
+    }
+}

--- a/config/templates/bot/_liaison_load.pb.cfg.in
+++ b/config/templates/bot/_liaison_load.pb.cfg.in
@@ -11,3 +11,11 @@ load_protobuf {
         group: "jaiabot::camera"
     }
 }
+
+load_protobuf {
+    name: "jaiabot.protobuf.SimulatorCommand" 
+    publish_to {
+        group: "jaiabot::simulator_command"
+    }
+}
+

--- a/config/templates/bot/jaiabot_fusion.pb.cfg.in
+++ b/config/templates/bot/jaiabot_fusion.pb.cfg.in
@@ -13,7 +13,6 @@ discard_location_states: IN_MISSION__UNDERWAY__TASK__DIVE__HOLD
 discard_location_states: IN_MISSION__UNDERWAY__TASK__DIVE__UNPOWERED_ASCENT
 discard_location_states: IN_MISSION__UNDERWAY__TASK__DIVE__POWERED_ASCENT
 discard_location_states: IN_MISSION__UNDERWAY__TASK__DIVE__REACQUIRE_GPS
-discard_location_states: IN_MISSION__PAUSE__REACQUIRE_GPS
 
 # IMU Detection
 imu_heading_course_max_diff: 45 # In Degrees

--- a/config/templates/bot/jaiabot_simulator.pb.cfg.in
+++ b/config/templates/bot/jaiabot_simulator.pb.cfg.in
@@ -49,8 +49,6 @@ temperature_stdev: 0.05
 salinity_stdev: 0.05
 
 # GPS
-gps_hdop_rand_max: 1.30 # (optional) (default=1.3)
-gps_pdop_rand_max: 2.20 # (optional) (default=2.2)
 heading_rand_max: 0 # (optional) (default=0)
 
 # Voltage

--- a/config/templates/bot/jaiabot_simulator.pb.cfg.in
+++ b/config/templates/bot/jaiabot_simulator.pb.cfg.in
@@ -63,3 +63,8 @@ arduino_config {
 
 minimum_thrust: 1  #  normalized 0-100
 pitch_at_rest: 85  #  degrees
+
+gps_noise {
+    lateral_r95: 5
+    lateral_phi: 0.999
+}

--- a/src/bin/fusion/TPVFilter.h
+++ b/src/bin/fusion/TPVFilter.h
@@ -1,0 +1,77 @@
+#include <vector>
+#include <goby/middleware/protobuf/gpsd.pb.h>
+#include <goby/time/steady_clock.h>
+#include <goby/middleware/marshalling/protobuf.h>
+#include <goby/util/debug_logger/flex_ostream.h>
+
+using namespace std;
+using namespace goby::middleware::protobuf::gpsd;
+using namespace goby::time;
+using goby::glog;
+
+struct TPVState {
+    SteadyClock::time_point received_time;
+    TimePositionVelocity tpv;
+    SkyView sky;
+};
+
+
+class TPVFilter {
+    public:
+
+        TPVFilter(const int tpv_state_expiration_time_ms = 1000)
+            : tpv_state_expiration_time_ms_(tpv_state_expiration_time_ms) {
+        }
+
+        void push_skyview(const SkyView& sky) {
+            latest_skyview_ = sky;
+        }
+
+        void push_tpv(const TimePositionVelocity& tpv) {
+            // Add new tpv state
+            TPVState state;
+            auto now = SteadyClock::now();
+            state.received_time = now;
+            state.tpv = tpv;
+            state.sky = latest_skyview_;
+            tpv_states_.push_back(state);
+
+            // Remove old states, if we have more than one, (one old state is better than none)
+            if (tpv_states_.size() > 1) {
+                tpv_states_.erase(
+                    std::remove_if(
+                        tpv_states_.begin(),
+                        tpv_states_.end(),
+                        [this, now](const TPVState& old_state) {
+                            auto age = now - old_state.received_time;
+                            return age > std::chrono::milliseconds(tpv_state_expiration_time_ms_);
+                        }),
+                    tpv_states_.end());
+            }
+            
+            // Sort by hdop
+            std::sort(tpv_states_.begin(), tpv_states_.end(),
+                    [](const TPVState& a, const TPVState& b) {
+                        // No hdop means worst hdop
+                        if (!a.sky.has_hdop()) return false;
+                        if (!b.sky.has_hdop()) return true;
+                        return a.sky.hdop() < b.sky.hdop();
+                    });
+
+        }
+
+        const TPVState* best_tpv_state() const {
+            if (tpv_states_.empty()) {
+                return nullptr;
+            } else {
+                return &tpv_states_.front();
+            }
+        }
+
+        int tpv_state_expiration_time_ms_{1000};
+
+    private:
+        SkyView latest_skyview_;
+        vector<TPVState> tpv_states_;
+
+};

--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -30,7 +30,7 @@
 
 #include <goby/zeromq/application/single_thread.h>
 
-#include "config.pb.h"
+#include "bin/fusion/config.pb.h"
 #include "goby/util/sci.h" // for linear_interpolate
 #include "jaiabot/groups.h"
 #include "jaiabot/health/health.h"
@@ -46,11 +46,14 @@
 #include "wmm/WMM.h"
 #include <cmath>
 #include <math.h>
+#include "TPVFilter.h"
 
 #define NOW (goby::time::SystemClock::now<goby::time::MicroTime>())
 
 using goby::glog;
 using namespace std;
+using goby::middleware::protobuf::gpsd::TimePositionVelocity;
+using goby::middleware::protobuf::gpsd::SkyView;
 
 namespace si = boost::units::si;
 using boost::units::degree::degrees;
@@ -111,6 +114,9 @@ class Fusion : public ApplicationBase
 
     // Battery Percentage Health
     bool watch_battery_percentage_{false};
+
+    // Filter for TPV messages
+    TPVFilter tpv_filter_;
 
     enum class DataType
     {
@@ -325,16 +331,34 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(5 * si::hertz)
             latest_bot_status_.set_calibration_state(imu_data.calibration_state());
         }
     });
+
+    // Incoming GPS TimePositionVelocity messages
     interprocess().subscribe<goby::middleware::groups::gpsd::tpv>(
-        [this](const goby::middleware::protobuf::gpsd::TimePositionVelocity& tpv) {
-            glog.is_debug1() && glog << "Received TimePositionVelocity update: "
-                                     << tpv.ShortDebugString() << std::endl;
+        [this](const TimePositionVelocity& incoming_tpv) {
+            glog.is_warn() && glog << "Received TimePositionVelocity update: "
+                                     << incoming_tpv.ShortDebugString() << std::endl;
+
+            tpv_filter_.push_tpv(incoming_tpv);
+
+            const TPVState* best_state = tpv_filter_.best_tpv_state();
+            if (best_state == nullptr) {
+                glog.is_warn() && glog << "No valid TPV states available after filtering." << std::endl;
+                return;
+            }
+
+            const auto skyview = best_state->sky;
+            const auto tpv = best_state->tpv;
+
+            // Set our hdop and pdop from the latest skyview
+            latest_bot_status_.set_hdop(skyview.hdop());
+            latest_bot_status_.set_lateral_r95(skyview.hdop() * 1.96 * 5 / sqrt(2)); // approx conversion factor
+            latest_bot_status_.set_pdop(skyview.pdop());
 
             auto now = goby::time::SteadyClock::now();
 
             if (tpv.has_mode() &&
-                (tpv.mode() == goby::middleware::protobuf::gpsd::TimePositionVelocity::Mode2D ||
-                 tpv.mode() == goby::middleware::protobuf::gpsd::TimePositionVelocity::Mode3D))
+                (tpv.mode() == TimePositionVelocity::Mode2D ||
+                 tpv.mode() == TimePositionVelocity::Mode3D))
             {
                 last_data_time_[DataType::GPS_FIX] = now;
             }
@@ -570,15 +594,8 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(5 * si::hertz)
         });
 
     interprocess().subscribe<goby::middleware::groups::gpsd::sky>(
-        [this](const goby::middleware::protobuf::gpsd::SkyView& sky) {
-            if (sky.has_hdop())
-            {
-                latest_bot_status_.set_hdop(sky.hdop());
-            }
-            if (sky.has_pdop())
-            {
-                latest_bot_status_.set_pdop(sky.pdop());
-            }
+        [this](const SkyView& sky) {
+            tpv_filter_.push_skyview(sky);
         });
  
     // subscribe for commands from mission manager
@@ -710,6 +727,11 @@ void jaiabot::apps::Fusion::loop()
                 intervehicle().publish<jaiabot::groups::bot_status>(
                     latest_bot_status_,
                     intervehicle::default_publisher<decltype(latest_bot_status_)>);
+                
+                // Clear HDOP and PDOP after sending bot status
+                latest_bot_status_.clear_hdop();
+                latest_bot_status_.clear_pdop();
+
                 last_bot_status_report_time_ = now;
 
                 // If the rf is disabled and operator enables rf

--- a/src/bin/mission_manager/app.cpp
+++ b/src/bin/mission_manager/app.cpp
@@ -353,6 +353,18 @@ jaiabot::apps::MissionManager::MissionManager()
             }
         });
 
+        // Subscribe to bot_status
+    interprocess().subscribe<jaiabot::groups::bot_status>(
+        [this](const jaiabot::protobuf::BotStatus& bot_status)
+        {
+            glog.is_debug2() && glog << "Received BotStatus " << bot_status.ShortDebugString()
+                                     << std::endl;
+
+            statechart::EvBotStatusReceived ev;
+            ev.status = bot_status;
+            machine_->process_event(ev);
+        });
+
     // subscribe for engineering commands
     interprocess().subscribe<jaiabot::groups::engineering_command>(
         [this](const jaiabot::protobuf::Engineering& command)

--- a/src/bin/mission_manager/config.proto
+++ b/src/bin/mission_manager/config.proto
@@ -243,4 +243,8 @@ message MissionManager
 
     optional jaiabot.protobuf.CameraCommand start_camera_command = 90;
     optional jaiabot.protobuf.CameraCommand stop_camera_command = 91;
+
+    optional double max_allowed_heading_uncertainty = 92 [default = 20.0, (dccl.field).units = { derived_dimensions: "plane_angle" system: "angle::degree" }]; // Max heading uncertainty before we consider GPS degraded
+    optional double ok_lateral_r95 = 93 [default = 10.0, (dccl.field).units = { base_dimensions: "L" }]; // Precision is always good enough if R95 is less than this value
+    optional double heading_uncertainty_recovery_time = 94 [default = 30.0, (dccl.field).units = { base_dimensions: "T" }]; // Time the lateral precision must be good before we consider the heading uncertainty resolved
 }

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -996,47 +996,8 @@ struct ReacquireGPS
     ReacquireGPS(typename StateBase::my_context c);
     ~ReacquireGPS(){};
 
-    void gps(const EvVehicleGPS& ev)
-    {
-        if ((ev.hdop <= this->machine().transit_hdop_req()) &&
-            (ev.pdop <= this->machine().transit_pdop_req()))
-        {
-            // Increment gps fix checks until we are > the threshold for confirming gps fix
-            if (gps_fix_check_incr_ < (this->machine().transit_gps_fix_checks() - 1))
-            {
-                goby::glog.is_debug2() &&
-                    goby::glog << "GPS has a good fix, but has not "
-                                  "reached threshold for total checks"
-                                  " "
-                               << gps_fix_check_incr_ << " < "
-                               << (this->machine().transit_gps_fix_checks() - 1) << std::endl;
-                // Increment until we reach total gps fix checks
-                gps_fix_check_incr_++;
-            }
-            else
-            {
-                goby::glog.is_debug2() &&
-                    goby::glog << "GPS has a good fix, Post EvGPSFix, hdop is " << ev.hdop
-                               << " <= " << this->machine().transit_hdop_req() << ", pdop is "
-                               << ev.pdop << " <= " << this->machine().transit_pdop_req()
-                               << " Reset incr for gps degraded fix" << std::endl;
-
-                // Post Event for gps fix
-                this->post_event(statechart::EvGPSFix());
-            }
-        }
-        else
-        {
-            // Reset gps fix incrementor
-            gps_fix_check_incr_ = 0;
-        }
-    }
-
     using reactions = boost::mpl::list<
-        boost::statechart::transition<EvGPSFix,
-                                      boost::statechart::deep_history<underway::Abort // default
-                                                                      >>,
-        boost::statechart::in_state_reaction<EvVehicleGPS, ReacquireGPS, &ReacquireGPS::gps>>;
+        boost::statechart::transition<EvHeadingUncertaintyResolved, boost::statechart::deep_history<underway::Abort>>>;
 
   private:
     int gps_fix_check_incr_{0};
@@ -1152,50 +1113,9 @@ struct IvPSensorPauseCommon : boost::statechart::state<Derived, Parent>,
 
     ~IvPSensorPauseCommon(){};
 
-    void gps(const EvVehicleGPS& ev)
-    {
-        if ((ev.hdop <= this->machine().transit_hdop_req()) &&
-            (ev.pdop <= this->machine().transit_pdop_req()))
-        {
-            // Reset Counter For Degraded Checks
-            gps_degraded_fix_check_incr_ = 0;
-        }
-        else
-        {
-            // Increment degraded checks until we are > the threshold for confirming degraded gps
-            if (gps_degraded_fix_check_incr_ <
-                (this->machine().transit_gps_degraded_fix_checks() - 1))
-            {
-                goby::glog.is_debug2() &&
-                    goby::glog << "GPS has a degraded fix, but has not "
-                                  "reached threshold for total checks: "
-                                  " "
-                               << gps_degraded_fix_check_incr_ << " < "
-                               << (this->machine().transit_gps_degraded_fix_checks() - 1)
-                               << std::endl;
-
-                // Increment until we reach total gps degraded fix checks
-                gps_degraded_fix_check_incr_++;
-            }
-            else
-            {
-                goby::glog.is_debug2() &&
-                    goby::glog << "GPS has a degraded fix, Post EvGPSNoFix, hdop is " << ev.hdop
-                               << " > " << this->machine().transit_hdop_req() << ", pdop is "
-                               << ev.pdop << " > " << this->machine().transit_pdop_req()
-                               << " Reset incr for gps fix" << std::endl;
-
-                // Post Event for no gps fix
-                this->post_event(statechart::EvGPSNoFix());
-            }
-        }
-    }
-
     using common_reactions =
-        boost::mpl::list<boost::statechart::in_state_reaction<EvVehicleGPS, IvPSensorPauseCommon,
-                                                              &IvPSensorPauseCommon::gps>,
-                         boost::statechart::transition<EvGPSNoFix, pause::ReacquireGPS>,
-                         boost::statechart::transition<EvIMURestart, pause::IMURestart>>;
+                    boost::mpl::list<boost::statechart::transition<EvIMURestart, pause::IMURestart>,
+                         boost::statechart::transition<EvHeadingUncertaintyExceeded, pause::ReacquireGPS>>;
 
   private:
     int gps_degraded_fix_check_incr_{0};

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -527,6 +527,13 @@ struct MissionManagerStateMachine
     }
     const std::string& data_offload_exclude() { return data_offload_exclude_; }
 
+    void set_current_bot_status(const jaiabot::protobuf::BotStatus& bot_status)
+    {
+        current_bot_status_ = bot_status;
+    }
+    const jaiabot::protobuf::BotStatus& current_bot_status() { return current_bot_status_; }
+
+
   private:
     apps::MissionManager& app_;
     jaiabot::protobuf::MissionState state_{jaiabot::protobuf::PRE_DEPLOYMENT__IDLE};
@@ -564,6 +571,7 @@ struct MissionManagerStateMachine
     std::string data_time_string_{""};
     int32_t hub_id_{0};
     std::string data_offload_exclude_{""};
+    jaiabot::protobuf::BotStatus current_bot_status_;
 };
 
 struct PreDeployment

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -534,12 +534,6 @@ struct MissionManagerStateMachine
     }
     const std::string& data_offload_exclude() { return data_offload_exclude_; }
 
-    void set_current_bot_status(const jaiabot::protobuf::BotStatus& bot_status)
-    {
-        current_bot_status_ = bot_status;
-    }
-    const jaiabot::protobuf::BotStatus& current_bot_status() { return current_bot_status_; }
-
 
   private:
     apps::MissionManager& app_;
@@ -578,7 +572,6 @@ struct MissionManagerStateMachine
     std::string data_time_string_{""};
     int32_t hub_id_{0};
     std::string data_offload_exclude_{""};
-    jaiabot::protobuf::BotStatus current_bot_status_;
 };
 
 struct PreDeployment

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -109,6 +109,8 @@ STATECHART_EVENT(EvGPSNoFix)
 STATECHART_EVENT(EvIMURestart)
 STATECHART_EVENT(EvIMURestartCompleted)
 STATECHART_EVENT(EvBottomDepthAbort)
+STATECHART_EVENT(EvHeadingUncertaintyExceeded)
+STATECHART_EVENT(EvHeadingUncertaintyResolved)
 
 STATECHART_EVENT(EvLoop)
 struct EvVehicleDepth : boost::statechart::event<EvVehicleDepth>

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -16,7 +16,7 @@
 #include <goby/util/debug_logger.h>
 #include <goby/util/linebasedcomms/nmea_sentence.h>
 
-#include "config.pb.h"
+#include "bin/mission_manager/config.pb.h"
 #include "jaiabot/groups.h"
 #include "jaiabot/messages/dive_debug.pb.h"
 #include "jaiabot/messages/high_control.pb.h"

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -75,6 +75,11 @@ STATECHART_EVENT(EvMissionInfeasible)
 STATECHART_EVENT(EvDeployed)
 STATECHART_EVENT(EvWaypointReached)
 
+struct EvBotStatusReceived : boost::statechart::event<EvBotStatusReceived>
+{
+    jaiabot::protobuf::BotStatus status;
+};
+
 struct EvPerformTask : boost::statechart::event<EvPerformTask>
 {
     EvPerformTask() : has_task(false) {}
@@ -873,11 +878,86 @@ struct InMission
 
     bool is_echo_recording() const { return is_echo_recording_; }
 
+    // Check heading uncertainty to current goal
+    // If exceeded, post EvHeadingUncertaintyExceeded
+    // If recovered, post EvHeadingUncertaintyResolved
+    void check_heading_uncertainty(const EvBotStatusReceived& ev)
+    {
+        const double DEGREES = M_PI / 180.0;
+
+        if (current_goal() == boost::none)
+            return;
+
+        const auto& current_goal_ = current_goal().get();
+
+        const auto lateral_r95 = ev.status.lateral_r95();
+        if (lateral_r95 > cfg().ok_lateral_r95())
+        {
+            const auto bot_xy = this->machine().geodesy().convert({ev.status.location().lat_with_units(), ev.status.location().lon_with_units()});
+            const auto goal_xy = this->machine().geodesy().convert({current_goal_.location().lat_with_units(), current_goal_.location().lon_with_units()});
+            const auto dx = (goal_xy.x - bot_xy.x).value();
+            const auto dy = (goal_xy.y - bot_xy.y).value();
+            const auto distance_to_goal = std::sqrt(dx * dx + dy * dy);
+
+            double heading_uncertainty_radians;
+            if (lateral_r95 >= distance_to_goal)
+            {
+                heading_uncertainty_radians = M_PI; // 180 degrees
+            }
+            else {
+                heading_uncertainty_radians = std::asin(lateral_r95 / distance_to_goal);
+            }
+
+            // goby::glog.is_warn() && goby::glog << group("goal") << "Distance to goal index " << goal_index_
+            //                    << " is " << distance_to_goal
+            //                    << " meters." << std::endl;
+            // goby::glog.is_warn() && goby::glog << group("goal") << "Lateral uncertainty " << goal_index_
+            //                    << " is " << lateral_r95
+            //                    << " meters." << std::endl;
+            // goby::glog.is_warn() && goby::glog << group("goal") << "Heading uncertainty to goal index " << goal_index_
+            //                    << " is " << heading_uncertainty_radians / DEGREES
+            //                    << " degrees." << std::endl;
+
+            if (heading_uncertainty_radians > cfg().max_allowed_heading_uncertainty() * DEGREES)
+            {
+                goby::glog.is_warn() && goby::glog << group("goal") << "Heading uncertainty = " 
+                                << heading_uncertainty_radians / DEGREES << "deg > "
+                                << cfg().max_allowed_heading_uncertainty() << " deg."
+                                << std::endl;
+
+                this->post_event(EvHeadingUncertaintyExceeded());
+                last_bad_heading_uncertainty = goby::time::SteadyClock::now();
+                return;
+            }
+        }
+
+        // We've been good for some time
+        if (last_bad_heading_uncertainty == goby::time::SteadyClock::time_point::min())
+            return;
+
+        // lateral uncertainty is ok
+        const auto& heading_uncertainty_recovery_time = goby::time::convert_duration<goby::time::SteadyClock::duration>(cfg().heading_uncertainty_recovery_time_with_units());
+        const auto& elapsed_time = goby::time::SteadyClock::now() - last_bad_heading_uncertainty;
+
+        if (elapsed_time > heading_uncertainty_recovery_time) {
+
+            goby::glog.is_warn() && goby::glog << group("goal") << "Heading uncertainty to goal index "
+                            << goal_index_ << " has recovered." << std::endl;
+
+            this->post_event(EvHeadingUncertaintyResolved());
+            last_bad_heading_uncertainty = goby::time::SteadyClock::time_point::min();
+        }
+        else {
+            goby::glog.is_warn() && goby::glog << group("goal") << "Insufficient recovery time: " << elapsed_time.count() / 1e6 << " sec" << std::endl;
+        }
+    }
+
     using reactions = boost::mpl::list<
         boost::statechart::transition<EvNewMission, inmission::underway::Replan>,
         boost::statechart::transition<EvRecovered, PostDeployment>,
         boost::statechart::transition<EvAbort, inmission::underway::Abort>,
-        boost::statechart::transition<EvStop, inmission::underway::recovery::Stopped>>;
+        boost::statechart::transition<EvStop, inmission::underway::recovery::Stopped>,
+        boost::statechart::in_state_reaction<EvBotStatusReceived, InMission, &InMission::check_heading_uncertainty>>;
 
   private:
     int goal_index_{0};
@@ -885,6 +965,7 @@ struct InMission
     bool mission_complete_{false};
     bool use_heading_constant_pid_{false};
     bool is_echo_recording_{false};
+    goby::time::SteadyClock::time_point last_bad_heading_uncertainty = goby::time::SteadyClock::time_point::min();
 };
 
 namespace inmission

--- a/src/bin/mission_manager/mission_manager.h
+++ b/src/bin/mission_manager/mission_manager.h
@@ -7,7 +7,7 @@
 #include <goby/middleware/protobuf/frontseat_data.pb.h>
 #include <goby/zeromq/application/multi_thread.h>
 
-#include "config.pb.h"
+#include "bin/mission_manager/config.pb.h"
 #include "jaiabot/groups.h"
 #include "jaiabot/messages/jaia_dccl.pb.h"
 #include "jaiabot/messages/comms.pb.h"

--- a/src/bin/simulator/GPSNoiseGenerator.h
+++ b/src/bin/simulator/GPSNoiseGenerator.h
@@ -1,0 +1,44 @@
+#include <random>
+#include "jaiabot/messages/simulator.pb.h"
+
+
+using jaiabot::protobuf::GPSNoise;
+
+
+struct GPSNoiseGenerator {
+    GPSNoiseGenerator(const GPSNoise& gps_noise): config(gps_noise) {
+        last_noise_x_ = 0.0;
+        last_noise_y_ = 0.0;
+    }
+
+    std::pair<double, double> generate() {
+
+        // We're using an AR(1) process to model temporally correlated GPS noise
+        const double lateral_stdev = config.lateral_r95() / 2.4477;  // R95 to 1 sigma
+        const double lateral_phi = config.lateral_phi();
+        // Calculate the standard deviation of the epsilon term
+        const double sigma_epsilon =
+            lateral_stdev * std::sqrt(1 - lateral_phi * lateral_phi);
+        auto gps_noise_distribution_ = std::normal_distribution<double>(0.0, sigma_epsilon);
+
+        double x_noise = lateral_phi * last_noise_x_ + gps_noise_distribution_(generator_);
+        double y_noise = lateral_phi * last_noise_y_ + gps_noise_distribution_(generator_);
+        last_noise_x_ = x_noise;
+        last_noise_y_ = y_noise;
+
+        // Set the hdop and pdop values to match the noise characteristics
+        hdop = (lateral_stdev * std::sqrt(2)) / 5.0;  // assuming vertical stdev is half of horizontal
+        pdop = hdop;
+
+        return {x_noise, y_noise};
+    }
+
+  public:
+    const GPSNoise config;
+    double hdop, pdop;
+
+  private:
+    std::default_random_engine generator_;
+    double last_noise_x_;
+    double last_noise_y_;
+};

--- a/src/bin/simulator/GPSNoiseGenerator.h
+++ b/src/bin/simulator/GPSNoiseGenerator.h
@@ -6,7 +6,12 @@ using jaiabot::protobuf::GPSNoise;
 
 
 struct GPSNoiseGenerator {
-    GPSNoiseGenerator(const GPSNoise& gps_noise): config(gps_noise) {
+    GPSNoiseGenerator(const GPSNoise& gps_noise) {
+        set_noise_params(gps_noise);
+    }
+
+    void set_noise_params(const GPSNoise& gps_noise) {
+        config = gps_noise;
         last_noise_x_ = 0.0;
         last_noise_y_ = 0.0;
     }
@@ -34,7 +39,7 @@ struct GPSNoiseGenerator {
     }
 
   public:
-    const GPSNoise config;
+    GPSNoise config;
     double hdop, pdop;
 
   private:

--- a/src/bin/simulator/config.proto
+++ b/src/bin/simulator/config.proto
@@ -29,6 +29,7 @@ import "goby/zeromq/protobuf/interprocess_config.proto";
 import "goby/moos/protobuf/moos_gateway_config.proto";
 import "goby/middleware/protobuf/udp_config.proto";
 import "jaiabot/messages/geographic_coordinate.proto";
+import "jaiabot/messages/simulator.proto";
 
 package jaiabot.config;
 
@@ -116,6 +117,8 @@ message Simulator
     optional string hub_gpsd_device = 43;
 
     optional ArduinoSimThread arduino_config = 60;
+
+    optional jaiabot.protobuf.GPSNoise gps_noise = 70;
 }
 
 message ArduinoSimThread

--- a/src/bin/simulator/config.proto
+++ b/src/bin/simulator/config.proto
@@ -57,13 +57,7 @@ message Simulator
 
     optional jaiabot.protobuf.GeographicCoordinate start_location = 26;
 
-    // Default is to use the hdop value so bot does not need to reacquire gps
-    optional double gps_hdop_rand_max = 27 [default = 1.3];
-
     optional bool is_bot_sim = 28 [default = true];
-
-    // Default is to use the pdop value so bot does not need to reacquire gps
-    optional double gps_pdop_rand_max = 29 [default = 2.2];
 
     optional double heading_rand_max = 30 [default = 0];
 

--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -220,6 +220,10 @@ jaiabot::apps::SimulatorTranslation::SimulatorTranslation(
         goby().interprocess().subscribe<groups::simulator_command>(
             [this](const jaiabot::protobuf::SimulatorCommand& command)
             {
+
+                glog.is_warn() && glog << "Received simulator command: " << command.ShortDebugString()
+                                       << std::endl;
+
                 switch (command.command_case())
                 {
                     case jaiabot::protobuf::SimulatorCommand::kGpsDropout:
@@ -235,6 +239,10 @@ jaiabot::apps::SimulatorTranslation::SimulatorTranslation(
                             goby::time::SteadyClock::now() +
                             goby::time::convert_duration<goby::time::SteadyClock::duration>(
                                 command.stop_forward_progress().duration_with_units());
+                        break;
+
+                    case jaiabot::protobuf::SimulatorCommand::kGpsNoise:
+                        gps_noise_generator_.set_noise_params(command.gps_noise());
                         break;
 
                     case jaiabot::protobuf::SimulatorCommand::COMMAND_NOT_SET:

--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -53,6 +53,7 @@
 #include "jaiabot/messages/simulator.pb.h"
 #include <goby/middleware/gpsd/groups.h>
 #include <goby/middleware/protobuf/gpsd.pb.h>
+#include "GPSNoiseGenerator.h"
 
 using jaiabot::protobuf::GPSNoise;
 
@@ -109,10 +110,10 @@ class SimulatorTranslation : public goby::moos::Translator
     std::default_random_engine generator_;
     std::normal_distribution<double> temperature_distribution_;
     std::normal_distribution<double> salinity_distribution_;
-    std::normal_distribution<double> gps_noise_distribution_{0.0, 1.0};
-    double gps_noise_phi_{0.0};
-    double last_gps_noise_x_{0.0};
-    double last_gps_noise_y_{0.0};
+
+    // GPS noise generator
+    GPSNoiseGenerator gps_noise_generator_{sim_cfg_.gps_noise()};
+
     goby::time::SteadyClock::time_point sky_last_updated_{std::chrono::seconds(0)};
     int time_out_sky_{200};
 
@@ -177,21 +178,6 @@ jaiabot::apps::SimulatorTranslation::SimulatorTranslation(
       salinity_distribution_(0, sim_cfg_.salinity_stdev())
 
 {
-
-    if (sim_cfg_.has_gps_noise())
-    {
-        // We're using an AR(1) process to model temporally correlated GPS noise
-        const double lateral_stdev = sim_cfg_.gps_noise().lateral_r95() / 2.4477;  // R95 to 1 sigma
-        gps_noise_phi_ = sim_cfg_.gps_noise().lateral_phi();
-        // Calculate the standard deviation of the epsilon term
-        const double sigma_epsilon =
-            lateral_stdev * std::sqrt(1 - gps_noise_phi_ * gps_noise_phi_);
-        gps_noise_distribution_ = std::normal_distribution<double>(0.0, sigma_epsilon);
-    }
-    else
-    {
-        gps_noise_distribution_ = std::normal_distribution<double>(0.0, 0.0);
-    }
 
     if (sim_cfg_.is_bot_sim())
     {
@@ -321,13 +307,9 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
 
     auto& moos_buffer = moos().buffer();
 
-    auto x_noise = gps_noise_phi_ * last_gps_noise_x_ + gps_noise_distribution_(generator_);
-    auto y_noise = gps_noise_phi_ * last_gps_noise_y_ + gps_noise_distribution_(generator_);
-    last_gps_noise_x_ = x_noise;
-    last_gps_noise_y_ = y_noise;
-
-    auto x = (moos_buffer["NAV_X"].GetDouble() + x_noise) * si::meters;
-    auto y = (moos_buffer["NAV_Y"].GetDouble() + y_noise) * si::meters;
+    auto lateral_noise = gps_noise_generator_.generate();
+    auto x = (moos_buffer["NAV_X"].GetDouble() + lateral_noise.first) * si::meters;
+    auto y = (moos_buffer["NAV_Y"].GetDouble() + lateral_noise.second) * si::meters;
     auto depth = moos_buffer["NAV_DEPTH"].GetDouble() * si::meters;
 
     // very simple vertical depth simulation assuming perfect controller
@@ -408,10 +390,10 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
 
         double hdop =
             is_dropout ? sim_cfg_.gps_hdop_dropout()
-                       : static_cast<double>(std::rand()) / (RAND_MAX)*sim_cfg_.gps_hdop_rand_max();
+                       : gps_noise_generator_.hdop;
         double pdop =
             is_dropout ? sim_cfg_.gps_pdop_dropout()
-                       : static_cast<double>(std::rand()) / (RAND_MAX)*sim_cfg_.gps_pdop_rand_max();
+                       : gps_noise_generator_.pdop;
 
         sky.set_hdop(hdop);
         sky.set_pdop(pdop);

--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -110,6 +110,9 @@ class SimulatorTranslation : public goby::moos::Translator
     std::normal_distribution<double> temperature_distribution_;
     std::normal_distribution<double> salinity_distribution_;
     std::normal_distribution<double> gps_noise_distribution_{0.0, 1.0};
+    double gps_noise_phi_{0.0};
+    double last_gps_noise_x_{0.0};
+    double last_gps_noise_y_{0.0};
     goby::time::SteadyClock::time_point sky_last_updated_{std::chrono::seconds(0)};
     int time_out_sky_{200};
 
@@ -177,8 +180,13 @@ jaiabot::apps::SimulatorTranslation::SimulatorTranslation(
 
     if (sim_cfg_.has_gps_noise())
     {
+        // We're using an AR(1) process to model temporally correlated GPS noise
         const double lateral_stdev = sim_cfg_.gps_noise().lateral_r95() / 2.4477;  // R95 to 1 sigma
-        gps_noise_distribution_ = std::normal_distribution<double>(0.0, lateral_stdev);
+        gps_noise_phi_ = sim_cfg_.gps_noise().lateral_phi();
+        // Calculate the standard deviation of the epsilon term
+        const double sigma_epsilon =
+            lateral_stdev * std::sqrt(1 - gps_noise_phi_ * gps_noise_phi_);
+        gps_noise_distribution_ = std::normal_distribution<double>(0.0, sigma_epsilon);
     }
     else
     {
@@ -313,8 +321,13 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
 
     auto& moos_buffer = moos().buffer();
 
-    auto x = (moos_buffer["NAV_X"].GetDouble() + gps_noise_distribution_(generator_)) * si::meters;
-    auto y = (moos_buffer["NAV_Y"].GetDouble() + gps_noise_distribution_(generator_)) * si::meters;
+    auto x_noise = gps_noise_phi_ * last_gps_noise_x_ + gps_noise_distribution_(generator_);
+    auto y_noise = gps_noise_phi_ * last_gps_noise_y_ + gps_noise_distribution_(generator_);
+    last_gps_noise_x_ = x_noise;
+    last_gps_noise_y_ = y_noise;
+
+    auto x = (moos_buffer["NAV_X"].GetDouble() + x_noise) * si::meters;
+    auto y = (moos_buffer["NAV_Y"].GetDouble() + y_noise) * si::meters;
     auto depth = moos_buffer["NAV_DEPTH"].GetDouble() * si::meters;
 
     // very simple vertical depth simulation assuming perfect controller

--- a/src/bin/simulator/simulator.cpp
+++ b/src/bin/simulator/simulator.cpp
@@ -54,6 +54,8 @@
 #include <goby/middleware/gpsd/groups.h>
 #include <goby/middleware/protobuf/gpsd.pb.h>
 
+using jaiabot::protobuf::GPSNoise;
+
 using goby::glog;
 namespace si = boost::units::si;
 namespace config = jaiabot::config;
@@ -107,6 +109,7 @@ class SimulatorTranslation : public goby::moos::Translator
     std::default_random_engine generator_;
     std::normal_distribution<double> temperature_distribution_;
     std::normal_distribution<double> salinity_distribution_;
+    std::normal_distribution<double> gps_noise_distribution_{0.0, 1.0};
     goby::time::SteadyClock::time_point sky_last_updated_{std::chrono::seconds(0)};
     int time_out_sky_{200};
 
@@ -171,6 +174,17 @@ jaiabot::apps::SimulatorTranslation::SimulatorTranslation(
       salinity_distribution_(0, sim_cfg_.salinity_stdev())
 
 {
+
+    if (sim_cfg_.has_gps_noise())
+    {
+        const double lateral_stdev = sim_cfg_.gps_noise().lateral_r95() / 2.4477;  // R95 to 1 sigma
+        gps_noise_distribution_ = std::normal_distribution<double>(0.0, lateral_stdev);
+    }
+    else
+    {
+        gps_noise_distribution_ = std::normal_distribution<double>(0.0, 0.0);
+    }
+
     if (sim_cfg_.is_bot_sim())
     {
         interprocess().subscribe<goby::middleware::groups::datum_update>(
@@ -299,8 +313,8 @@ void jaiabot::apps::SimulatorTranslation::process_nav(const CMOOSMsg& msg)
 
     auto& moos_buffer = moos().buffer();
 
-    auto x = moos_buffer["NAV_X"].GetDouble() * si::meters;
-    auto y = moos_buffer["NAV_Y"].GetDouble() * si::meters;
+    auto x = (moos_buffer["NAV_X"].GetDouble() + gps_noise_distribution_(generator_)) * si::meters;
+    auto y = (moos_buffer["NAV_Y"].GetDouble() + gps_noise_distribution_(generator_)) * si::meters;
     auto depth = moos_buffer["NAV_DEPTH"].GetDouble() * si::meters;
 
     // very simple vertical depth simulation assuming perfect controller

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -114,7 +114,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xce048a7bf557d5eb")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xfbba1d63c2d313a3")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xd6cdaf32db2fd089")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0x14ebbe8ed8aed722")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/jaia_dccl.proto
+++ b/src/lib/messages/jaia_dccl.proto
@@ -339,6 +339,8 @@ message BotStatus
 
     optional double pdop = 57 [(dccl.field) = { min: 0 max: 100 precision: 2 }];
 
+    optional double lateral_r95 = 60 [ (dccl.field) = { units { derived_dimensions: "length" }, min: 0 max: 1000 precision: 0 } ];
+
     optional int32 wifi_link_quality_percentage = 58 [
         (dccl.field) = { min: 0 max: 100 precision: 0 },
         (jaia.field).rest_api.presence = GUARANTEED

--- a/src/lib/messages/simulator.proto
+++ b/src/lib/messages/simulator.proto
@@ -25,6 +25,16 @@ import "dccl/option_extensions.proto";
 
 package jaiabot.protobuf;
 
+message GPSNoise 
+{
+    option (dccl.msg) = {
+        unit_system: "si"
+    };
+
+    required double lateral_r95 = 1
+        [(dccl.field) = { units { derived_dimensions: "length" } }];
+}
+
 message SimulatorCommand
 {
     option (dccl.msg) = {
@@ -46,5 +56,6 @@ message SimulatorCommand
     {
         GPSDropOut gps_dropout = 1;
         StopForwardProgress stop_forward_progress = 2;
+        GPSNoise gps_noise = 3;
     }
 }

--- a/src/lib/messages/simulator.proto
+++ b/src/lib/messages/simulator.proto
@@ -33,6 +33,14 @@ message GPSNoise
 
     required double lateral_r95 = 1
         [(dccl.field) = { units { derived_dimensions: "length" } }];
+    
+    // phi for AR(1) process modeling temporal correlation
+    required double lateral_phi = 4;
+
+    // These are optional, and default to the standard GPS values corresponding to the lateral_r95 if not set
+    // i.e. hdop = lateral_r95 / 5.0, pdop = 3.0
+    optional double hdop = 2;
+    optional double pdop = 3;
 }
 
 message SimulatorCommand

--- a/src/lib/messages/simulator.proto
+++ b/src/lib/messages/simulator.proto
@@ -31,16 +31,11 @@ message GPSNoise
         unit_system: "si"
     };
 
-    required double lateral_r95 = 1
-        [(dccl.field) = { units { derived_dimensions: "length" } }];
+    optional double lateral_r95 = 1
+        [(dccl.field) = { units { derived_dimensions: "length" } }, default = 5.0];
     
     // phi for AR(1) process modeling temporal correlation
-    required double lateral_phi = 4;
-
-    // These are optional, and default to the standard GPS values corresponding to the lateral_r95 if not set
-    // i.e. hdop = lateral_r95 / 5.0, pdop = 3.0
-    optional double hdop = 2;
-    optional double pdop = 3;
+    optional double lateral_phi = 4 [default = 0.999];
 }
 
 message SimulatorCommand


### PR DESCRIPTION
Here is the algorithm that uses heading uncertainty to enter and exit REACQUIRE_GPS, without any refactoring.

Description:
Use the GPS heading uncertainty and the distance to the next waypoint to issue EvHeadingUncertaintyExceeded and EvHeadingUncertaintyRecovered messages, processed by the state machine to enter and leave the pause::ReacquireGPS state.

Note:
There may be an issue with the Trail state, since it doesn't have a goal per se.

I believe we're going to want to check for the `trail` message, and if it's there we can use the `range` field instead of the distance to next goal.  I can make these changes if it's confirmed that this makes sense.