### PR TITLE
task/add-back-initial-metadata-call-in-sim-banner

### DIFF
--- a/src/web/components/SimulationBanner/SimulationBanner.tsx
+++ b/src/web/components/SimulationBanner/SimulationBanner.tsx
@@ -25,6 +25,8 @@ export default function SimulationBanner() {
     };
 
     useEffect(() => {
+        // Start at time 0
+        fetchSimulationMode();
         const interval = setInterval(fetchSimulationMode, METADATA_POLL_TIME);
         return () => clearInterval(interval);
     }, []);


### PR DESCRIPTION
### Summary
I bricked it and removed a line of code that triggered the inital fetch of metadata. This pull request adds back that line.

### Testing
Simulation banner shows at start-up.