### PR TITLE
task/2.y/style-ol-map-control-buttons

### DIFF
--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -12,6 +12,7 @@ import { toLonLat } from "ol/proj";
 import { map } from "../../openlayers/maps/map";
 import { view } from "../../openlayers/views/view";
 import { gridLayer } from "../../openlayers/layers/vector/survey/grid-layer";
+import { styleControlButtons } from "../../openlayers/controls/controls";
 import { generateSurveyEndpoint } from "../../openlayers/features/survey/survey-endpoints";
 
 import { NodeTypes } from "../../types/jaia-system-types";
@@ -32,6 +33,7 @@ export default function Map() {
         map.on("click", (event: MapBrowserEvent<PointerEvent>) => {
             handleMapClick(event);
         });
+        styleControlButtons();
     }, []);
 
     /**

--- a/src/web/jcc/App.less
+++ b/src/web/jcc/App.less
@@ -8,6 +8,7 @@
 @import "../style/stylesheets/dialog.less";
 @import "../style/stylesheets/input.less";
 @import "../style/stylesheets/panel.less";
+@import "../style/stylesheets/openlayers.less";
 
 * {
     margin: 0;

--- a/src/web/openlayers/controls/controls.ts
+++ b/src/web/openlayers/controls/controls.ts
@@ -1,4 +1,5 @@
 import { Zoom, Rotate, ScaleLine, Attribution } from "ol/control";
+import { mdiMinus, mdiPlus, mdiRotate3dVariant } from "@mdi/js";
 
 export const controls = [
     new Zoom(),
@@ -8,3 +9,36 @@ export const controls = [
         collapsible: false,
     }),
 ];
+
+const zoomInSVG = `
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" role="img" aria-label="zoom-in">
+        <path d="${mdiPlus}"></path>
+    </svg>
+`;
+
+const zoomOutSVG = `
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" role="img" aria-label="zoom-out">
+        <path d="${mdiMinus}"></path>
+    </svg>
+`;
+
+const rotateSVG = `
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" role="img" aria-label="rotate-north">
+        <path d="${mdiRotate3dVariant}"></path>
+    </svg>
+`;
+
+export function styleControlButtons() {
+    const buttons = document.querySelectorAll(".ol-zoom-in, .ol-zoom-out, .ol-rotate-reset");
+    buttons.forEach((button) => {
+        button.classList.add("jaia-button", "ol-control-button");
+        button.removeChild(button.firstChild);
+        if (button.classList.contains("ol-zoom-in")) {
+            button.innerHTML = zoomInSVG;
+        } else if (button.classList.contains("ol-zoom-out")) {
+            button.innerHTML = zoomOutSVG;
+        } else if (button.classList.contains("ol-rotate-reset")) {
+            button.innerHTML = rotateSVG;
+        }
+    });
+}

--- a/src/web/openlayers/controls/controls.ts
+++ b/src/web/openlayers/controls/controls.ts
@@ -28,6 +28,11 @@ const rotateSVG = `
     </svg>
 `;
 
+/**
+ * Applies the jaia-button style to the map control buttons and attaches a MDI icon
+ *
+ * @returns {void}
+ */
 export function styleControlButtons() {
     const buttons = document.querySelectorAll(".ol-zoom-in, .ol-zoom-out, .ol-rotate-reset");
     buttons.forEach((button) => {

--- a/src/web/style/stylesheets/button.less
+++ b/src/web/style/stylesheets/button.less
@@ -10,6 +10,10 @@
     height: @jaia-button-height;
     width: @jaia-button-width;
 
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
     background-color: @jaia-button-background-color !important;
     border-radius: @jaia-button-border-radius !important;
     min-width: 48px !important;

--- a/src/web/style/stylesheets/openlayers.less
+++ b/src/web/style/stylesheets/openlayers.less
@@ -1,0 +1,18 @@
+.ol-zoom {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+
+    position: absolute;
+    right: 6px;
+}
+
+.ol-control-button {
+    border: none;
+}
+
+.ol-rotate-reset {
+    position: absolute;
+    bottom: 12px;
+    right: -9px;
+}

--- a/src/web/style/stylesheets/openlayers.less
+++ b/src/web/style/stylesheets/openlayers.less
@@ -1,7 +1,7 @@
 .ol-zoom {
     display: flex;
     flex-direction: column;
-    gap: 3px;
+    gap: 6px;
 
     position: absolute;
     right: 6px;
@@ -13,6 +13,6 @@
 
 .ol-rotate-reset {
     position: absolute;
-    bottom: 12px;
+    bottom: 19px;
     right: -9px;
 }


### PR DESCRIPTION
### Summary
This pull request aligns the style of the OpenLayers control buttons (zoom and rotate) with the style of the other buttons in the JCC.

### Testing
<img width="1025" height="768" alt="image" src="https://github.com/user-attachments/assets/f4782bbc-45c8-49b5-93b3-b9c83879bf6d" />
