### PR TITLE
bug/ntp-check-at-boot

### DIFF
--- a/config/templates/systemd/backup-date.service.in
+++ b/config/templates/systemd/backup-date.service.in
@@ -1,13 +1,13 @@
 [Unit]
 Description=Backup the date to a file when we have a valid date time ntp
+Before=jaiabot.service
 
 [Service]
-Type=notify
+Type=simple
 User=root
 Group=root
 ExecStart=$jaiabot_bin_dir/$exe $args
-NotifyAccess=all
-TimeoutSec=180
+TimeoutStopSec=15
 
 [Install]
 WantedBy=multi-user.target

--- a/config/templates/systemd/jaiabot.service.in
+++ b/config/templates/systemd/jaiabot.service.in
@@ -7,21 +7,29 @@ After=network-online.target
 Requires=var-log.mount
 After=var-log.mount
 
-Requires=jaia_firm_backup_date_sh.service
+# Start backup alongside us, but do not kill jaiabot if backup crashes
+Wants=jaia_firm_backup_date_sh.service
 After=jaia_firm_backup_date_sh.service
 
 [Service]
 User=$user
 Group=$group
 
-
 Type=oneshot
 RemainAfterExit=true
-
 
 EnvironmentFile=$env_file
 # make the log directory first so that we don't end up with it root only read/write
 ExecStartPre=/bin/bash -c "/bin/mkdir -p `$gen log_file`"
+
+# make sure the ready file has been created for accurate log time
+ExecStartPre=/bin/bash -c '\
+  echo "Waiting for /etc/jaiabot/timekeeper/READY..."; \
+  sleep 1; \
+  while [ ! -f /etc/jaiabot/timekeeper/READY ]; do \
+    sleep 5; \
+  done; \
+  echo "READY file detected. Continuing startup.";'
 
 ExecStart=/bin/echo "Starting Jaia"
 

--- a/scripts/jaia_firm_backup_date.sh
+++ b/scripts/jaia_firm_backup_date.sh
@@ -7,6 +7,7 @@ timekeeper_file="${timekeeper_dir}/time.txt"
 gps_time_set=0
 ntp_time_set=0
 setting_time_timeout=0
+systemd_notified=0
 
 # Create directory if missing
 if [ ! -d "${timekeeper_dir}" ]; then
@@ -18,101 +19,174 @@ start_time=$(date +%s)
 timeout_duration=120
 
 while true; do
-  # Check NTP status
-  ntp_status=$(timedatectl show --property=NTPSynchronized --value)
-  has_ntp_peer=$(ntpq -p 2>/dev/null | grep -q '^\*' && echo "yes" || echo "no")
+  # Check NTP status (stratum between 1 and 15)
+  ntp_peer_synced=$(ntpq -pn 2>/dev/null | awk '/^\*/ { s=$3+0; if (s>0 && s<16) { found=1; exit 0 } } END { exit !found }' && echo "yes" || echo "no")
 
-  if [[ $ntp_status == "yes" ]] || [[ $has_ntp_peer == "yes" ]]; then
+  if [[ $ntp_peer_synced == "yes" ]]; then
+    echo "NTP Peer Synchronized (stratum 1-15)"
+
     if [[ $ntp_time_set -eq 0 ]]; then
-      echo "NTP synchronized or has active peer"
       ntp_time_set=1
     fi
+
     # Save time from NTP
     date > "$timekeeper_file"
     echo "Saved NTP time to $timekeeper_file"
+
+    if [[ $systemd_notified -eq 0 ]]; then
+      echo "Send Systemd Notification Ready"
+      systemd-notify --ready
+      systemd_notified=1
+    fi
+    sleep 60
+    continue
   else
-    echo "NTP not syncronized, skipping ntp check."
-    # NTP not synced — try GPS if gpsd is active
-    if systemctl is-active --quiet gpsd; then
-      gps_time_iso=$(timeout 10 gpspipe -w -n 50 2>/dev/null | \
-        grep '"class":"TPV"' | grep '"mode":[23]' | \
-        sed -n 's/.*"time":"\([^"]*\)".*/\1/p' | tail -n1)
+    echo "NTP not synchronized, checking GPS..."
+  fi
 
-      if [[ -n "$gps_time_iso" ]]; then
-        gps_time_fmt=$(echo "$gps_time_iso" | sed 's/T/ /; s/Z/ UTC/')
-        echo "Got GPS time: $gps_time_fmt"
+  ## Check GPS Status (capture once, evaluate based on timeout)
+  gps_line=""
+  ept=""
+  iso=""
+  gps_time_fmt=""
+  has_good_mode=0
+  has_good_ept=0
+  
+  if systemctl is-active --quiet gpsd; then
+    echo "Attempting to get GPS time..."
+    gps_line=$(timeout 10 gpspipe -w -n 50 2>/dev/null | grep '"class":"TPV"' | tail -n1)
+    
+    if [[ -n "$gps_line" ]]; then
+      # Extract EPT and ISO time once
+      ept=$(echo "$gps_line" | sed -n 's/.*"ept":\([0-9.e+-]*\).*/\1/p')
+      iso=$(echo "$gps_line" | sed -n 's/.*"time":"\([^"]*\)".*/\1/p')
+      
+      # Convert ISO to formatted time once
+      if [[ -n "$iso" ]]; then
+        gps_time_fmt=$(echo "$iso" | sed 's/T/ /; s/Z/ UTC/')
+      fi
+      
+      # Check if we have good mode (2 or 3)
+      if echo "$gps_line" | grep -q '"mode":[23]'; then
+        has_good_mode=1
+      fi
+      
+      # Check EPT once (used by both normal and degraded mode)
+      if [[ -n "$ept" ]] && awk -v e="$ept" 'BEGIN{exit !(e <= 0.5)}'; then
+        has_good_ept=1
+      fi  
 
-        # Set the system clock from GPS only once, and only if NTP hasn’t already set it
+      # Normal mode: require mode 2/3 and EPT <= 0.5
+      if [[ $has_good_mode -eq 1 && $has_good_ept -eq 1 && -n "$gps_time_fmt" ]]; then
+        echo "Got good GPS time (mode 2/3, EPT=$ept): $gps_time_fmt"
+        
+        # Set system clock from GPS if not already set
         if [[ $gps_time_set -eq 0 && $ntp_time_set -eq 0 ]]; then
-          echo "Setting system clock from GPS once..."
+          echo "Setting system clock from GPS..."
           timedatectl set-time "$gps_time_fmt"
           gps_time_set=1
         fi
-
-        # Always write GPS time to backup file
-        echo "$gps_time_fmt" | tee "$timekeeper_file" >/dev/null
+        
+        # Save GPS time to backup file
+        echo "$gps_time_fmt" > "$timekeeper_file"
         echo "Saved GPS time to $timekeeper_file"
+        
+        if [[ $systemd_notified -eq 0 ]]; then
+          echo "Send Systemd Notification Ready"
+          systemd-notify --ready
+          systemd_notified=1
+        fi
+        sleep 60
+        continue
       else
-        echo "No valid GPS time yet."
+        if [[ $has_good_mode -eq 0 ]]; then
+          echo "GPS mode not 2 or 3"
+        fi
+        if [[ $has_good_ept -eq 0 ]]; then
+          echo "GPS EPT too high: $ept"
+        fi
       fi
     else
-      echo "Gpsd not active, skipping GPS time check."
+      echo "No GPS data received"
+    fi
+  else
+    echo "Gpsd not active, skipping GPS time check."
+  fi
+
+  ## Check timeout - enter degraded mode if needed
+  current_time=$(date +%s)
+  elapsed=$((current_time - start_time))
+
+  if [[ $elapsed -gt $timeout_duration && $setting_time_timeout -eq 0 ]]; then
+    echo "========================================="
+    echo "Reached ${timeout_duration}s timeout - entering degraded mode"
+    echo "========================================="
+    setting_time_timeout=1
+    
+    # Try degraded GPS mode using already-captured GPS data (any mode, just check EPT)
+    if [[ $has_good_ept -eq 1 && -n "$gps_time_fmt" ]]; then
+      echo "Got degraded GPS time (EPT=$ept): $gps_time_fmt"
+      
+      if [[ $gps_time_set -eq 0 && $ntp_time_set -eq 0 ]]; then
+        echo "Setting system clock from degraded GPS..."
+        timedatectl set-time "$gps_time_fmt"
+        gps_time_set=1
+      fi
+      
+      # Save to backup file
+      echo "$gps_time_fmt" > "$timekeeper_file"
+      echo "Saved degraded GPS time to $timekeeper_file"
+      
+      if [[ $systemd_notified -eq 0 ]]; then
+        echo "Send Systemd Notification Ready"
+        systemd-notify --ready
+        systemd_notified=1
+      fi
+      sleep 60
+      continue
+    else
+      if [[ $has_good_ept -eq 0 ]]; then
+        echo "Degraded GPS EPT still too high: $ept"
+      else
+        echo "No GPS data available for degraded mode"
+      fi
+    fi
+    
+    # Last resort: restore from backup file if it's ahead of current time
+    if [[ $gps_time_set -eq 0 && $ntp_time_set -eq 0 ]]; then
+      if [ -e "${timekeeper_file}" ]; then
+        read -r saved_time < "$timekeeper_file"
+        saved_epoch=$(date -d "$saved_time" +%s 2>/dev/null)
+        current_epoch=$(date +%s)
+        
+        if [[ $saved_epoch -gt 0 ]] && [[ $saved_epoch -gt $current_epoch ]]; then
+          echo "Current time ($current_epoch) is behind saved time ($saved_epoch)"
+          echo "Restoring time from file: $saved_time"
+          date -s "$saved_time"
+        else
+          echo "Current system time is already ahead of saved time - no restore needed"
+        fi
+      else
+        echo "No saved time file found - continuing with system time"
+      fi
+      
+      if [[ $systemd_notified -eq 0 ]]; then
+        echo "Send Systemd Notification Ready (degraded mode)"
+        systemd-notify --ready
+        systemd_notified=1
+      fi
+
+      sleep 60
+      continue
     fi
   fi
 
-  # Adjust sleep time: check faster until time is set by GPS or NTP
-  if [[ $gps_time_set -eq 0 && $ntp_time_set -eq 0 ]]; then
-    current_time=$(date +%s)
-    elapsed=$((current_time - start_time))
-
-    if [[ $elapsed -gt $timeout_duration && $setting_time_timeout -eq 0 ]]; then
-      echo "Timeout: Moving on..."
-
-      gps_time_iso=$(timeout 10 gpspipe -w -n 50 2>/dev/null | \
-        grep '"class":"TPV"' | grep '"ept":' | \
-        sed -n 's/.*"time":"\([^"]*\)".*/\1/p' | tail -n1)
-
-      if [[ -n "$gps_time_iso" ]]; then
-        gps_time_fmt=$(echo "$gps_time_iso" | sed 's/T/ /; s/Z/ UTC/')
-        echo "Got GPS time: $gps_time_fmt"
-
-        echo "Setting system clock from GPS once..."
-        timedatectl set-time "$gps_time_fmt"
-
-        # Always write GPS time to backup file
-        echo "$gps_time_fmt" | tee "$timekeeper_file" >/dev/null
-        echo "Saved GPS time to $timekeeper_file"
-
-        gps_time_set=1
-      else
-        # Only restore saved time if it would move the clock FORWARD
-        if [ -e "${timekeeper_file}" ]; then
-          read -r saved_time < "$timekeeper_file"
-          saved_epoch=$(date -d "$saved_time" +%s 2>/dev/null)
-          current_epoch=$(date +%s)
-          
-          # If saved time is in the future relative to current system time, use it
-          # This ensures we're at least as recent as the last known good time
-          if [[ $saved_epoch -gt 0 ]] && [[ $saved_epoch -gt $current_epoch ]]; then
-            echo "Current time ($current_epoch) is behind saved time ($saved_epoch)"
-            echo "Restoring time from file: $saved_time"
-            date -s "$saved_time"
-          else
-            echo "Current system time is already ahead of saved time - no restore needed"
-          fi
-        else
-          echo "No saved time file found."
-        fi
-      fi
-
-      systemd-notify --ready
-      setting_time_timeout=1
-    fi
-
+  # Adaptive sleep: check frequently until we have a good time, then slow down
+  if [[ $gps_time_set -eq 0 && $ntp_time_set -eq 0 && $setting_time_timeout -eq 0 ]]; then
+    # Still searching for a reliable time source - check frequently
     sleep 10
   else
-    echo "Time set: Moving on..."
-    systemd-notify --ready
+    # We have a time source (NTP, GPS, or fallback) - check less frequently
     sleep 60
   fi
 done

--- a/scripts/jaia_firm_backup_date.sh
+++ b/scripts/jaia_firm_backup_date.sh
@@ -2,18 +2,22 @@
 
 timekeeper_dir="/etc/jaiabot/timekeeper"
 timekeeper_file="${timekeeper_dir}/time.txt"
+ready_flag="${timekeeper_dir}/READY"
 
 # Flags to prevent redundant system clock sets
 gps_time_set=0
 ntp_time_set=0
 setting_time_timeout=0
-systemd_notified=0
+ready_flag_created=0
 
 # Create directory if missing
 if [ ! -d "${timekeeper_dir}" ]; then
   mkdir -p "${timekeeper_dir}"
   echo "Created ${timekeeper_dir}"
 fi
+
+# Remove ready flag at the start
+rm -f "$ready_flag"
 
 start_time=$(date +%s)
 timeout_duration=120
@@ -33,10 +37,10 @@ while true; do
     date > "$timekeeper_file"
     echo "Saved NTP time to $timekeeper_file"
 
-    if [[ $systemd_notified -eq 0 ]]; then
-      echo "Send Systemd Notification Ready"
-      systemd-notify --ready
-      systemd_notified=1
+    if [[ $ready_flag_created -eq 0 ]]; then
+      echo "Ready Flag Created"
+      touch "$ready_flag"
+      ready_flag_created=1
     fi
     sleep 60
     continue
@@ -91,10 +95,10 @@ while true; do
         echo "$gps_time_fmt" > "$timekeeper_file"
         echo "Saved GPS time to $timekeeper_file"
         
-        if [[ $systemd_notified -eq 0 ]]; then
-          echo "Send Systemd Notification Ready"
-          systemd-notify --ready
-          systemd_notified=1
+        if [[ $ready_flag_created -eq 0 ]]; then
+          echo "Ready Flag Created"
+          touch "$ready_flag"
+          ready_flag_created=1
         fi
         sleep 60
         continue
@@ -137,10 +141,10 @@ while true; do
       echo "$gps_time_fmt" > "$timekeeper_file"
       echo "Saved degraded GPS time to $timekeeper_file"
       
-      if [[ $systemd_notified -eq 0 ]]; then
-        echo "Send Systemd Notification Ready"
-        systemd-notify --ready
-        systemd_notified=1
+      if [[ $ready_flag_created -eq 0 ]]; then
+        echo "Ready Flag Created"
+        touch "$ready_flag"
+        ready_flag_created=1
       fi
       sleep 60
       continue
@@ -170,10 +174,10 @@ while true; do
         echo "No saved time file found - continuing with system time"
       fi
       
-      if [[ $systemd_notified -eq 0 ]]; then
-        echo "Send Systemd Notification Ready (degraded mode)"
-        systemd-notify --ready
-        systemd_notified=1
+      if [[ $ready_flag_created -eq 0 ]]; then
+        echo "Ready Flag Created (Degraded Mode)"
+        touch "$ready_flag"
+        ready_flag_created=1
       fi
 
       sleep 60


### PR DESCRIPTION
## Description

There was an error using timedatectl and checking for synchronization. On boot this value would be true even if the time was not sync'd. This caused log files to be created with the incorrect time. 

Now we check if we have a sync'd peer with a stratum between 1-15 (Values 1–15 are considered valid; Stratum 16 means “unsynchronized.”). 

We also now confirm gps time is equal to or below ept: 0.5 (Estimated Position (or Time) Error, within 0.5 seconds). 

We also change how we are notifying jaiabot.service when to start. We now use a ready file as a flag for when to start jaiabot.service. The jaia_firm_backup_date_sh.service starts before the jaiabot.service. On start we remove the ready file. The jaiabot.service loops indefinitely until that file is created. The jaia_firm_backup_date_sh.service has a 2 min timeout to use the best available time.

## Testing

Tested on fleet 1 bots 1 and hub 1