### PR TITLE
feature/downsampling-jdv-zoomed-in-jaia-2155

### DIFF
--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -7,10 +7,13 @@ export interface Plot {
     path: string;
 }
 
-export function Plot_get_hovertext(plot: Plot) {
-    if (!plot.hovertext) {
+export function Plot_get_hovertext(
+    y: number[],
+    hovertext_map: { [key: number]: string },
+): (string | number)[] {
+    if (!hovertext_map) {
         return null;
     }
 
-    return plot.series_y.map((y_value) => plot.hovertext[y_value] ?? y_value);
+    return y.map((y_value) => hovertext_map[y_value] ?? y_value);
 }

--- a/src/web/jdv/client/src/ui/App.tsx
+++ b/src/web/jdv/client/src/ui/App.tsx
@@ -47,7 +47,6 @@ interface State {
     tMin: number | null; // Minimum time for these logs
     tMax: number | null; // Maximum time for these logs
     visibleTimeRange: number[]; // Time range visible on plots and map
-    plotMode: string | null; // Mode for lines and/or markers (null means automatic depending on zoom level)
 
     // Modal busy indicator
     isBusy: boolean;
@@ -68,7 +67,6 @@ export class App extends React.Component {
             isSelectingLogs: false,
             chosenLogs: [],
             plots: [],
-            plotMode: null,
             layerSwitcherVisible: false,
             measureResultVisible: false,
             measureMagnitude: "",
@@ -129,7 +127,6 @@ export class App extends React.Component {
                         t={this.state.t}
                         delegate={this}
                         visibleTimeRange={this.state.visibleTimeRange}
-                        plotMode={this.state.plotMode}
                     />
 
                     <div id="mapPane" className="rounded clipped shadowed margin">
@@ -430,10 +427,6 @@ export class App extends React.Component {
 
     setPlots(plots: Plot[]) {
         this.setState({ plots });
-    }
-
-    setPlotMode(plotMode: string | null) {
-        this.setState({ plotMode });
     }
 
     setVisibleTimeRange(timeRange?: number[]) {

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -212,7 +212,7 @@ export function Plots(props: PlotsProps) {
 
         if (plots.length == 0) return;
 
-        const MAX_DATA_POINTS = 400;
+        const MAX_DATA_POINTS = 200;
 
         let update: any = {
             x: [],
@@ -222,91 +222,58 @@ export function Plots(props: PlotsProps) {
             customdata: [],
         };
 
-        const getIndexRange = (series: Plot, t_start: number, t_end: number, increment: number) => {
-            const start_index_raw = bisect(series._utime_, (t) => t_start - t)?.index ?? 0;
-            const end_index_raw =
-                bisect(series._utime_, (t) => t_end - t)?.index ?? series._utime_.length;
-            return [
-                start_index_raw - (start_index_raw % increment),
-                Math.min(
-                    end_index_raw - (end_index_raw % increment) + increment,
-                    series._utime_.length,
-                ),
-            ];
+        const getIndexRange = (series: Plot, t_start: number, t_end: number) => {
+            /**
+             * Find the indices of the data points that are within the given time range.
+             * Uses binary search to find the indices efficiently.
+             * Returns [start_index, end_index] where start_index is the index of the first point >= t_start
+             * and end_index is the index of the first point > t_end.
+             * If no points are found, returns [0, 0] or [length, length] as appropriate.
+             */
+            const start_bisection = bisect(series._utime_, (t) => t_start - t);
+            const end_bisection = bisect(series._utime_, (t) => t_end - t);
+
+            const start_index = start_bisection?.index ?? 0;
+            const end_index_raw = (end_bisection?.index ?? series._utime_.length) + 2;
+            const end_index = Math.min(end_index_raw, series._utime_.length);
+
+            return [start_index, end_index];
         };
 
         for (let [plot_index, series] of plots.entries()) {
-            update.x.push(series._utime_.map((t_micros) => microsToDate(t_micros)));
-            update.y.push(series.series_y);
+            // If we are zoomed in enough, use lines+markers to show that we have full resolution
+            const utime = series._utime_;
+            const num_points = utime.length;
+            const min_utime = utime[0];
+            const max_utime = utime[num_points - 1];
+            const series_duration = max_utime - min_utime;
+            const visible_duration = Math.min(
+                visibleTimeRange[1] - visibleTimeRange[0],
+                series_duration,
+            );
 
-            update.hovertext.push(Plot_get_hovertext(series));
-            update.customdata.push(series._utime_);
+            const visible_index_range = getIndexRange(
+                series,
+                visibleTimeRange[0],
+                visibleTimeRange[1],
+            );
+            let update_utime = series._utime_;
+            let update_y = series.series_y;
+            let update_mode = "lines";
 
-            const auto_mode = "lines";
-            update.mode.push(auto_mode);
+            if (visible_index_range[1] - visible_index_range[0] < MAX_DATA_POINTS) {
+                // Use only the points in the visible range, because Plotly can't handle too many points efficiently if markers are enabled
+                update_utime = series._utime_.slice(visible_index_range[0], visible_index_range[1]);
+                update_y = series.series_y.slice(visible_index_range[0], visible_index_range[1]);
+                update_mode = "lines+markers";
+            }
 
-            // // Plotly optimization:  only use the data within the plot time range, and only use a maximum number of data points.
-            // // This greatly improves GUI responsiveness.
-            // const utime = series._utime_;
-            // const num_points = utime.length;
-            // const min_utime = utime[0];
-            // const max_utime = utime[num_points - 1];
-            // const series_duration = max_utime - min_utime;
-            // const visible_duration = Math.min(
-            //     visibleTimeRange[1] - visibleTimeRange[0],
-            //     series_duration,
-            // );
-
-            // const num_visible_points_estimate = Math.ceil(
-            //     (num_points * visible_duration) / series_duration,
-            // );
-
-            // const inside_index_step = Math.ceil(num_visible_points_estimate / MAX_DATA_POINTS);
-            // const [inside_index_min, inside_index_max] = getIndexRange(
-            //     series,
-            //     visibleTimeRange[0],
-            //     visibleTimeRange[1],
-            //     inside_index_step,
-            // );
-
-            // const outside_index_step = inside_index_step * 4;
-            // const outside_time_min = visibleTimeRange[0] - visible_duration;
-            // const outside_time_max = visibleTimeRange[1] + visible_duration;
-            // const [outside_index_min, outside_index_max] = getIndexRange(
-            //     series,
-            //     outside_time_min,
-            //     outside_time_max,
-            //     outside_index_step,
-            // );
-
-            // let x_values = [];
-            // let customdata = [];
-            // let y_values = [];
-
-            // let data_index = outside_index_min;
-
-            // while (data_index < outside_index_max) {
-            //     customdata.push(series._utime_[data_index]);
-            //     x_values.push(microsToDate(series._utime_[data_index]));
-            //     y_values.push(series.series_y[data_index]);
-
-            //     if (
-            //         data_index + inside_index_step > inside_index_min &&
-            //         data_index < inside_index_max
-            //     ) {
-            //         data_index += inside_index_step;
-            //     } else {
-            //         data_index += outside_index_step;
-            //     }
-            // }
-
-            // const auto_mode = inside_index_step > 1 ? "lines" : "lines+markers"; // Use lines and markers to indicate that we've got full resolution
-
-            // update.x.push(x_values);
-            // update.y.push(y_values);
-            // update.hovertext.push(Plot_get_hovertext(series));
-            // update.customdata.push(customdata);
-            // update.mode.push(plotMode == "auto" ? auto_mode : plotMode);
+            // Push the update data for this series
+            update.x.push(update_utime.map((t_micros) => microsToDate(t_micros)));
+            update.customdata.push(update_utime);
+            update.y.push(update_y);
+            update.hovertext.push(Plot_get_hovertext(update_y, series.hovertext));
+            update.mode.push(update_mode);
         }
         Plotly.restyle("plot", update);
     };

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -29,7 +29,6 @@ import "./Plots.css";
 
 export interface PlotsDelegate {
     setPlots: (plots: Plot[]) => void;
-    setPlotMode: (plotMode: string | null) => void;
     setPaths: (paths: string[]) => void;
     setTime: (t_micros: number | null) => void;
     setVisibleTimeRange: (timeRange: number[] | null) => void;
@@ -41,13 +40,11 @@ export interface PlotsProps {
     plots: Plot[];
     t: number;
     visibleTimeRange: number[];
-    plotMode: string | null;
 }
 
 export function Plots(props: PlotsProps) {
     const [isPathSelectorDisplayed, setIsPathSelectorDisplayed] = React.useState(false);
     const [isOpenPlotSetDisplayed, setIsOpenPlotSetDisplayed] = React.useState(false);
-    const [shouldUseAllData, setShouldUseAllData] = React.useState(true);
 
     function deletePlotClicked(plotIndex: number) {
         let { plots } = props;
@@ -158,8 +155,8 @@ export function Plots(props: PlotsProps) {
                 xaxis: "x",
                 yaxis: yaxis,
                 hovertext: [],
-                type: "scatter",
-                mode: "lines+markers",
+                type: "scattergl",
+                mode: "lines",
             };
 
             data.push(trace);
@@ -211,7 +208,7 @@ export function Plots(props: PlotsProps) {
     useEffect(createPlots, [props.chosenLogs, props.plots]);
 
     const refreshPlotData = () => {
-        const { plots, visibleTimeRange, plotMode } = props;
+        const { plots, visibleTimeRange } = props;
 
         if (plots.length == 0) return;
 
@@ -239,91 +236,82 @@ export function Plots(props: PlotsProps) {
         };
 
         for (let [plot_index, series] of plots.entries()) {
-            if (shouldUseAllData) {
-                update.x.push(series._utime_.map((t_micros) => microsToDate(t_micros)));
-                update.y.push(series.series_y);
+            update.x.push(series._utime_.map((t_micros) => microsToDate(t_micros)));
+            update.y.push(series.series_y);
 
-                update.hovertext.push(Plot_get_hovertext(series));
-                update.customdata.push(series._utime_);
-
-                const auto_mode = "lines+markers";
-                update.mode.push(plotMode == "auto" ? auto_mode : plotMode);
-                continue;
-            }
-
-            // Plotly optimization:  only use the data within the plot time range, and only use a maximum number of data points.
-            // This greatly improves GUI responsiveness.
-            const utime = series._utime_;
-            const num_points = utime.length;
-            const min_utime = utime[0];
-            const max_utime = utime[num_points - 1];
-            const series_duration = max_utime - min_utime;
-            const visible_duration = Math.min(
-                visibleTimeRange[1] - visibleTimeRange[0],
-                series_duration,
-            );
-
-            const num_visible_points_estimate = Math.ceil(
-                (num_points * visible_duration) / series_duration,
-            );
-
-            const inside_index_step = Math.ceil(num_visible_points_estimate / MAX_DATA_POINTS);
-            const [inside_index_min, inside_index_max] = getIndexRange(
-                series,
-                visibleTimeRange[0],
-                visibleTimeRange[1],
-                inside_index_step,
-            );
-
-            const outside_index_step = inside_index_step * 4;
-            const outside_time_min = visibleTimeRange[0] - visible_duration;
-            const outside_time_max = visibleTimeRange[1] + visible_duration;
-            const [outside_index_min, outside_index_max] = getIndexRange(
-                series,
-                outside_time_min,
-                outside_time_max,
-                outside_index_step,
-            );
-
-            let x_values = [];
-            let customdata = [];
-            let y_values = [];
-
-            let data_index = outside_index_min;
-
-            while (data_index < outside_index_max) {
-                customdata.push(series._utime_[data_index]);
-                x_values.push(microsToDate(series._utime_[data_index]));
-                y_values.push(series.series_y[data_index]);
-
-                if (
-                    data_index + inside_index_step > inside_index_min &&
-                    data_index < inside_index_max
-                ) {
-                    data_index += inside_index_step;
-                } else {
-                    data_index += outside_index_step;
-                }
-            }
-
-            const auto_mode = inside_index_step > 1 ? "lines" : "lines+markers"; // Use lines and markers to indicate that we've got full resolution
-
-            update.x.push(x_values);
-            update.y.push(y_values);
             update.hovertext.push(Plot_get_hovertext(series));
-            update.customdata.push(customdata);
-            update.mode.push(plotMode == "auto" ? auto_mode : plotMode);
+            update.customdata.push(series._utime_);
+
+            const auto_mode = "lines";
+            update.mode.push(auto_mode);
+
+            // // Plotly optimization:  only use the data within the plot time range, and only use a maximum number of data points.
+            // // This greatly improves GUI responsiveness.
+            // const utime = series._utime_;
+            // const num_points = utime.length;
+            // const min_utime = utime[0];
+            // const max_utime = utime[num_points - 1];
+            // const series_duration = max_utime - min_utime;
+            // const visible_duration = Math.min(
+            //     visibleTimeRange[1] - visibleTimeRange[0],
+            //     series_duration,
+            // );
+
+            // const num_visible_points_estimate = Math.ceil(
+            //     (num_points * visible_duration) / series_duration,
+            // );
+
+            // const inside_index_step = Math.ceil(num_visible_points_estimate / MAX_DATA_POINTS);
+            // const [inside_index_min, inside_index_max] = getIndexRange(
+            //     series,
+            //     visibleTimeRange[0],
+            //     visibleTimeRange[1],
+            //     inside_index_step,
+            // );
+
+            // const outside_index_step = inside_index_step * 4;
+            // const outside_time_min = visibleTimeRange[0] - visible_duration;
+            // const outside_time_max = visibleTimeRange[1] + visible_duration;
+            // const [outside_index_min, outside_index_max] = getIndexRange(
+            //     series,
+            //     outside_time_min,
+            //     outside_time_max,
+            //     outside_index_step,
+            // );
+
+            // let x_values = [];
+            // let customdata = [];
+            // let y_values = [];
+
+            // let data_index = outside_index_min;
+
+            // while (data_index < outside_index_max) {
+            //     customdata.push(series._utime_[data_index]);
+            //     x_values.push(microsToDate(series._utime_[data_index]));
+            //     y_values.push(series.series_y[data_index]);
+
+            //     if (
+            //         data_index + inside_index_step > inside_index_min &&
+            //         data_index < inside_index_max
+            //     ) {
+            //         data_index += inside_index_step;
+            //     } else {
+            //         data_index += outside_index_step;
+            //     }
+            // }
+
+            // const auto_mode = inside_index_step > 1 ? "lines" : "lines+markers"; // Use lines and markers to indicate that we've got full resolution
+
+            // update.x.push(x_values);
+            // update.y.push(y_values);
+            // update.hovertext.push(Plot_get_hovertext(series));
+            // update.customdata.push(customdata);
+            // update.mode.push(plotMode == "auto" ? auto_mode : plotMode);
         }
         Plotly.restyle("plot", update);
     };
 
-    useEffect(refreshPlotData, [
-        props.chosenLogs,
-        props.plots,
-        props.visibleTimeRange,
-        props.plotMode,
-        shouldUseAllData,
-    ]);
+    useEffect(refreshPlotData, [props.chosenLogs, props.plots, props.visibleTimeRange]);
 
     var actionBar: JSX.Element | null;
 
@@ -371,28 +359,6 @@ export function Plots(props: PlotsProps) {
                 >
                     <Icon path={mdiTrashCan} size={1} style={{ verticalAlign: "middle" }}></Icon>
                 </button>
-                <div>
-                    <label>Chart Style:</label>
-                    <select
-                        name="mode"
-                        id="modeSelect"
-                        onChange={(e) => {
-                            props.delegate.setPlotMode(e.target.value);
-                        }}
-                    >
-                        <option value="lines">Lines</option>
-                        <option value="markers">Markers</option>
-                        <option value="lines+markers">Lines & Markers</option>
-                        <option value="auto">Auto</option>
-                    </select>
-                </div>
-                <div>
-                    <label>Downsample Data:</label>
-                    <Switch
-                        checked={!shouldUseAllData}
-                        onChange={(_, checked) => setShouldUseAllData(!checked)}
-                    />
-                </div>
             </div>
         );
     } else {


### PR DESCRIPTION
JDV now uses scattergl.  Also, when zoomed out:

* Use all of the points and only "lines" mode.  Plotly and scattergl can handle this because it does its own downsampling for "lines" plots.

When zoomed in:

* Use only the subset of points that are visible, and enable "lines+markers" mode.  Plotly can handle this smaller number of markers.
