### PR TITLE
task/2.y/default-lanes-to-num-of-bots

### DIFF
--- a/src/web/components/SurveyPlanner/SurveyPlanner.tsx
+++ b/src/web/components/SurveyPlanner/SurveyPlanner.tsx
@@ -11,9 +11,11 @@ import TaskParameters from "../WaypointPanel/TaskParameters/TaskParameters";
 
 import { gridLayer } from "../../openlayers/layers/vector/survey/grid-layer";
 import Task from "../../data/tasks/task";
+import { bots } from "../../data/bots/bots";
 import { gridPlan, GridPlanDetails, GridPlanningStates } from "../../data/survey_planner/grid-plan";
 import { formatNumericalInput, snakeCaseToTitleCase } from "../../utils/input";
 import { selectTheme } from "../../utils/style";
+import { DEFAULT_LANES, INIT_LANES } from "../../utils/constants";
 import { TaskType } from "../../types/protobuf-types";
 
 import "./SurveyPlanner.less";
@@ -171,7 +173,29 @@ function RequestEndMissionLocation() {
  * Renders the third panel in the series of building a grid-survey mission set
  */
 function GridConfigs(props: Props) {
-    const [numOfLanes, setNumOfLanes] = useState(props.gridPlanDetails.numOfLanes);
+    /**
+     * Determines the number of lanes to show on first render.
+     * The last user input will be used unless no input has been provided yet.
+     * In that case, we use the number of Bots or DEFAULT_LANES if no Bots connected.
+     *
+     * @returns {number} Number of lanes to show on first render
+     */
+    const initNumOfLanes = () => {
+        const numOfBots = bots.getBots().size;
+        if (gridPlan.getNumOfLanes() === INIT_LANES && bots.getBots().size > 0) {
+            gridPlan.setNumOfLanes(numOfBots);
+            return numOfBots;
+        }
+
+        if (gridPlan.getNumOfLanes() === INIT_LANES) {
+            gridPlan.setNumOfLanes(DEFAULT_LANES);
+            return DEFAULT_LANES;
+        }
+
+        return gridPlan.getNumOfLanes();
+    };
+
+    const [numOfLanes, setNumOfLanes] = useState(initNumOfLanes());
     const [pointSpacing, setPointSpacing] = useState(props.gridPlanDetails.pointSpacing);
     const [laneSpacing, setLaneSpacing] = useState(props.gridPlanDetails.laneSpacing);
 

--- a/src/web/data/survey_planner/grid-plan.ts
+++ b/src/web/data/survey_planner/grid-plan.ts
@@ -1,5 +1,6 @@
 import Task from "../tasks/task";
 import Mission from "../mission_set/mission";
+import { INIT_LANES } from "../../utils/constants";
 import { GeographicCoordinate } from "../../types/protobuf-types";
 
 export enum GridPlanningStates {
@@ -34,7 +35,7 @@ export class GridPlan {
 
     constructor() {
         this.state = GridPlanningStates.ACCEPTING_MISSION_START_LOCATION;
-        this.numOfLanes = 5;
+        this.numOfLanes = INIT_LANES;
         this.laneSpacing = 10;
         this.pointSpacing = 10;
         this.surveyTask = new Task();

--- a/src/web/utils/constants.ts
+++ b/src/web/utils/constants.ts
@@ -1,5 +1,7 @@
 export const UNASSIGNED_ID = -1;
 export const NO_CONSTRAINT = -1;
+export const INIT_LANES = -1;
+export const DEFAULT_LANES = 5;
 export const DEFAULT_HUB_ID = 1;
 export const DETAILS_DECIMALS = 2;
 export const LAT_LON_DECIMALS = 5;


### PR DESCRIPTION
### Summary
Adds the function `initNumOfLanes` in `SurveyPlanner.tsx` to set the number of lanes to the last user setting, the number of Bots connected or DEFAULT.

### Testing
* Connected 3 Bots in simulation and watched the number of lanes be set correctly as I updated the value and opened/closed the panel