### PR TITLE
task/change-jdv-plots-to-scattergl

### DIFF
--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -158,7 +158,7 @@ export function Plots(props: PlotsProps) {
                 xaxis: "x",
                 yaxis: yaxis,
                 hovertext: [],
-                type: "scatter",
+                type: "scattergl",
                 mode: "lines+markers",
             };
 


### PR DESCRIPTION
Change scatter to scattergl because it handles displaying larger datasets more efficiently. 