### PR TITLE
bug/2.y/constant-heading-time-integer

### DIFF
--- a/src/web/utils/conversions.ts
+++ b/src/web/utils/conversions.ts
@@ -91,6 +91,6 @@ export function locationToConstantHeadingParams(
     // Convert km to m
     const distance = turf.distance(startCoord, endCoord, options) * 1000;
     params.constant_heading = (bearing + 360) % 360;
-    params.constant_heading_time = Math.floor(distance / params.constant_heading_speed);
+    params.constant_heading_time = Math.round(distance / params.constant_heading_speed);
     return params;
 }

--- a/src/web/utils/conversions.ts
+++ b/src/web/utils/conversions.ts
@@ -91,6 +91,6 @@ export function locationToConstantHeadingParams(
     // Convert km to m
     const distance = turf.distance(startCoord, endCoord, options) * 1000;
     params.constant_heading = (bearing + 360) % 360;
-    params.constant_heading_time = distance / params.constant_heading_speed;
+    params.constant_heading_time = Math.floor(distance / params.constant_heading_speed);
     return params;
 }


### PR DESCRIPTION
### Bug
```
Failed to parse goal field: Failed to parse task field: Failed to parse constant_heading field: Failed to parse constant_heading_time field: Couldn't parse integer: 60.716233545010056 at Command.plan.goal[12].task.constant_heading.constant_heading_time....
```

### Solution
Use `Math.round` to convert float to int