### PR TITLE
task/add-configurable-data-rate-for-imu-jaia-2102

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
+        - "task/add-configurable-data-rate-for-imu-jaia-2102"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
-        - "task/add-configurable-data-rate-for-imu-jaia-2102"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/config/templates/bot/jaiabot_adafruit_BNO055_driver.pb.cfg.in
+++ b/config/templates/bot/jaiabot_adafruit_BNO055_driver.pb.cfg.in
@@ -8,3 +8,4 @@ udp_config {
 }
 
 adafruit_bno055_report_in_simulation: $adafruit_bno055_report_in_simulation
+sample_rate: 10

--- a/config/templates/bot/jaiabot_adafruit_BNO085_driver.pb.cfg.in
+++ b/config/templates/bot/jaiabot_adafruit_BNO085_driver.pb.cfg.in
@@ -8,3 +8,4 @@ udp_config {
 }
 
 adafruit_bno085_report_in_simulation: $adafruit_bno085_report_in_simulation
+sample_rate: 10

--- a/src/bin/drivers/adafruit_BNO055/app.cpp
+++ b/src/bin/drivers/adafruit_BNO055/app.cpp
@@ -145,7 +145,7 @@ void jaiabot::apps::AdaFruitBNO055Publisher::loop()
     // Send a command to start the data stream
     auto command = jaiabot::protobuf::IMUCommand();
     command.set_type(jaiabot::protobuf::IMUCommand::CONFIGURE);
-    command.set_sample_rate(10.0);
+    command.set_sample_rate(cfg().sample_rate());
     send_command(command);
 }
 

--- a/src/bin/drivers/adafruit_BNO055/app.cpp
+++ b/src/bin/drivers/adafruit_BNO055/app.cpp
@@ -60,6 +60,7 @@ class AdaFruitBNO055Publisher : public zeromq::MultiThreadApplication<config::Ad
 
   private:
     void loop() override;
+    void send_command(const jaiabot::protobuf::IMUCommand& command);
     void health(goby::middleware::protobuf::ThreadHealth& health) override;
     void check_last_report(goby::middleware::protobuf::ThreadHealth& health,
                            goby::middleware::protobuf::HealthState& health_state);
@@ -86,7 +87,7 @@ int main(int argc, char* argv[])
 double loop_freq = 10;
 
 jaiabot::apps::AdaFruitBNO055Publisher::AdaFruitBNO055Publisher()
-    : zeromq::MultiThreadApplication<config::AdaFruitBNO055Publisher>(loop_freq * si::hertz)
+    : zeromq::MultiThreadApplication<config::AdaFruitBNO055Publisher>(1 * si::hertz)
 {
     glog.add_group("main", goby::util::Colors::yellow);
 
@@ -122,27 +123,30 @@ jaiabot::apps::AdaFruitBNO055Publisher::AdaFruitBNO055Publisher()
         }
     });
 
-    interprocess().subscribe<jaiabot::groups::imu>([this](const protobuf::IMUCommand& imu_command) {
-        auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
-        io_data->set_data(imu_command.SerializeAsString());
-        interthread().publish<imu_udp_out>(io_data);
-
-        glog.is_debug1() && glog << "Sending IMUCommand: " << imu_command.ShortDebugString()
-                                 << endl;
+    interprocess().subscribe<jaiabot::groups::imu>([this](const protobuf::IMUCommand& imu_command)
+    {
+        send_command(imu_command);
     });
+
 }
+
+
+void jaiabot::apps::AdaFruitBNO055Publisher::send_command(const jaiabot::protobuf::IMUCommand& command)
+{
+    auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
+    io_data->set_data(command.SerializeAsString());
+    interthread().publish<imu_udp_out>(io_data);
+    glog.is_debug2() && glog << "Sending command: " << command.ShortDebugString() << endl;
+}
+
 
 void jaiabot::apps::AdaFruitBNO055Publisher::loop()
 {
-    // Just send an empty packet
-    auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
+    // Send a command to start the data stream
     auto command = jaiabot::protobuf::IMUCommand();
-    command.set_type(jaiabot::protobuf::IMUCommand::TAKE_READING);
-
-    io_data->set_data(command.SerializeAsString());
-    interthread().publish<imu_udp_out>(io_data);
-
-    glog.is_debug2() && glog << "Requesting IMUData from python driver" << endl;
+    command.set_type(jaiabot::protobuf::IMUCommand::CONFIGURE);
+    command.set_sample_rate(10.0);
+    send_command(command);
 }
 
 void jaiabot::apps::AdaFruitBNO055Publisher::health(

--- a/src/bin/drivers/adafruit_BNO055/config.proto
+++ b/src/bin/drivers/adafruit_BNO055/config.proto
@@ -44,4 +44,5 @@ message AdaFruitBNO055Publisher
     optional bool adafruit_bno055_report_in_simulation = 11 [default = true];
     optional jaiabot.protobuf.IMUIssue.SolutionType imu_issue_solution = 12 [default = RESTART_IMU_PY];
     optional int32 imu_trigger_issue_timeout_seconds = 13 [default = 30];
+    optional double sample_rate = 14 [default = 10.0];
 }

--- a/src/bin/drivers/adafruit_BNO085/app.cpp
+++ b/src/bin/drivers/adafruit_BNO085/app.cpp
@@ -149,7 +149,7 @@ void jaiabot::apps::AdaFruitBNO085Publisher::loop()
     // Send a command to start the data stream
     auto command = jaiabot::protobuf::IMUCommand();
     command.set_type(jaiabot::protobuf::IMUCommand::CONFIGURE);
-    command.set_sample_rate(10.0);
+    command.set_sample_rate(cfg().sample_rate());
     send_command(command);
 }
 

--- a/src/bin/drivers/adafruit_BNO085/app.cpp
+++ b/src/bin/drivers/adafruit_BNO085/app.cpp
@@ -61,6 +61,7 @@ class AdaFruitBNO085Publisher
 
   private:
     void loop() override;
+    void send_command(const jaiabot::protobuf::IMUCommand& command);
     void health(goby::middleware::protobuf::ThreadHealth& health) override;
     void check_last_report(goby::middleware::protobuf::ThreadHealth& health,
                            goby::middleware::protobuf::HealthState& health_state);
@@ -84,10 +85,8 @@ int main(int argc, char* argv[])
 
 // Main thread
 
-double loop_freq = 10;
-
 jaiabot::apps::AdaFruitBNO085Publisher::AdaFruitBNO085Publisher()
-    : zeromq::MultiThreadApplication<config::AdaFruitBNO085Publisher>(loop_freq * si::hertz)
+    : zeromq::MultiThreadApplication<config::AdaFruitBNO085Publisher>(1 * si::hertz)
 {
     glog.add_group("main", goby::util::Colors::yellow);
 
@@ -132,26 +131,26 @@ jaiabot::apps::AdaFruitBNO085Publisher::AdaFruitBNO085Publisher()
     interprocess().subscribe<jaiabot::groups::imu>(
         [this](const protobuf::IMUCommand& imu_command)
         {
-            auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
-            io_data->set_data(imu_command.SerializeAsString());
-            interthread().publish<imu_udp_out>(io_data);
-
-            glog.is_debug1() && glog << "Sending IMUCommand: " << imu_command.ShortDebugString()
-                                     << endl;
+            send_command(imu_command);
         });
+
+}
+
+void jaiabot::apps::AdaFruitBNO085Publisher::send_command(const jaiabot::protobuf::IMUCommand& command)
+{
+    auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
+    io_data->set_data(command.SerializeAsString());
+    interthread().publish<imu_udp_out>(io_data);
+    glog.is_debug2() && glog << "Sending command: " << command.ShortDebugString() << endl;
 }
 
 void jaiabot::apps::AdaFruitBNO085Publisher::loop()
 {
-    // Just send an empty packet
-    auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
+    // Send a command to start the data stream
     auto command = jaiabot::protobuf::IMUCommand();
-    command.set_type(jaiabot::protobuf::IMUCommand::TAKE_READING);
-
-    io_data->set_data(command.SerializeAsString());
-    interthread().publish<imu_udp_out>(io_data);
-
-    glog.is_debug2() && glog << "Requesting IMUData from python driver" << endl;
+    command.set_type(jaiabot::protobuf::IMUCommand::CONFIGURE);
+    command.set_sample_rate(10.0);
+    send_command(command);
 }
 
 void jaiabot::apps::AdaFruitBNO085Publisher::health(

--- a/src/bin/drivers/adafruit_BNO085/config.proto
+++ b/src/bin/drivers/adafruit_BNO085/config.proto
@@ -44,4 +44,5 @@ message AdaFruitBNO085Publisher
     optional bool adafruit_bno085_report_in_simulation = 11 [default = true];
     optional jaiabot.protobuf.IMUIssue.SolutionType imu_issue_solution = 12 [default = REBOOT_BNO085_IMU];
     optional int32 imu_trigger_issue_timeout_seconds = 13 [default = 30];
+    optional double sample_rate = 14 [default = 10.0];
 }

--- a/src/lib/messages/imu.proto
+++ b/src/lib/messages/imu.proto
@@ -9,7 +9,7 @@ message IMUCommand
 {
     enum IMUCommandType
     {
-        TAKE_READING = 0;
+        CONFIGURE = 0;
         START_WAVE_HEIGHT_SAMPLING = 1;
         STOP_WAVE_HEIGHT_SAMPLING = 2;
         START_BOTTOM_TYPE_SAMPLING = 3;
@@ -18,6 +18,15 @@ message IMUCommand
     }
 
     required IMUCommandType type = 1;
+
+    /// Sample rate for data collection in Hz
+    optional double sample_rate = 2
+        [(dccl.field) = {units {
+            derived_dimensions: "frequency"
+            system: "si"
+            }, min: 0.1 max: 60 precision: 1},
+            default = 10
+        ];
 }
 
 enum IMUCalibrationState

--- a/src/python/adafruit/jaiabot_imu.py
+++ b/src/python/adafruit/jaiabot_imu.py
@@ -18,7 +18,7 @@ parser.add_argument('-t', dest='device_type', choices=['sim', 'bno055', 'bno085'
 parser.add_argument('-p', dest='port', type=int, default=20000, help='Port to publish orientation data')
 parser.add_argument('-l', dest='logging_level', default='WARNING', type=str, help='Logging level (CRITICAL, ERROR, WARNING (default), INFO, DEBUG)')
 parser.add_argument('-i', dest='interactive', action='store_true', help='Menu-based interactive IMU tester')
-
+parser.add_argument('-r', '--data_rate', metavar="data_rate", choices=[10, 20, 25, 50, 75, 100], default=10, type=int, help='Data Rate, default is 10 Hz')
 parser.add_argument('-wh', dest='wave_height', default=1, type=float, help='Simulated wave height (meters)')
 parser.add_argument('-wp', dest='wave_period', default=5, type=float, help='Simulated wave period (seconds)')
 
@@ -47,13 +47,14 @@ def do_port_loop(imu: IMU, wave_analyzer: AccelerationAnalyzer):
     sock.bind(('', port))
 
     sample_rate_hz = 10.0
-    sample_period = 1 / sample_rate_hz
+    if args.data_rate != 10.0:
+        sample_rate_hz = args.data_rate
+    sample_period = 1.0 / sample_rate_hz
+    next_send_time = time.perf_counter() 
 
     client_address = None
 
-    while True:
-        sleep(sample_period)
-        
+    while True:        
         # Take a reading and publish it
         if client_address is not None:
             port_log.debug(f'client_address: {client_address}')
@@ -84,6 +85,7 @@ def do_port_loop(imu: IMU, wave_analyzer: AccelerationAnalyzer):
             data, client_address = sock.recvfrom(1024) # buffer size is 1024 bytes
             port_log.debug(f'Received command from {client_address}:\n{data}')
         except BlockingIOError:
+            port_log.debug('No command received')
             continue
 
         try:
@@ -110,6 +112,11 @@ def do_port_loop(imu: IMU, wave_analyzer: AccelerationAnalyzer):
 
         except Exception as e:
             traceback.print_exc()
+
+        next_send_time += sample_period
+        sleep_time = max(0, next_send_time - time.perf_counter())
+        time.sleep(sleep_time)
+
 
 
 def do_interactive_loop():

--- a/src/python/adafruit/jaiabot_imu.py
+++ b/src/python/adafruit/jaiabot_imu.py
@@ -86,7 +86,7 @@ def do_port_loop(imu: IMU, wave_analyzer: AccelerationAnalyzer):
             port_log.debug(f'Received command from {client_address}:\n{data}')
         except BlockingIOError:
             port_log.debug('No command received')
-            continue
+            pass
 
         try:
             # Deserialize the message

--- a/src/python/adafruit/jaiabot_imu.py
+++ b/src/python/adafruit/jaiabot_imu.py
@@ -43,11 +43,48 @@ def do_port_loop(imu: IMU, wave_analyzer: AccelerationAnalyzer):
     port_log.info(f'Socket mode: listening on port {port}.')
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setblocking(False)
     sock.bind(('', port))
 
-    while True:
+    sample_rate_hz = 10.0
+    sample_period = 1 / sample_rate_hz
 
-        data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
+    client_address = None
+
+    while True:
+        sleep(sample_period)
+        
+        # Take a reading and publish it
+        if client_address is not None:
+            port_log.debug(f'client_address: {client_address}')
+            port_log.debug(f'taking reading')
+            reading = imu.takeReading()
+            port_log.debug(f'IMU reading taken:\n{reading}')
+
+            if reading is None:
+                port_log.warning('takeReading() returned None')
+            else:
+                imuData = reading.convertToIMUData()
+                wave_analyzer.addIMUData(imuData)
+
+                if wave_analyzer._sampling_for_wave_height:
+                    imuData.significant_wave_height = wave_analyzer.getSignificantWaveHeight()
+
+                if wave_analyzer._sampling_for_bottom_characterization:
+                    imuData.max_acceleration = wave_analyzer.getMaximumAcceleration()
+
+                imuData.imu_type = args.device_type
+
+                #log.warning(imuData)
+                port_log.debug(f'Sending IMU data:\n{imuData}')
+                port_log.debug(f'Sending IMU data to {client_address}')
+                sock.sendto(imuData.SerializeToString(), client_address)
+
+        try:
+            data, client_address = sock.recvfrom(1024) # buffer size is 1024 bytes
+            port_log.debug(f'Received command from {client_address}:\n{data}')
+        except BlockingIOError:
+            continue
 
         try:
             # Deserialize the message
@@ -56,29 +93,10 @@ def do_port_loop(imu: IMU, wave_analyzer: AccelerationAnalyzer):
             port_log.debug(f'Received command:\n{command}')
 
             # Execute the command
-            if command.type == IMUCommand.TAKE_READING:
-                port_log.debug(f'Taking IMU reading')
-                reading = imu.takeReading()
-                port_log.debug(f'IMU reading taken:\n{reading}')
-
-                if reading is None:
-                    port_log.warning('takeReading() returned None')
-                else:
-                    imuData = reading.convertToIMUData()
-                    wave_analyzer.addIMUData(imuData)
-
-                    if wave_analyzer._sampling_for_wave_height:
-                        imuData.significant_wave_height = wave_analyzer.getSignificantWaveHeight()
-
-                    if wave_analyzer._sampling_for_bottom_characterization:
-                        imuData.max_acceleration = wave_analyzer.getMaximumAcceleration()
-
-                    imuData.imu_type = args.device_type
-
-                    #log.warning(imuData)
-                    port_log.debug(f'Sending IMU data:\n{imuData}')
-                    sock.sendto(imuData.SerializeToString(), addr)
-
+            if command.type == IMUCommand.CONFIGURE:
+                sample_rate_hz = command.sample_rate
+                sample_period = 1 / sample_rate_hz
+                port_log.info(f'Configured sample rate: {sample_rate_hz} Hz')
             elif command.type == IMUCommand.START_WAVE_HEIGHT_SAMPLING:
                 wave_analyzer.startSamplingForWaveHeight()
             elif command.type == IMUCommand.STOP_WAVE_HEIGHT_SAMPLING:
@@ -95,11 +113,20 @@ def do_port_loop(imu: IMU, wave_analyzer: AccelerationAnalyzer):
 
 
 def do_interactive_loop():
+    interactive_log = logging.getLogger('jaiabot_imu.interactive_loop')
+    interactive_log.info('Starting IMU interactive loop')
+
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.settimeout(5)
+    sock.setblocking(False)
     sock.bind(('', 0)) # Port zero picks an available port
 
     destinationAddress = ('localhost', args.port)
+
+    # Configure for 1 Hz sampling
+    command = IMUCommand()
+    command.type = IMUCommand.CONFIGURE
+    command.sample_rate = 1.0
+    sock.sendto(command.SerializeToString(), destinationAddress)
 
     while True:
         print('''
@@ -107,7 +134,7 @@ def do_interactive_loop():
     ====
               
     Raw commands:
-    [Enter]    Sample the IMU
+    [Enter]    Print a reading
     [w]        Start sampling for wave height
     [e]        Stop sampling for wave height
     [s]        Start sampling for bottom type
@@ -121,89 +148,95 @@ def do_interactive_loop():
         choice = input('Command >> ').lower()
         print()
 
-        if choice == 'x':
-            exit()
-        elif choice == 'h':
-            sample_duration = float(input('Sample for how long (seconds)?'))
-            sample_frequency = float(input('Sample at what frequency (Hz)?'))
-            sample_period = 1 / sample_frequency
+        match choice:
+            case '':
+                # Just take a reading
+                # Drain all but the last packet
+                last_packet = None
+                while True:
+                    try:
+                        data, addr = sock.recvfrom(65535)
+                        interactive_log.debug(f'Received datagram from {addr}')
+                        last_packet = (data, addr)
+                    except BlockingIOError:
+                        break
 
-            start_time = datetime.datetime.now()
-
-            # Start sampling for wave height
-            imuCommand = IMUCommand()
-            imuCommand.type = IMUCommand.START_WAVE_HEIGHT_SAMPLING
-            sock.sendto(imuCommand.SerializeToString(), destinationAddress)
-
-            while True:
-                current_time = datetime.datetime.now()
-                sample_time = (current_time - start_time).total_seconds()
-                if sample_time > sample_duration:
-                    break
-                
-                # Send command to take a reading
-                imuCommand = IMUCommand()
-                imuCommand.type = IMUCommand.TAKE_READING
-                sock.sendto(imuCommand.SerializeToString(), destinationAddress)
-
-                try:
-                    # Wait for reading to come back...
-                    data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
-
-                    # Deserialize the message
-                    imuData = IMUData()
-                    imuData.ParseFromString(data)
-                    print(f'Took a reading ({sample_time:6.1f}/{sample_duration:6.1f} seconds)', end='\r')
-                except Exception as e:
-                    traceback.print_exc()
-
-                sleep(sample_period)
-
-            # Start sampling for wave height
-            imuCommand = IMUCommand()
-            imuCommand.type = IMUCommand.STOP_WAVE_HEIGHT_SAMPLING
-            sock.sendto(imuCommand.SerializeToString(), destinationAddress)
-
-            print('Results:')
-            print(imuData)
-
-
-
-            continue
-
-
-        commandTypeMap = {
-            'w': IMUCommand.START_WAVE_HEIGHT_SAMPLING,
-            'e': IMUCommand.STOP_WAVE_HEIGHT_SAMPLING,
-            's': IMUCommand.START_BOTTOM_TYPE_SAMPLING,
-            'd': IMUCommand.STOP_BOTTOM_TYPE_SAMPLING,
-            '': IMUCommand.TAKE_READING
-        }
-
-        imuCommand = IMUCommand()
-
-        try:
-            imuCommand.type = commandTypeMap[choice]
-        except KeyError:
-            print(f'ERROR:  Unknown command "{choice}"\n')
-            continue
-
-        sock.sendto(imuCommand.SerializeToString(), destinationAddress)
-        print(f'  SENT:\n{text_format.MessageToString(imuCommand, as_one_line=True)}')
-        print()
-
-        if imuCommand.type == IMUCommand.TAKE_READING:
-            try:
-                # Wait for reading to come back...
-                data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
+                if last_packet is None:
+                    interactive_log.info('No data received')
+                    continue
 
                 # Deserialize the message
                 imuData = IMUData()
-                imuData.ParseFromString(data)
-                print(f'RECEIVED:\n{imuData}')
-                print()
-            except Exception as e:
-                traceback.print_exc()
+                imuData.ParseFromString(last_packet[0])
+                interactive_log.info(f'RECEIVED:\n{imuData}')
+            case 'h':
+                sample_duration = float(input('Sample for how long (seconds)?'))
+                sample_frequency = float(input('Sample at what frequency (Hz)?'))
+                sample_period = 1 / sample_frequency
+
+                start_time = datetime.datetime.now()
+
+                # Start sampling for wave height
+                imuCommand = IMUCommand()
+                imuCommand.type = IMUCommand.START_WAVE_HEIGHT_SAMPLING
+                sock.sendto(imuCommand.SerializeToString(), destinationAddress)
+
+                while True:
+                    current_time = datetime.datetime.now()
+                    sample_time = (current_time - start_time).total_seconds()
+                    if sample_time > sample_duration:
+                        break
+                    
+                    # Send command to take a reading
+                    imuCommand = IMUCommand()
+                    imuCommand.type = IMUCommand.TAKE_READING
+                    sock.sendto(imuCommand.SerializeToString(), destinationAddress)
+
+                    try:
+                        # Wait for reading to come back...
+                        data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
+
+                        # Deserialize the message
+                        imuData = IMUData()
+                        imuData.ParseFromString(data)
+                        print(f'Took a reading ({sample_time:6.1f}/{sample_duration:6.1f} seconds)', end='\r')
+                    except Exception as e:
+                        traceback.print_exc()
+
+                    sleep(sample_period)
+
+                # Start sampling for wave height
+                imuCommand = IMUCommand()
+                imuCommand.type = IMUCommand.STOP_WAVE_HEIGHT_SAMPLING
+                sock.sendto(imuCommand.SerializeToString(), destinationAddress)
+
+                print('Results:')
+                print(imuData)
+            case 'w':
+                imuCommand = IMUCommand()
+                imuCommand.type = IMUCommand.START_WAVE_HEIGHT_SAMPLING
+                sock.sendto(imuCommand.SerializeToString(), destinationAddress)
+                print('Started sampling for wave height')
+            case 'e':
+                imuCommand = IMUCommand()
+                imuCommand.type = IMUCommand.STOP_WAVE_HEIGHT_SAMPLING
+                sock.sendto(imuCommand.SerializeToString(), destinationAddress)
+                print('Stopped sampling for wave height')
+            case 's':
+                imuCommand = IMUCommand()
+                imuCommand.type = IMUCommand.START_BOTTOM_TYPE_SAMPLING
+                sock.sendto(imuCommand.SerializeToString(), destinationAddress)
+                print('Started sampling for bottom type')
+            case 'd':
+                imuCommand = IMUCommand()
+                imuCommand.type = IMUCommand.STOP_BOTTOM_TYPE_SAMPLING
+                sock.sendto(imuCommand.SerializeToString(), destinationAddress)
+                print('Stopped sampling for bottom type')
+            case 'x':
+                exit()
+            case _:
+                pass
+
 
 
 if __name__ == '__main__':

--- a/src/python/adafruit/remote_test.sh
+++ b/src/python/adafruit/remote_test.sh
@@ -2,6 +2,9 @@
 
 VENV_DIR=./venv
 
+# Make sure the services aren't running
+sudo systemctl stop jaiabot.service
+
 if [ ! -d "$VENV_DIR" ]; then
     echo "Creating virtual environment in $VENV_DIR"
     python3 -m venv $VENV_DIR
@@ -9,11 +12,9 @@ if [ ! -d "$VENV_DIR" ]; then
     $VENV_DIR/bin/pip3 install -r requirements.txt
 else
     echo "Using existing virtual environment in $VENV_DIR"
+    $VENV_DIR/bin/pip3 install -U ../pyjaiaprotobuf
 fi
 
 PYTHON=$VENV_DIR/bin/python3
 
-# Make sure the services aren't running
-sudo systemctl stop jaiabot.service
-
-$PYTHON jaiabot_imu.py -t bno085 -i -l DEBUG
+$PYTHON jaiabot_imu.py -t bno085 -i -l INFO

--- a/src/python/pressure_sensor/jaiabot_pressure_sensor.py
+++ b/src/python/pressure_sensor/jaiabot_pressure_sensor.py
@@ -122,8 +122,6 @@ target_interval = 1.0 / args.data_rate
 next_send_time = time.perf_counter()  
 
 while True:
-    loop_start = time.perf_counter()
-
     # Read data from sensor
     try:
         p_mbar, t_celsius = sensor.read()
@@ -149,9 +147,6 @@ while True:
         sock.sendto(pressure_temperature_data.SerializeToString(), addr)
     except Exception as e:
         log.error(f"Failed to send data: {e}")
-
-    # Measure loop duration
-    loop_duration = time.perf_counter() - loop_start
 
     # Adjust next send time dynamically
     next_send_time += target_interval


### PR DESCRIPTION
`jaiabot_imu.pu` now has a configurable sample rate.  The C++ driver sends a message to the python driver to configure this rate, (as well as start the flow of data).

Extra thoughts:
* Is it time to remove the BNO055 driver from the tree, since it doesn't get used and is just maintenance now?
* We could potentially reduce our number of used ports drastically:
    * We have a single "jaiabot_udp_gateway" app that listens on a designated port and takes a "UDPMessage"
    * The python sensor drivers contact this port on startup, and `jaiabot_udp_gateway` receives and publishes submessages
    * Example:

```
message UDPMessage {
    optional message IMUData
    optional message PressureData
    optional message SalinityData
    optional message SomeOtherMessageFromOutsideC++
}
```

* The `jaiabot_udp_gateway` app would then publish the messages onto the correct Goby group.