### PR TITLE
bug/jcc-not-being-enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
+        - "bug/jcc-not-being-enabled"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
-        - "bug/jcc-not-being-enabled"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -817,7 +817,7 @@ for app in jaiabot_apps:
         if app['template'] == 'jcc.conf.in':
             print('Enabling ' + service)
             subprocess.run('a2ensite ' + service, check=True, shell=True)
-            subprocess.run('systemctl reload apache2' + service, check=True, shell=True)
+            subprocess.run('systemctl reload apache2', check=True, shell=True)
             
 # check if the firmware is run on this type (bot/hub), at this time (runtime/simulation), and if the system has the capability
 def is_firm_run(firm):

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -814,6 +814,10 @@ for app in jaiabot_apps:
         if disable:
             print('Disabling ' + service)
             subprocess.run('systemctl disable ' + service, check=True, shell=True)
+        if app['template'] == 'jcc.conf.in':
+            print('Enabling ' + service)
+            subprocess.run('a2ensite ' + service, check=True, shell=True)
+            subprocess.run('systemctl reload apache2' + service, check=True, shell=True)
             
 # check if the firmware is run on this type (bot/hub), at this time (runtime/simulation), and if the system has the capability
 def is_firm_run(firm):

--- a/debian/jaiabot-web.postinst
+++ b/debian/jaiabot-web.postinst
@@ -3,10 +3,6 @@ set -e
 
 # disable default apache2 site if enabled
 a2dissite 000-default || true
-# enable JCC site in apache2
-if [ -f /etc/apache2/sites-available/jcc.conf ] && [ ! -f /etc/apache2/sites-enabled/jcc.conf ]; then
-    a2ensite jcc
-fi
 
 #DEBHELPER#
 


### PR DESCRIPTION
## Description

We were trying to field trial spicers new bots and when we went to the JCC for hub 2 we were brought to the switchboard instead of the JCC.

The reason for the regression is how the jcc.conf gets copied to the /etc/apache2/sites-available directory. This use to happen during the installation of jaiabot-web. Now it happens during the creation of the systemd configuration files. The thought behind the change was it was a systemd configuration since we use apache2. Previously a2ensite was run in the post install script for jaiabot-web, but since initially the jcc.conf is not in the /etc/apache2/sites-available directory it had no affect. The fix is to run the a2ensite after the creation of the jcc.conf file. 

I am also removing from the post install script since we are doing it during the creation of the configuration file.

## Testing

* No tests as of yet