### PR TITLE
task/2.y/make-full-screen-on-first-tap

### DIFF
--- a/src/web/jcc/App.less
+++ b/src/web/jcc/App.less
@@ -16,8 +16,10 @@
     box-sizing: border-box;
 }
 
+html,
 body {
     font-family: @global-font-family;
+    touch-action: pan-y;
 }
 
 #root {
@@ -28,6 +30,15 @@ body {
 #jcc {
     height: 100%;
     width: 100%;
+}
+
+// Turns off general touch actions
+// so they are processed as OpenLayer Events
+// which allows the operator to smoothly
+// pan and drag in full-screen mode
+#map,
+.ol-viewport {
+    touch-action: none;
 }
 
 #connection-warning {

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -30,8 +30,21 @@ import "./App.less";
  * The root of the JCC interface
  */
 export default function App() {
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+    /**
+     * Places the JCC in full-screen mode on mobile devices
+     *
+     * @returns {void}
+     */
+    const handleJCCClick = () => {
+        if (!document.fullscreenElement && isMobile) {
+            document.documentElement.requestFullscreen();
+        }
+    };
+
     return (
-        <div id="jcc">
+        <div id="jcc" onClick={() => handleJCCClick()}>
             <JaiaContextProvider>
                 <Map />
                 <NodeList />

--- a/src/web/jcc/public/index.html
+++ b/src/web/jcc/public/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no" />
-        <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="mobile-web-app-capable" content="yes" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+        />
         <link rel="manifest" href="/manifest.json" />
         <link rel="shortcut icon" href="/favicon.png" />
 


### PR DESCRIPTION
### Summary
This pull request makes the JCC switch to full-screen mode on mobile devices when the first tap occurs. It also solves the bug where dragging and panning in full-screen mode became less responsive by making sure interactions are handled by OpenLayers not the browser.

### Testing
Panned, zoomed, and dragged on the new and old tablets used by JaiaBot operators in full-screen mode.