### PR TITLE
bug/2.y/fix-task-packet-rounding-in-panel

### DIFF
--- a/src/web/components/RemoteControlPanel/DiveControls/DiveControls.tsx
+++ b/src/web/components/RemoteControlPanel/DiveControls/DiveControls.tsx
@@ -34,7 +34,7 @@ export function DiveInputs(props: DiveInputsProps) {
             <div>Max Depth</div>
             <input
                 name="max_depth"
-                type="number"
+                type="search"
                 value={formatNumericalInput(props.rcDiveParameters.max_depth)}
                 className="jaia-input"
                 autoComplete="off"
@@ -45,7 +45,7 @@ export function DiveInputs(props: DiveInputsProps) {
             <div>Depth Interval</div>
             <input
                 name="depth_interval"
-                type="number"
+                type="search"
                 value={formatNumericalInput(props.rcDiveParameters.depth_interval)}
                 className="jaia-input"
                 autoComplete="off"
@@ -56,7 +56,7 @@ export function DiveInputs(props: DiveInputsProps) {
             <div>Hold Time</div>
             <input
                 name="hold_time"
-                type="number"
+                type="search"
                 value={formatNumericalInput(props.rcDiveParameters.hold_time)}
                 className="jaia-input"
                 autoComplete="off"
@@ -67,7 +67,7 @@ export function DiveInputs(props: DiveInputsProps) {
             <div>Drift Time</div>
             <input
                 name="drift_time"
-                type="number"
+                type="search"
                 value={formatNumericalInput(props.rcDiveParameters.drift_time)}
                 className="jaia-input"
                 autoComplete="off"

--- a/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
+++ b/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
@@ -15,6 +15,8 @@ interface Props {
     taskPacketID?: string;
 }
 
+const DECIMALS = 2;
+
 /**
  * Displays task packet data to the operator in a tabular format
  */
@@ -95,10 +97,10 @@ export default function TaskPacketPanel(props: Props) {
                         <div>{taskPacket.bot_id}</div>
                         <div className="line-break"></div>
                         <div className="label">Depth Achieved:</div>
-                        <div>{taskPacket.dive.depth_achieved} m</div>
+                        <div>{taskPacket.dive.depth_achieved.toFixed(DECIMALS)} m</div>
                         <div className="line-break"></div>
                         <div className="label">Dive Rate:</div>
-                        <div>{taskPacket.dive.dive_rate} m/s</div>
+                        <div>{taskPacket.dive.dive_rate.toFixed(DECIMALS)} m/s</div>
                         <div className="line-break"></div>
                         <div className="label">Bottom Dive:</div>
                         <div>{taskPacket.dive.bottom_dive ? "Yes" : "No"}</div>
@@ -122,18 +124,18 @@ export default function TaskPacketPanel(props: Props) {
                         <div>{taskPacket.bot_id}</div>
                         <div className="line-break"></div>
                         <div className="label">Duration:</div>
-                        <div>{taskPacket.drift.drift_duration} s</div>
+                        <div>{taskPacket.drift.drift_duration.toFixed(DECIMALS)} s</div>
                         <div className="line-break"></div>
                         <div className="label">Speed:</div>
-                        <div>{taskPacket.drift.estimated_drift.speed} m/s</div>
+                        <div>{taskPacket.drift.estimated_drift.speed.toFixed(DECIMALS)} m/s</div>
                         <div className="line-break"></div>
                         <div className="label">Direction:</div>
-                        <div>{taskPacket.drift.estimated_drift.heading} deg</div>
+                        <div>{taskPacket.drift.estimated_drift.heading.toFixed(DECIMALS)} deg</div>
                         <div className="line-break"></div>
                         <div className="label">
                             Sig Wave Height<br></br>Beta:
                         </div>
-                        <div>{taskPacket.drift.significant_wave_height} m</div>
+                        <div>{taskPacket.drift.significant_wave_height.toFixed(DECIMALS)} m</div>
                         <div className="line-break"></div>
                         <div className="label">Start Time:</div>
                         <div>{startTime}</div>

--- a/src/web/context/handlers/survey-handlers.ts
+++ b/src/web/context/handlers/survey-handlers.ts
@@ -91,6 +91,7 @@ export function handleChangeGridPlanningState(mutableState: JaiaContextType, act
             missionSet.setMissions(cloneDeep(gridPlan.getMissions()));
             missionSet.setMissionIDInEditMode(UNASSIGNED_ID);
             missionSet.setNextMissionID(gridPlan.getMissions().size + 1);
+            missionsManager.clear();
             missionsManager.autoAssign();
 
             handleMapModeChange(MapModes.DEFAULT);


### PR DESCRIPTION
### Summary
This pull request makes some minor adjustments based on live testing.
1. Switch RC dive inputs to type "search" to prevent the Samsung bar from blocking the input boxes
2. Display task packet data to two decimal places
3. Clear Bot assignments prior to auto-assigning on survey finalization

### Testing
Reviewed these changes on tablet