### PR TITLE
bug/2.y/fix-default-hub-id-settings

### DIFF
--- a/src/web/components/BotDetails/BotDetails.tsx
+++ b/src/web/components/BotDetails/BotDetails.tsx
@@ -31,7 +31,6 @@ import {
     isBotLogging,
 } from "./bot-details";
 
-import { DEFAULT_HUB_ID } from "../../utils/constants";
 import { accordionTheme, addDropdownListener } from "../../utils/style";
 import {
     formatLatitude,
@@ -58,7 +57,7 @@ export default function BotDetails() {
         addDropdownListener("accordion-container", "bot-details-accordions-container");
     });
 
-    const hub = jaiaContext.hubs.getHub(DEFAULT_HUB_ID);
+    const hub = jaiaContext.hubs.getHubs().values().next()?.value;
 
     const botID = jaiaContext.jaiaGlobal.getSelectedNode().id;
     const bot = jaiaContext.bots.getBot(botID);
@@ -66,8 +65,8 @@ export default function BotDetails() {
     const missionID = missionsManager.getMissionID(botID);
     const mission = jaiaContext.missionSet.getMission(missionID);
 
-    if (!bot) {
-        return <div></div>;
+    if (!bot || !hub) {
+        return;
     }
 
     const missionStatus: MissionStatus = bot.getMissionStatus();

--- a/src/web/components/ButtonList/ButtonList.tsx
+++ b/src/web/components/ButtonList/ButtonList.tsx
@@ -25,7 +25,6 @@ import {
     mdiSquareEditOutline,
 } from "@mdi/js";
 
-import JaiaLogo from "../../jcc/public/favicon.png";
 import "./ButtonList.less";
 
 interface Props {
@@ -120,7 +119,7 @@ export default function ButtonList(props: Props) {
                         handleButtonClick(ButtonTypes.PANEL, ButtonNames.JAIA_ABOUT_PANEL)
                     }
                 >
-                    <img src={JaiaLogo} title="About" />
+                    <img src="/favicon.png" title="About" />
                 </Button>
             </div>
         );

--- a/src/web/components/DataOffloadPanel/DataOffloadQueue/DataOffloadQueue.tsx
+++ b/src/web/components/DataOffloadPanel/DataOffloadQueue/DataOffloadQueue.tsx
@@ -1,7 +1,6 @@
 import CircularProgress from "@mui/joy/CircularProgress";
 import { useContext } from "react";
 import { JaiaContext } from "../../../context/JaiaContext";
-import { DEFAULT_HUB_ID } from "../../../utils/constants";
 import "./DataOffloadQueue.less";
 
 interface Props {
@@ -18,7 +17,7 @@ export default function DataOffloadQueue() {
         return;
     }
 
-    const hub = jaiaContext.hubs.getHub(DEFAULT_HUB_ID);
+    const hub = jaiaContext.hubs.getHubs().values().next()?.value;
     if (!hub) {
         return;
     }
@@ -29,7 +28,7 @@ export default function DataOffloadQueue() {
      * @returns {QueueItem[]} QueueItem elements for Bots pending data offload
      */
     const renderBotsPending = () => {
-        const botsPending = hub.getBotOffload().bots_pending;
+        const botsPending: number[] = hub.getBotOffload().bots_pending;
         if (botsPending) {
             return botsPending.map((botID) => (
                 <QueueItem botID={botID} offloadPercentage={0} key={botID} />

--- a/src/web/components/HubDetails/HubDetails.tsx
+++ b/src/web/components/HubDetails/HubDetails.tsx
@@ -11,7 +11,6 @@ import {
     formatLatitude,
     formatLongitude,
 } from "../../shared/Utilities";
-import { DEFAULT_HUB_ID } from "../../utils/constants";
 import { accordionTheme, addDropdownListener } from "../../utils/style";
 import { getIPPrefix } from "../../shared/IPPrefix";
 import { HubAccordionNames } from "../../types/context-types";
@@ -40,10 +39,10 @@ export default function HubDetails() {
         addDropdownListener("accordion-container", "hub-details-accordions-container");
     }, []);
 
-    const hub = jaiaContext.hubs.getHub(DEFAULT_HUB_ID);
+    const hub = jaiaContext.hubs.getHubs().values().next()?.value;
 
     if (!hub) {
-        return <div></div>;
+        return;
     }
 
     /**

--- a/src/web/components/SettingsPanel/MoveHub/MoveHub.tsx
+++ b/src/web/components/SettingsPanel/MoveHub/MoveHub.tsx
@@ -5,7 +5,7 @@ import { JaiaActions } from "../../../context/jaia-actions";
 import JaiaToggle from "../../JaiaToggle/JaiaToggle";
 import { MapModes } from "../../../types/openlayers-types";
 import { CoordinateTypes } from "../../../types/jaia-system-types";
-import { DEFAULT_HUB_ID, LAT_LON_DECIMALS } from "../../../utils/constants";
+import { LAT_LON_DECIMALS } from "../../../utils/constants";
 import { validateCoordinate } from "../../../utils/input";
 
 import "./MoveHub.less";
@@ -25,7 +25,7 @@ export default function MoveHub() {
      * @returns {string} Latitude or longitude point (0 if not available)
      */
     const getHubLocation = (coordType: CoordinateTypes) => {
-        const hub = jaiaContext.hubs.getHub(DEFAULT_HUB_ID);
+        const hub = jaiaContext.hubs.getHubs().values().next()?.value;
 
         if (hub && hub.getLocation()) {
             if (coordType === CoordinateTypes.LAT) {

--- a/src/web/components/SettingsPanel/ScanForBot/ScanForBot.tsx
+++ b/src/web/components/SettingsPanel/ScanForBot/ScanForBot.tsx
@@ -1,7 +1,6 @@
 import { useContext, useState } from "react";
 import { FormControl, MenuItem, Select, SelectChangeEvent } from "@mui/material";
 import { JaiaContext } from "../../../context/JaiaContext";
-import { DEFAULT_HUB_ID } from "../../../utils/constants";
 import { sendHubCommand } from "../../../utils/commands";
 import { CommandForHub, HubCommandType } from "../../../types/protobuf-types";
 import { success } from "../../../utils/notifications";
@@ -31,7 +30,7 @@ export default function ScanForBot() {
      * @returns {void}
      */
     const sendScanForBot = async (botID: number) => {
-        const hub = jaiaContext.hubs.getHub(DEFAULT_HUB_ID);
+        const hub = jaiaContext.hubs.getHubs().values().next()?.value;
 
         if (!hub || botID === 0) {
             return;

--- a/src/web/context/handlers/simulation-handlers.ts
+++ b/src/web/context/handlers/simulation-handlers.ts
@@ -3,7 +3,6 @@ import { handleMapModeChange } from "../../openlayers/maps/map";
 import { JaiaAction, JaiaContextType } from "../../types/context-types";
 import { MapModes } from "../../types/openlayers-types";
 import { CommandForHub, HubCommandType } from "../../types/protobuf-types";
-import { DEFAULT_HUB_ID } from "../../utils/constants";
 import { jaiaAPI } from "../../utils/jaia-api";
 
 /**
@@ -30,7 +29,7 @@ export function handleToggleSelectHubLocation(mutableState: JaiaContextType) {
  */
 export function handleMoveHub(mutableState: JaiaContextType, action: JaiaAction) {
     const hubCommand: CommandForHub = {
-        hub_id: DEFAULT_HUB_ID,
+        hub_id: 1,
         type: HubCommandType.SET_HUB_LOCATION,
         hub_location: action.location,
     };

--- a/src/web/openlayers/features/hub-comms-feature.ts
+++ b/src/web/openlayers/features/hub-comms-feature.ts
@@ -6,7 +6,6 @@ import { Coordinate } from "ol/coordinate";
 
 import { hubs } from "../../data/hubs/hubs";
 import { view } from "../views/view";
-import { DEFAULT_HUB_ID } from "../../utils/constants";
 import { degreesToRadians } from "../../utils/conversions";
 import { HUB_COMMS_INNER_RADIUS, HUB_COMMS_OUTER_RADIUS } from "../../utils/constants";
 import { OpenLayersColors } from "../../style/openlayers/colors";
@@ -23,7 +22,7 @@ export enum CommsRangeTypes {
  * @returns {Feature} Circle outline around Hub or empty feature if no Hub location
  */
 export function generateHubCommsFeature(commsRangeType: CommsRangeTypes) {
-    const hub = hubs.getHub(DEFAULT_HUB_ID);
+    const hub = hubs.getHubs().values().next()?.value;
     if (!hub || !hub.getLocation()) {
         return new Feature();
     }

--- a/src/web/utils/constants.ts
+++ b/src/web/utils/constants.ts
@@ -1,7 +1,6 @@
 export const UNASSIGNED_ID = -1;
 export const NO_CONSTRAINT = -1;
 export const DEFAULT_LANES = 5;
-export const DEFAULT_HUB_ID = 1;
 export const DETAILS_DECIMALS = 2;
 export const LAT_LON_DECIMALS = 5;
 export const TEXT_OFFSET_RADIUS = 11;


### PR DESCRIPTION
### Summary
This pull requests removes the use of `DEFAULT_HUB_ID = 1`. This works in simulation, but with a physical system you cannot count on the Hub always having an ID of 1. To resolve this issue, we grab the first item inserted into the map of Hubs which should either be size 0 (no Hub connected) or size 1 (the Hub started up correctly).

### Testing
Testing will be conducted on Fleet 6 using Hub 4.