### PR TITLE
bug/2.y/hub-details-not-closing-as-expected

### DIFF
--- a/src/web/components/RemoteControlPanel/RemoteControlPanel.less
+++ b/src/web/components/RemoteControlPanel/RemoteControlPanel.less
@@ -5,6 +5,7 @@
     bottom: 0;
     width: 100%;
     height: 225px;
+    z-index: 101;
 
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;

--- a/src/web/components/SurveyPlanner/SurveyPlanner.tsx
+++ b/src/web/components/SurveyPlanner/SurveyPlanner.tsx
@@ -3,7 +3,7 @@ import { FormControl, Select, MenuItem, SelectChangeEvent, ThemeProvider } from 
 import Icon from "@mdi/react";
 import { mdiArrowLeft, mdiArrowRight } from "@mdi/js";
 
-import { ChangeEvent, useContext, useState } from "react";
+import { ChangeEvent, useContext, useEffect, useState } from "react";
 import { JaiaContext, JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 
@@ -461,6 +461,11 @@ function OfferSRP(props: Props) {
  * Renders the window to modify safety return parameters to the survey mission set
  */
 function SRPConfig(props: Props) {
+    useEffect(() => {
+        // Show constant heading lines on init
+        gridLayer.finalizeGrid();
+    }, []);
+
     return (
         <div className="jaia-panel survey">
             <div className="jaia-panel-title">Survey Planner</div>

--- a/src/web/components/__buttons__/DeleteMissionButton/DeleteMissionDialog.tsx
+++ b/src/web/components/__buttons__/DeleteMissionButton/DeleteMissionDialog.tsx
@@ -83,7 +83,7 @@ function ButtonRow(props: ButtonRowProps) {
                     className="dialog-button"
                     onClick={() => props.onClose(DialogActions.CONFIRMED)}
                 >
-                    {props.deleteAll ? "Delete All Missions" : "Delete Mission"}
+                    {props.deleteAll ? "Delete All" : "Delete Mission"}
                 </button>
             </div>
         );

--- a/src/web/components/__buttons__/DeleteMissionButton/__tests__/DeleteMissionButton.test.tsx
+++ b/src/web/components/__buttons__/DeleteMissionButton/__tests__/DeleteMissionButton.test.tsx
@@ -59,8 +59,7 @@ test("Delete all missions", async () => {
     const button = screen.getByRole("button", { name: "delete-all-missions" });
     await userEvent.click(button);
     expect(screen.getByText("Confirm"));
-    // Includes button text and helper text that appears when hovering over button
-    expect(screen.getAllByText("Delete All Missions").length).toBe(2);
+    expect(screen.getAllByText("Delete All").length).toBe(1);
     expect(screen.getByText("Cancel"));
 });
 
@@ -104,7 +103,7 @@ test("Click Delete Mission confirmation button", async () => {
     expect(missionSet.getMissions().size).toBe(0);
 });
 
-test("Click Delete All Missions confirmation button", async () => {
+test("Click Delete All confirmation button", async () => {
     const mockMission = new Mission();
     const missionID = missionSet.addMission(mockMission);
 
@@ -116,7 +115,7 @@ test("Click Delete All Missions confirmation button", async () => {
     const button = screen.getByRole("button", { name: "delete-all-missions" });
     await userEvent.click(button);
     expect(screen.queryByText("Confirm")).toBeVisible();
-    await userEvent.click(screen.getAllByText("Delete All Missions")[1]);
+    await userEvent.click(screen.getByText("Delete All"));
     expect(screen.queryByText("Confirm")).toBeNull();
     expect(missionSet.getMissions().size).toBe(0);
 });

--- a/src/web/context/handlers/selection-handlers.ts
+++ b/src/web/context/handlers/selection-handlers.ts
@@ -25,7 +25,7 @@ import { gridPlan, GridPlanningStates } from "../../data/survey_planner/grid-pla
  */
 export function handleClickedNode(mutableState: JaiaContextType, action: JaiaAction) {
     jaiaGlobal.setSelectedNode(action.clickedNode);
-    mutableState.visibleDetails = action.clickedNode.type;
+    mutableState.visibleDetails = jaiaGlobal.getSelectedNode().type;
 
     syncOpenLayers();
 

--- a/src/web/style/stylesheets/z-index.txt
+++ b/src/web/style/stylesheets/z-index.txt
@@ -1,0 +1,2 @@
+Jaia Panels: 100
+RC Panel   : 101


### PR DESCRIPTION
### Summary 
This pull request fixes the Hub details panel not closing properly. Additionally, it resolves some small bugs found in testing:
1. Increase the z-index of the RC panel to be greater than the Jaia panels
2. Changes the delete all missions button text to delete all (so it fits better in the dialog)
3. Shows the constant heading lines on the when the SRP config window is opened