### PR TITLE
bug/2.y/task-packet-color-flashing

### DIFF
--- a/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
+++ b/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 import { TaskPackets } from "../../data/task_packets/task-packets";
@@ -21,6 +21,17 @@ const DECIMALS = 2;
  * Displays task packet data to the operator in a tabular format
  */
 export default function TaskPacketPanel(props: Props) {
+    const [selectCount, setSelectCount] = useState(0);
+
+    useEffect(() => {
+        if (
+            `${taskPacket.bot_id}_${taskPacket.start_time}` !==
+            `${props.selectedTaskPacket.botID}_${props.selectedTaskPacket.startTime}`
+        ) {
+            setSelectCount(selectCount + 1);
+        }
+    });
+
     /**
      * Retrieves the data associated with the selected task packet
      *
@@ -40,8 +51,8 @@ export default function TaskPacketPanel(props: Props) {
         }
     };
 
-    // Call getTaskPacket once on initial render
-    const taskPacket = useMemo(() => getTaskPacket(), []);
+    // Call getTaskPacket on initial render and task packet selection changes
+    const taskPacket = useMemo(() => getTaskPacket(), [selectCount]);
 
     /**
      * Gets the ID used by the server for querying task packet data

--- a/src/web/components/__buttons__/GoToRallyButton/GoToRallyDialog.tsx
+++ b/src/web/components/__buttons__/GoToRallyButton/GoToRallyDialog.tsx
@@ -61,7 +61,7 @@ export function GoToRallyDialog(props: DialogProps) {
     const generateSubMessage = (disabledCode: DisabledCodes) => {
         const botIDs = props.botReadyStates.get(disabledCode);
 
-        if (botIDs.length === 0) {
+        if (!botIDs || botIDs.length === 0) {
             return "";
         }
 

--- a/src/web/context/handlers/panel-handlers.ts
+++ b/src/web/context/handlers/panel-handlers.ts
@@ -3,6 +3,7 @@ import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
 import { missionSet } from "../../data/mission_set/mission-set";
 import { diveLayer } from "../../openlayers/layers/vector/dive-layer";
 import { driftLayer } from "../../openlayers/layers/vector/drift-layer";
+import { excludedTaskPacketsLayer } from "../../openlayers/layers/vector/excluded-task-packets-layer";
 import { missionLayer } from "../../openlayers/layers/vector/mission-layer";
 import { NodeTypes } from "../../types/jaia-system-types";
 import { MapFeatureTypes } from "../../types/openlayers-types";
@@ -66,6 +67,7 @@ export function handleClosedTaskPacketPanel(mutableState: JaiaContextType, actio
     });
     diveLayer.updateFeatures();
     driftLayer.updateFeatures();
+    excludedTaskPacketsLayer.updateFeatures();
     return mutableState;
 }
 

--- a/src/web/context/handlers/selection-handlers.ts
+++ b/src/web/context/handlers/selection-handlers.ts
@@ -2,6 +2,7 @@ import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
 import { missionSet } from "../../data/mission_set/mission-set";
 import { diveLayer } from "../../openlayers/layers/vector/dive-layer";
 import { driftLayer } from "../../openlayers/layers/vector/drift-layer";
+import { excludedTaskPacketsLayer } from "../../openlayers/layers/vector/excluded-task-packets-layer";
 import { missionLayer } from "../../openlayers/layers/vector/mission-layer";
 import { rallyLayer } from "../../openlayers/layers/vector/rally-layer";
 import { handleMapModeChange } from "../../openlayers/maps/map";
@@ -181,5 +182,6 @@ export function handleClickedTaskPacket(mutableState: JaiaContextType, action: J
     mutableState.visiblePanel = ButtonNames.TASK_PACKET_PANEL;
     diveLayer.updateFeatures();
     driftLayer.updateFeatures();
+    excludedTaskPacketsLayer.updateFeatures();
     return mutableState;
 }

--- a/src/web/jcc/index.tsx
+++ b/src/web/jcc/index.tsx
@@ -66,6 +66,7 @@ const taskPacketInterval = setInterval(async () => {
                 const taskPacketRes = await fetch(TASK_PACKET_URL);
                 const json = await taskPacketRes.json();
                 taskPackets.setIncludedTaskPackets(json.result.included);
+                taskPackets.setExcludedTaskPackets(json.result.excluded);
                 updateTaskLayers();
                 taskPackets.setVersion(version);
             }

--- a/src/web/openlayers/features/dive-feature.ts
+++ b/src/web/openlayers/features/dive-feature.ts
@@ -8,15 +8,9 @@ import { view } from "../views/view";
 import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
 import { MapFeatureTypes } from "../../types/openlayers-types";
 import { DivePacket, TaskPacket } from "../../types/protobuf-types";
+import { OpenLayersColors } from "../../style/openlayers/colors";
 
 import diveMarker from "../../style/icons/dive-marker.svg";
-
-enum TaskPacketColors {
-    LIGHT = "white",
-    DARK = "black",
-}
-
-let taskPacketColor = TaskPacketColors.LIGHT;
 
 /**
  * Creates a dive icon to be placed on the map
@@ -90,13 +84,8 @@ function getColor(taskPacket: TaskPacket) {
         selectedTaskPacket.startTime === taskPacket.start_time &&
         selectedTaskPacket.type === MapFeatureTypes.DIVE
     ) {
-        if (taskPacketColor === TaskPacketColors.LIGHT) {
-            taskPacketColor = TaskPacketColors.DARK;
-        } else {
-            taskPacketColor = TaskPacketColors.LIGHT;
-        }
-        return taskPacketColor;
+        return OpenLayersColors.EDIT;
     }
 
-    return TaskPacketColors.LIGHT;
+    return OpenLayersColors.DEFAULT;
 }

--- a/src/web/openlayers/features/dive-feature.ts
+++ b/src/web/openlayers/features/dive-feature.ts
@@ -84,7 +84,7 @@ function getColor(taskPacket: TaskPacket) {
         selectedTaskPacket.startTime === taskPacket.start_time &&
         selectedTaskPacket.type === MapFeatureTypes.DIVE
     ) {
-        return OpenLayersColors.EDIT;
+        return OpenLayersColors.TARGET;
     }
 
     return OpenLayersColors.DEFAULT;

--- a/src/web/openlayers/features/drift-feature.ts
+++ b/src/web/openlayers/features/drift-feature.ts
@@ -105,7 +105,7 @@ function getColor(taskPacket: TaskPacket) {
         selectedTaskPacket.startTime === taskPacket.start_time &&
         selectedTaskPacket.type === MapFeatureTypes.DRIFT
     ) {
-        return OpenLayersColors.EDIT;
+        return OpenLayersColors.TARGET;
     }
 
     return OpenLayersColors.DEFAULT;

--- a/src/web/openlayers/features/drift-feature.ts
+++ b/src/web/openlayers/features/drift-feature.ts
@@ -11,6 +11,7 @@ import { MapFeatureTypes } from "../../types/openlayers-types";
 import { DriftPacket, TaskPacket } from "../../types/protobuf-types";
 import { degreesToRadians } from "../../utils/conversions";
 import { DRIFT_INTENSITY_INTERVAL, MAX_DRIFT_INTENSITY } from "../../utils/constants";
+import { OpenLayersColors } from "../../style/openlayers/colors";
 
 import driftMarker1 from "../../style/icons/drift-arrows/drift-arrow-1.svg";
 import driftMarker2 from "../../style/icons/drift-arrows/drift-arrow-2.svg";
@@ -18,13 +19,6 @@ import driftMarker3 from "../../style/icons/drift-arrows/drift-arrow-3.svg";
 import driftMarker4 from "../../style/icons/drift-arrows/drift-arrow-4.svg";
 import driftMarker5 from "../../style/icons/drift-arrows/drift-arrow-5.svg";
 import driftMarker6 from "../../style/icons/drift-arrows/drift-arrow-6.svg";
-
-enum TaskPacketColors {
-    LIGHT = "white",
-    DARK = "black",
-}
-
-let taskPacketColor = TaskPacketColors.LIGHT;
 
 /**
  * Creates a drift icon to be placed on the map
@@ -111,13 +105,8 @@ function getColor(taskPacket: TaskPacket) {
         selectedTaskPacket.startTime === taskPacket.start_time &&
         selectedTaskPacket.type === MapFeatureTypes.DRIFT
     ) {
-        if (taskPacketColor === TaskPacketColors.LIGHT) {
-            taskPacketColor = TaskPacketColors.DARK;
-        } else {
-            taskPacketColor = TaskPacketColors.LIGHT;
-        }
-        return taskPacketColor;
+        return OpenLayersColors.EDIT;
     }
 
-    return TaskPacketColors.LIGHT;
+    return OpenLayersColors.DEFAULT;
 }

--- a/src/web/openlayers/features/waypoint-feature.ts
+++ b/src/web/openlayers/features/waypoint-feature.ts
@@ -322,12 +322,6 @@ function shouldColorTargetWaypoint(missionID: number, waypointNum: number) {
     }
 
     const bot = bots.getBot(botID);
-    if (
-        bot.getMissionStatus().missionState !== MissionState.IN_MISSION__UNDERWAY__MOVEMENT__TRANSIT
-    ) {
-        return false;
-    }
-
     const targetWaypoint = bot.getMissionStatus().targetWaypoint;
     if (targetWaypoint && targetWaypoint === waypointNum) {
         return true;


### PR DESCRIPTION
### Summary
This pull requests makes improvements to the developer friendly JCC based on today's water testing:
1. Fix bug in go to rally dialog
2. Fix task packet panel switching bug
3. Replace task packet flashing with a solid color to indicate selection
4. Use the target waypoint from the Bot status to highlight the correct waypoint