### PR TITLE
bug/2.y/incorrect-alert-message-for-activate-button-at-startup

### DIFF
--- a/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
+++ b/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
@@ -13,7 +13,7 @@ import Bot from "../../../data/bots/bot";
 import { isCommsDropped } from "../button-utils";
 import { MDI_BUTTON_SIZE } from "../../../utils/constants";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
-import { Command, CommandType } from "../../../types/protobuf-types";
+import { Command, CommandType, MissionState } from "../../../types/protobuf-types";
 import { DialogActions } from "../../../types/context-types";
 
 interface Props {
@@ -46,6 +46,10 @@ export default function ActivateAllButton(props: Props) {
         for (const [botID, bot] of props.bots.entries()) {
             if (isCommsDropped(bot.getStatusAge())) {
                 updatedBotReadyStates.get(DisabledCodes.NO_COMMS).push(botID);
+            } else if (
+                bot.getMissionStatus().missionState === MissionState.PRE_DEPLOYMENT__STARTING_UP
+            ) {
+                updatedBotReadyStates.get(DisabledCodes.STARTING_UP).push(botID);
             } else if (
                 !isCommandAvailable(CommandType.ACTIVATE, bot.getMissionStatus().missionState)
             ) {
@@ -137,6 +141,7 @@ function initBotReadyStates() {
         [DisabledCodes.NONE, []],
         [DisabledCodes.NO_COMMS, []],
         [DisabledCodes.MISSION_STATE, []],
+        [DisabledCodes.STARTING_UP, []],
     ];
     return botReadyStates;
 }

--- a/src/web/components/__buttons__/ActivateAllButton/ActivateAllDialog.tsx
+++ b/src/web/components/__buttons__/ActivateAllButton/ActivateAllDialog.tsx
@@ -90,6 +90,9 @@ export function ActivateAllDialog(props: DialogProps) {
             case DisabledCodes.MISSION_STATE:
                 subMessage += `because ${botIDs.length > 1 ? "they are activated." : "it is activated."}`;
                 break;
+            case DisabledCodes.STARTING_UP:
+                subMessage += `because ${botIDs.length > 1 ? "they are completing the startup process." : "it is completing the startup process."}`;
+                break;
         }
 
         return subMessage;

--- a/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
+++ b/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
@@ -10,7 +10,7 @@ import { mdiCheckboxMarkedCirclePlusOutline } from "@mdi/js";
 
 import Bot from "../../../data/bots/bot";
 import { DialogActions } from "../../../types/context-types";
-import { Command, CommandType } from "../../../types/protobuf-types";
+import { Command, CommandType, MissionState } from "../../../types/protobuf-types";
 import { MDI_BUTTON_SIZE, NO_COMMS_STATUS_AGE } from "../../../utils/constants";
 import { microsecondsToSeconds } from "../../../utils/conversions";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
@@ -50,6 +50,12 @@ export default function ActivateButton(props: Props) {
     const getDisabledCode = () => {
         if (microsecondsToSeconds(props.bot.getStatusAge()) > NO_COMMS_STATUS_AGE) {
             return DisabledCodes.NO_COMMS;
+        }
+
+        if (
+            props.bot.getMissionStatus().missionState === MissionState.PRE_DEPLOYMENT__STARTING_UP
+        ) {
+            return DisabledCodes.STARTING_UP;
         }
 
         if (!isCommandAvailable(CommandType.ACTIVATE, props.bot.getMissionStatus().missionState)) {

--- a/src/web/components/__buttons__/ActivateButton/activate-messages.ts
+++ b/src/web/components/__buttons__/ActivateButton/activate-messages.ts
@@ -4,4 +4,5 @@ export const messages: ReadonlyMap<DisabledCodes, string> = new Map([
     [DisabledCodes.NONE, ""],
     [DisabledCodes.NO_COMMS, "The Bot does not have comms with the Hub."],
     [DisabledCodes.MISSION_STATE, "The Bot can only be activated when idle."],
+    [DisabledCodes.STARTING_UP, "The Bot is completing the startup process."],
 ]);

--- a/src/web/components/__buttons__/disabled-codes.ts
+++ b/src/web/components/__buttons__/disabled-codes.ts
@@ -7,4 +7,5 @@ export enum DisabledCodes {
     DOWNLOAD_QUEUE = 6,
     NO_MISSION = 7,
     LOW_BATTERY = 8,
+    STARTING_UP = 9,
 }


### PR DESCRIPTION
### Summary
This pull request creates the disabled code `STARTING_UP` to provide better messaging to an operator when they click the activate button while the Bot is in `PRE_DEPLOYMENT__STARTING_UP`. The command cannot be sent in this state, but the messaging was misleading by saying the Bot has already been activated. Now it says the Bot is completing the startup process.

### Testing
* Press the activate button when the Bot is in `PRE_DEPLOYMENT__STARTING_UP`
* Press the activate all button when the Bot is in `PRE_DEPLOYMENT__STARTING_UP`
* Press the activate buttons outside of these states
* *Messaging displayed as expected*