### PR TITLE
task/2.y/add-back-take-control-button

### DIFF
--- a/src/web/components/SimulationBanner/SimulationBanner.less
+++ b/src/web/components/SimulationBanner/SimulationBanner.less
@@ -5,7 +5,7 @@
     bottom: 106px;
     right: 75px;
     height: 40px;
-    width: 120px;
+    width: 90px;
 
     display: flex;
     justify-content: center;

--- a/src/web/components/SimulationBanner/SimulationBanner.less
+++ b/src/web/components/SimulationBanner/SimulationBanner.less
@@ -5,7 +5,7 @@
     bottom: 106px;
     right: 75px;
     height: 40px;
-    width: 100px;
+    width: 120px;
 
     display: flex;
     justify-content: center;

--- a/src/web/components/TakeControlDialog/TakeControlDialog.tsx
+++ b/src/web/components/TakeControlDialog/TakeControlDialog.tsx
@@ -18,14 +18,14 @@ export default function TakeControlDialog(props: Props) {
      * @returns {void}
      */
     const handleTakeControlClick = () => {
-        jaiaAPI.takeControl();
+        jaiaAPI.takeControl().then(() => {
+            if (props.groupBotsByReadyState) {
+                props.groupBotsByReadyState();
+            }
 
-        if (props.groupBotsByReadyState) {
-            props.groupBotsByReadyState();
-        }
-
-        props.setIsTakeControlVisible(false);
-        props.setIsDialogVisible(true);
+            props.setIsTakeControlVisible(false);
+            props.setIsDialogVisible(true);
+        });
     };
 
     if (props.isVisible) {

--- a/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
+++ b/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
@@ -63,12 +63,12 @@ export default function ActivateAllButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
+    const handleClick = () => {
         if (props.bots.size === 0) {
             return;
         }
 
-        const hasControl = await isControllingClient();
+        const hasControl = isControllingClient();
 
         if (!hasControl) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
+++ b/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { ActivateAllDialog } from "./ActivateAllDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
+++ b/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { ActivateDialog } from "./ActivateDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
+++ b/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
@@ -63,8 +63,8 @@ export default function ActivateButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
-        const hasControl = await isControllingClient();
+    const handleClick = () => {
+        const hasControl = isControllingClient();
 
         if (!hasControl && getDisabledCode() === DisabledCodes.NONE) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllButton.tsx
+++ b/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { DataOffloadAllDialog } from "./DataOffloadAllDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllButton.tsx
+++ b/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllButton.tsx
@@ -65,12 +65,12 @@ export default function DataOffloadAllButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
+    const handleClick = () => {
         if (props.bots.size === 0) {
             return;
         }
 
-        const hasControl = await isControllingClient();
+        const hasControl = isControllingClient();
 
         if (!hasControl) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/DataOffloadButton/DataOffloadButton.tsx
+++ b/src/web/components/__buttons__/DataOffloadButton/DataOffloadButton.tsx
@@ -66,8 +66,8 @@ export default function DataOffloadButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
-        const hasControl = await isControllingClient();
+    const handleClick = () => {
+        const hasControl = isControllingClient();
 
         if (!hasControl && getDisabledCode() === DisabledCodes.NONE) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/DataOffloadButton/DataOffloadButton.tsx
+++ b/src/web/components/__buttons__/DataOffloadButton/DataOffloadButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { DataOffloadDialog } from "./DataOffloadDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/GoToRallyButton/GoToRallyButton.tsx
+++ b/src/web/components/__buttons__/GoToRallyButton/GoToRallyButton.tsx
@@ -82,8 +82,8 @@ export default function GoToRallyButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
-        const hasControl = await isControllingClient();
+    const handleClick = () => {
+        const hasControl = isControllingClient();
 
         if (!hasControl) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/GoToRallyButton/GoToRallyButton.tsx
+++ b/src/web/components/__buttons__/GoToRallyButton/GoToRallyButton.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 import { JaiaDispatchContext } from "../../../context/JaiaContext";
 import { JaiaActions } from "../../../context/jaia-actions";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { GoToRallyDialog } from "./GoToRallyDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/NextTaskButton/NextTaskButton.tsx
+++ b/src/web/components/__buttons__/NextTaskButton/NextTaskButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { NextTaskDialog } from "./NextTaskDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/NextTaskButton/NextTaskButton.tsx
+++ b/src/web/components/__buttons__/NextTaskButton/NextTaskButton.tsx
@@ -58,8 +58,8 @@ export default function NextTaskButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
-        const hasControl = await isControllingClient();
+    const handleClick = () => {
+        const hasControl = isControllingClient();
 
         if (!hasControl && getDisabledCode() === DisabledCodes.NONE) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/RemoteControlButton/RemoteControlButton.tsx
+++ b/src/web/components/__buttons__/RemoteControlButton/RemoteControlButton.tsx
@@ -80,8 +80,8 @@ export default function RemoteControlButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
-        const hasControl = await isControllingClient();
+    const handleClick = () => {
+        const hasControl = isControllingClient();
 
         if (!hasControl && getDisabledCode() === DisabledCodes.NONE) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/RemoteControlButton/RemoteControlButton.tsx
+++ b/src/web/components/__buttons__/RemoteControlButton/RemoteControlButton.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState } from "react";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { RemoteControlDialog } from "./RemoteControlDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/StartAllMissionsButton/StartAllMissionsButton.tsx
+++ b/src/web/components/__buttons__/StartAllMissionsButton/StartAllMissionsButton.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 import { JaiaDispatchContext } from "../../../context/JaiaContext";
 import { JaiaActions } from "../../../context/jaia-actions";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { StartAllMissionsDialog } from "./StartAllMissionsDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/StartAllMissionsButton/StartAllMissionsButton.tsx
+++ b/src/web/components/__buttons__/StartAllMissionsButton/StartAllMissionsButton.tsx
@@ -83,12 +83,12 @@ export default function StartAllMissionsButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
+    const handleClick = () => {
         if (props.bots.size === 0) {
             return;
         }
 
-        const hasControl = await isControllingClient();
+        const hasControl = isControllingClient();
 
         if (!hasControl) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/StartMissionButton/StartMissionButton.tsx
+++ b/src/web/components/__buttons__/StartMissionButton/StartMissionButton.tsx
@@ -92,8 +92,8 @@ export default function StartMissionButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
-        const hasControl = await isControllingClient();
+    const handleClick = () => {
+        const hasControl = isControllingClient();
 
         if (!hasControl && getDisabledCode() === DisabledCodes.NONE) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/StartMissionButton/StartMissionButton.tsx
+++ b/src/web/components/__buttons__/StartMissionButton/StartMissionButton.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 import { JaiaDispatchContext } from "../../../context/JaiaContext";
 import { JaiaActions } from "../../../context/jaia-actions";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { StartMissionDialog } from "./StartMissionDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/StopAllBotsButton/StopAllBotsButton.tsx
+++ b/src/web/components/__buttons__/StopAllBotsButton/StopAllBotsButton.tsx
@@ -65,12 +65,12 @@ export default function StopAllBotsButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
+    const handleClick = () => {
         if (props.bots.size === 0) {
             return;
         }
 
-        const hasControl = await isControllingClient();
+        const hasControl = isControllingClient();
 
         if (!hasControl) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/StopAllBotsButton/StopAllBotsButton.tsx
+++ b/src/web/components/__buttons__/StopAllBotsButton/StopAllBotsButton.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 import { JaiaDispatchContext } from "../../../context/JaiaContext";
 import { JaiaActions } from "../../../context/jaia-actions";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { StopAllBotsDialog } from "./StopAllBotsDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/StopButton/StopButton.tsx
+++ b/src/web/components/__buttons__/StopButton/StopButton.tsx
@@ -62,8 +62,8 @@ export default function StopButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
-        const hasControl = await isControllingClient();
+    const handleClick = () => {
+        const hasControl = isControllingClient();
 
         if (!hasControl && getDisabledCode() === DisabledCodes.NONE) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/StopButton/StopButton.tsx
+++ b/src/web/components/__buttons__/StopButton/StopButton.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 import { JaiaDispatchContext } from "../../../context/JaiaContext";
 import { JaiaActions } from "../../../context/jaia-actions";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { StopDialog } from "./StopDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/SystemButton/SystemButton.tsx
+++ b/src/web/components/__buttons__/SystemButton/SystemButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import TakeControlDialog from "../../TakeControlDialog/TakeControlDialog";
+import TakeControlDialog from "../TakeControl/TakeControlDialog/TakeControlDialog";
 import { SystemDialog } from "./SystemDialog";
 import { DisabledCodes } from "../disabled-codes";
 

--- a/src/web/components/__buttons__/SystemButton/SystemButton.tsx
+++ b/src/web/components/__buttons__/SystemButton/SystemButton.tsx
@@ -154,8 +154,8 @@ export default function SystemButton(props: Props) {
      *
      * @returns {void}
      */
-    const handleClick = async () => {
-        const hasControl = await isControllingClient();
+    const handleClick = () => {
+        const hasControl = isControllingClient();
 
         if (!hasControl && getDisabledCode() === DisabledCodes.NONE) {
             setIsTakeControlVisible(true);

--- a/src/web/components/__buttons__/TakeControl/TakeControlButton/TakeControlButton.less
+++ b/src/web/components/__buttons__/TakeControl/TakeControlButton/TakeControlButton.less
@@ -1,0 +1,14 @@
+@import "../../../../style/stylesheets/vars.less";
+
+#take-control {
+    all: unset;
+    position: absolute;
+    bottom: 66px;
+    left: 75px;
+    padding: 15px 30px;
+    border: 1px solid #fff;
+    border-radius: 6px;
+    background-color: @good-color;
+    color: #000;
+    font-size: 1.1rem;
+}

--- a/src/web/components/__buttons__/TakeControl/TakeControlButton/TakeControlButton.less
+++ b/src/web/components/__buttons__/TakeControl/TakeControlButton/TakeControlButton.less
@@ -6,9 +6,10 @@
     bottom: 66px;
     left: 75px;
     padding: 15px 30px;
-    border: 1px solid #fff;
+    border: 1px solid @good-color;
     border-radius: 6px;
-    background-color: @good-color;
-    color: #000;
+    background-color: @overlay-background;
+    color: @good-color;
     font-size: 1.1rem;
+    font-weight: 600;
 }

--- a/src/web/components/__buttons__/TakeControl/TakeControlButton/TakeControlButton.tsx
+++ b/src/web/components/__buttons__/TakeControl/TakeControlButton/TakeControlButton.tsx
@@ -1,5 +1,22 @@
+import { jaiaAPI } from "../../../../utils/jaia-api";
 import "./TakeControlButton.less";
 
+/**
+ * Renders the Take Control button in the bottom left corner of the JCC
+ */
 export default function TakeControlButton() {
-    return <button id="take-control">Take Control</button>;
+    /**
+     * Makes API call to take control of the system
+     *
+     * @returns {void}
+     */
+    const handleTakeControlClick = async () => {
+        const res = await jaiaAPI.takeControl();
+    };
+
+    return (
+        <button id="take-control" onClick={handleTakeControlClick}>
+            Take Control
+        </button>
+    );
 }

--- a/src/web/components/__buttons__/TakeControl/TakeControlButton/TakeControlButton.tsx
+++ b/src/web/components/__buttons__/TakeControl/TakeControlButton/TakeControlButton.tsx
@@ -1,0 +1,5 @@
+import "./TakeControlButton.less";
+
+export default function TakeControlButton() {
+    return <button id="take-control">Take Control</button>;
+}

--- a/src/web/components/__buttons__/TakeControl/TakeControlDialog/TakeControlDialog.tsx
+++ b/src/web/components/__buttons__/TakeControl/TakeControlDialog/TakeControlDialog.tsx
@@ -1,4 +1,4 @@
-import { jaiaAPI } from "../../utils/jaia-api";
+import { jaiaAPI } from "../../../../utils/jaia-api";
 
 interface Props {
     isVisible: boolean;

--- a/src/web/data/jaia_global/jaia-global.ts
+++ b/src/web/data/jaia_global/jaia-global.ts
@@ -39,6 +39,7 @@ export class JaiaGlobal {
     private selectedTaskPacket: SelectedTaskPacket;
     private mapMode: MapModes;
     private defaultTaskParameters: TaskParameters;
+    private controllingClientID: string;
 
     constructor() {
         this.selectedNode = { type: NodeTypes.NONE, id: UNASSIGNED_ID };
@@ -101,6 +102,14 @@ export class JaiaGlobal {
 
     setDefaultTaskParameters(defaultTaskParameters: TaskParameters) {
         this.defaultTaskParameters = defaultTaskParameters;
+    }
+
+    getControllingClientID() {
+        return this.controllingClientID;
+    }
+
+    setControllingClientID(controllingClientID: string) {
+        this.controllingClientID = controllingClientID;
     }
 
     /**

--- a/src/web/jcc/App.less
+++ b/src/web/jcc/App.less
@@ -42,7 +42,7 @@ body {
 }
 
 #connection-warning {
-    position: sticky;
+    position: absolute;
     visibility: hidden;
 
     width: 300px;

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -150,6 +150,10 @@ function TakeControl() {
     // Use context to participate in re-render cycles
     const jaiaContext = useContext(JaiaContext);
 
+    if (jaiaContext === null) {
+        return;
+    }
+
     if (!isControllingClient()) {
         return <TakeControlButton />;
     }

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -4,6 +4,7 @@ import { JaiaContext, JaiaContextProvider } from "../context/JaiaContext";
 import { gridPlan } from "../data/survey_planner/grid-plan";
 import { ButtonNames } from "../types/context-types";
 import { BotModes, ButtonListTypes, NodeTypes } from "../types/jaia-system-types";
+import { isControllingClient } from "../utils/commands";
 
 import Map from "../components/Map/Map";
 import NodeList from "../components/NodeList/NodeList";
@@ -55,8 +56,8 @@ export default function App() {
                 <Panel />
                 <RemoteControl />
                 <SimulationBanner />
+                <TakeControl />
             </JaiaContextProvider>
-            <TakeControlButton />
             <div id="connection-warning">Connection to Hub Dropped</div>
         </div>
     );
@@ -150,5 +151,9 @@ function TakeControl() {
 
     if (jaiaContext === null) {
         return;
+    }
+
+    if (!isControllingClient(jaiaContext.jaiaGlobal.getControllingClientID())) {
+        return <TakeControlButton />;
     }
 }

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -147,13 +147,10 @@ function RemoteControl() {
  * Controls the rendering of the TakeControlButton
  */
 function TakeControl() {
+    // Use context to participate in re-render cycles
     const jaiaContext = useContext(JaiaContext);
 
-    if (jaiaContext === null) {
-        return;
-    }
-
-    if (!isControllingClient(jaiaContext.jaiaGlobal.getControllingClientID())) {
+    if (!isControllingClient()) {
         return <TakeControlButton />;
     }
 }

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -22,6 +22,7 @@ import SurveyPlanner from "../components/SurveyPlanner/SurveyPlanner";
 import TaskPacketPanel from "../components/TaskPacketPanel/TaskPacketPanel";
 import DataOffloadPanel from "../components/DataOffloadPanel/DataOffloadPanel";
 import SimulationBanner from "../components/SimulationBanner/SimulationBanner";
+import TakeControlButton from "../components/__buttons__/TakeControl/TakeControlButton/TakeControlButton";
 import RemoteControlPanel from "../components/RemoteControlPanel/RemoteControlPanel";
 
 import "./App.less";
@@ -55,6 +56,7 @@ export default function App() {
                 <RemoteControl />
                 <SimulationBanner />
             </JaiaContextProvider>
+            <TakeControlButton />
             <div id="connection-warning">Connection to Hub Dropped</div>
         </div>
     );
@@ -76,7 +78,7 @@ function Details() {
         case NodeTypes.BOT:
             return <BotDetails />;
         default:
-            return <div></div>;
+            return;
     }
 }
 
@@ -87,7 +89,7 @@ function Panel() {
     const jaiaContext = useContext(JaiaContext);
 
     if (jaiaContext === null) {
-        return <div></div>;
+        return;
     }
 
     switch (jaiaContext.visiblePanel) {
@@ -119,7 +121,7 @@ function Panel() {
         case ButtonNames.DEPTH_MAP_3D:
             return <DepthMap3D />;
         default:
-            return <div></div>;
+            return;
     }
 }
 
@@ -130,12 +132,23 @@ function RemoteControl() {
     const jaiaContext = useContext(JaiaContext);
 
     if (jaiaContext === null) {
-        return <div></div>;
+        return;
     }
     if (jaiaContext.jaiaGlobal.getSelectedNode().type === NodeTypes.BOT) {
         const selectedBot = jaiaContext.bots.getBot(jaiaContext.jaiaGlobal.getSelectedNode().id);
         if (selectedBot.getMode() === BotModes.REMOTE_CONTROL) {
             return <RemoteControlPanel botID={selectedBot.getBotID()} />;
         }
+    }
+}
+
+/**
+ * Controls the rendering of the TakeControlButton
+ */
+function TakeControl() {
+    const jaiaContext = useContext(JaiaContext);
+
+    if (jaiaContext === null) {
+        return;
     }
 }

--- a/src/web/jcc/index.tsx
+++ b/src/web/jcc/index.tsx
@@ -14,6 +14,7 @@ import { contourLayer } from "../openlayers/layers/vector/contour-layer";
 import { hubCommsLayer } from "../openlayers/layers/vector/hub-comms-layer";
 import { excludedTaskPacketsLayer } from "../openlayers/layers/vector/excluded-task-packets-layer";
 import { DATA_MODEL_POLL_TIME, TASK_PACKET_POLL_TIME } from "../utils/constants";
+import { jaiaGlobal } from "../data/jaia_global/jaia-global";
 
 // Sample status messages twice as fast as produced by Bots and Hubs to reduce potential data age issues
 const STATUS_URL = "/jaia/v0/status";
@@ -37,6 +38,7 @@ const statusInterval = setInterval(async () => {
             const json = await response.json();
             updateBots(json.bots);
             updateHubs(json.hubs);
+            updateJaiaGlobal(json.controllingClientId);
             updateOpenLayers();
             if (json.messages.error && json.messages.error === HUB_CONNECTION_ERROR) {
                 updateDisconnectedWarning(true);
@@ -102,6 +104,16 @@ function updateHubs(hubStatuses: { [hubId: string]: PortalHubStatus }) {
     for (let hubID of hubIDs) {
         hubs.setHub(hubStatuses[hubID]);
     }
+}
+
+/**
+ * Move the controlling client ID from the server to the client-side data model
+ *
+ * @param {string} controllingClientID ID from the server
+ * @returns {void}
+ */
+function updateJaiaGlobal(controllingClientID: string) {
+    jaiaGlobal.setControllingClientID(controllingClientID);
 }
 
 /**

--- a/src/web/style/stylesheets/openlayers.less
+++ b/src/web/style/stylesheets/openlayers.less
@@ -23,7 +23,7 @@
     right: 75px;
 
     height: 40px;
-    width: 120px;
+    width: 90px;
     line-height: 18px;
 
     padding: 2px;

--- a/src/web/style/stylesheets/openlayers.less
+++ b/src/web/style/stylesheets/openlayers.less
@@ -23,7 +23,7 @@
     right: 75px;
 
     height: 40px;
-    width: 100px;
+    width: 120px;
     line-height: 18px;
 
     padding: 2px;

--- a/src/web/utils/commands.ts
+++ b/src/web/utils/commands.ts
@@ -6,6 +6,7 @@ import {
     Engineering,
     MissionState,
 } from "../types/protobuf-types";
+import { jaiaGlobal } from "../data/jaia_global/jaia-global";
 
 /**
  * commandStates is a map of command types to regular expressions
@@ -92,10 +93,8 @@ export function sendEngineeringCommand(command: Engineering) {
  *
  * @returns {boolean} True if the client is in control, otherwise false
  */
-export async function isControllingClient() {
-    const status = await jaiaAPI.getStatus();
-    const controllingID = status.controllingClientId;
-
+export function isControllingClient() {
+    const controllingID = jaiaGlobal.getControllingClientID();
     if (controllingID === jaiaAPI.getClientId() || controllingID === null) {
         return true;
     }

--- a/src/web/utils/commands.ts
+++ b/src/web/utils/commands.ts
@@ -93,7 +93,7 @@ export function sendEngineeringCommand(command: Engineering) {
  *
  * @returns {boolean} True if the client is in control, otherwise false
  */
-export function isControllingClient(clientID?: string) {
+export function isControllingClient() {
     const controllingID = jaiaGlobal.getControllingClientID();
     if (controllingID === jaiaAPI.getClientId() || controllingID === null) {
         return true;

--- a/src/web/utils/commands.ts
+++ b/src/web/utils/commands.ts
@@ -93,7 +93,7 @@ export function sendEngineeringCommand(command: Engineering) {
  *
  * @returns {boolean} True if the client is in control, otherwise false
  */
-export function isControllingClient() {
+export function isControllingClient(clientID?: string) {
     const controllingID = jaiaGlobal.getControllingClientID();
     if (controllingID === jaiaAPI.getClientId() || controllingID === null) {
         return true;


### PR DESCRIPTION
### Summary
This pull request adds back the Take Control button to the JCC. This alerts operators when they are out of control and gives them the option to take over the controls. Previously, we were sending a server request each time we checked for the controlling client ID. Now, we save it into jaiaGlobal to reduce the number of requests sent.

<img width="766" height="576" alt="image" src="https://github.com/user-attachments/assets/25cf296d-20cc-4ae3-9242-98066626d6a1" />

### Testing
Switched between two browsers changing which client held control. The button and messaging of other buttons updated correctly.
