### PR TITLE
bug/2.y/bot-not-being-assigned-multiple-lanes

### DIFF
--- a/src/web/context/handlers/survey-handlers.ts
+++ b/src/web/context/handlers/survey-handlers.ts
@@ -88,6 +88,7 @@ export function handleChangeGridPlanningState(mutableState: JaiaContextType, act
                     mission.setBottomDepthSafetyParams(bottomDepthSafetyParams);
                 }
             }
+            gridPlan.fitLanesToBots();
             missionSet.setMissions(cloneDeep(gridPlan.getMissions()));
             missionSet.setMissionIDInEditMode(UNASSIGNED_ID);
             missionSet.setNextMissionID(gridPlan.getMissions().size + 1);


### PR DESCRIPTION
### Summary
It appears the call to `gridPlan.fitBotsToLanes` was lost while resolving merge conflicts. This pull requests adds back the call.