### PR TITLE
task/optimize-jdv-plots

### DIFF
--- a/src/python/pyjaia/src/pyjaia/logtools/__init__.py
+++ b/src/python/pyjaia/src/pyjaia/logtools/__init__.py
@@ -60,7 +60,6 @@ def get_enum_map(dataset: h5py.Dataset):
         return enum_dict
 
     except KeyError:
-        l.warning(f"No enum attributes found for dataset at path {dataset.name}")
         return None
 
 

--- a/src/python/pyjaia/src/pyjaia/logtools/__init__.py
+++ b/src/python/pyjaia/src/pyjaia/logtools/__init__.py
@@ -264,7 +264,7 @@ class JaiaLogH5:
 
         series.utime = []
         series.y_values = []
-        series.hovertext_map = {}
+        series.hovertext_map = None
 
         path = self.get_path(path)
         l.info(color_text(f'Loading series from path {path} in file {self.log.filename}', 'green'))
@@ -288,7 +288,7 @@ class JaiaLogH5:
             series.hovertext_map = None
         else:
             series.utime, _, series.y_values = zip(*s)
-            series.hovertext_map = get_enum_map(self.log[path]) or {}
+            series.hovertext_map = get_enum_map(self.log[path])
             series.hovertext = None
 
         return series

--- a/src/python/pyjaia/src/pyjaia/logtools/__init__.py
+++ b/src/python/pyjaia/src/pyjaia/logtools/__init__.py
@@ -60,6 +60,7 @@ def get_enum_map(dataset: h5py.Dataset):
         return enum_dict
 
     except KeyError:
+        l.warning(f"No enum attributes found for dataset at path {dataset.name}")
         return None
 
 

--- a/src/python/pyjaia/src/pyjaia/series.py
+++ b/src/python/pyjaia/src/pyjaia/series.py
@@ -30,9 +30,11 @@ class Series:
         r.utime += list(other_series.utime)
         r.y_values += list(other_series.y_values)
         if other_series.hovertext is not None:
-            r.hovertext = (r.hovertext or []) + list(other_series.hovertext)
+            r.hovertext = r.hovertext or []
+            r.hovertext.extend(other_series.hovertext)
         elif other_series.hovertext_map is not None:
-            r.hovertext_map = (r.hovertext_map or {}).update(other_series.hovertext_map)
+            r.hovertext_map = r.hovertext_map or {}
+            r.hovertext_map.update(other_series.hovertext_map)
         return r
 
     def clear(self):

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -91,6 +91,10 @@ export function Plot_get_plot_to_use(
     max_points: number,
 ): Plot {
     const total_duration = plot._utime_[plot._utime_.length - 1] - plot._utime_[0];
+    if (total_duration === 0) {
+        // Downsampling is not meaningful for single-timestamp data
+        return plot;
+    }
     const actual_visible_duration = Math.min(visible_duration, total_duration); // Avoid division by zero
     const estimated_points_in_view =
         (actual_visible_duration / total_duration) * plot._utime_.length;

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -54,13 +54,13 @@ export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) 
     const N = plot._utime_.length;
     let last_y = 0;
     for (let i = 0; i < N; i += 2) {
-        let best_index: number = null;
+        let best_index: number = i;
         let largest_abs_delta = 0;
 
         // Find the point with the largest delta in this segment
-        for (let j = i; j < Math.min(i + 2, N); j++) {
+        for (let j = i; j < i + 2; j++) {
             let abs_delta = Math.abs(plot.series_y[j] - last_y);
-            if (best_index === null || abs_delta > largest_abs_delta) {
+            if (abs_delta > largest_abs_delta) {
                 best_index = j;
                 largest_abs_delta = abs_delta;
             }

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -141,6 +141,10 @@ export function Plot_get_plot_to_use(
     visible_duration: number,
     max_points: number,
 ): Plot {
+    if (!plot._utime_ || plot._utime_.length === 0) {
+        // No data points, return the plot as is
+        return plot;
+    }
     const total_duration = plot._utime_[plot._utime_.length - 1] - plot._utime_[0];
     if (total_duration === 0) {
         // Downsampling is not meaningful for single-timestamp data

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -58,7 +58,7 @@ export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) 
         let largest_abs_delta = 0;
 
         // Find the point with the largest delta in this segment
-        for (let j = i; j < i + 2; j++) {
+        for (let j = i; j < Math.min(i + 2, N); j++) {
             let abs_delta = Math.abs(plot.series_y[j] - last_y);
             if (best_index === null || abs_delta > largest_abs_delta) {
                 best_index = j;

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -6,7 +6,12 @@ export interface Plot {
     hovertext_map?: { [key: number]: string };
     hovertext?: string[];
     path: string;
+
+    // Added later
+    is_full_series?: boolean;
     downsampled_plot?: Plot;
+    ymin_index?: number;
+    ymax_index?: number;
 }
 
 /**
@@ -67,7 +72,11 @@ export function Plot_get_hovertext_by_range(plot: Plot, start_index: number, end
  * @param {Plot} plot
  * @param {number} max_points The maximum number of data points for the last downsampled Plot object.
  */
-export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) {
+export function Plot_generate_downsampled_plots(
+    plot: Plot,
+    max_points: number,
+    is_full_series: boolean = true,
+): void {
     if (plot.downsampled_plot) {
         // Already downsampled
         return;
@@ -77,6 +86,8 @@ export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) 
         // No need to downsample
         return;
     }
+
+    plot.is_full_series = is_full_series;
 
     let new_plot: Plot = {
         title: plot.title,
@@ -100,7 +111,9 @@ export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) 
 
         // Find the point with the largest delta in this segment
         for (let j = i; j < i + 2; j++) {
-            let abs_delta = Math.abs(plot.series_y[j] - last_y);
+            let y = plot.series_y[j];
+
+            let abs_delta = Math.abs(y - last_y);
             if (abs_delta > largest_abs_delta) {
                 best_index = j;
                 largest_abs_delta = abs_delta;
@@ -122,7 +135,7 @@ export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) 
     console.debug(`Downsampled plot ${plot.title} from ${N} to ${new_plot._utime_.length} points`);
 
     // Recursively downsample until we are under the max points
-    Plot_generate_downsampled_plots(new_plot, max_points);
+    Plot_generate_downsampled_plots(new_plot, max_points, (is_full_series = false));
     plot.downsampled_plot = new_plot;
 }
 
@@ -172,4 +185,31 @@ export function Plot_get_plot_to_use(
         // Use full resolution plot
         return plot;
     }
+}
+
+/**
+ * Calculate the indices of the min and max series_y values for a Plot object.
+ *
+ * @param {Plot} plot
+ * @returns {{ ymin_index: number; ymax_index: number }}
+ */
+export function Plot_calculate_yminmax_indices(plot: Plot) {
+    let ymin_index = 0;
+    let ymax_index = 0;
+    let ymin = Number.MAX_VALUE;
+    let ymax = Number.MIN_VALUE;
+
+    plot.series_y.forEach((y, i) => {
+        if (y < ymin) {
+            ymin = y;
+            ymin_index = i;
+        }
+        if (y > ymax) {
+            ymax = y;
+            ymax_index = i;
+        }
+    });
+
+    plot.ymin_index = ymin_index;
+    plot.ymax_index = ymax_index;
 }

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -92,14 +92,14 @@ export function Plot_get_plot_to_use(
 ): Plot {
     const total_duration = plot._utime_[plot._utime_.length - 1] - plot._utime_[0];
     const actual_visible_duration = Math.min(visible_duration, total_duration); // Avoid division by zero
-    const esimated_points_in_view =
+    const estimated_points_in_view =
         (actual_visible_duration / total_duration) * plot._utime_.length;
 
     console.debug(
-        `Plot ${plot.title} has total duration ${total_duration}s, visible duration ${actual_visible_duration}s, estimated points in view ${esimated_points_in_view}, max points ${max_points}`,
+        `Plot ${plot.title} has total duration ${total_duration}s, visible duration ${actual_visible_duration}s, estimated points in view ${estimated_points_in_view}, max points ${max_points}`,
     );
 
-    if (esimated_points_in_view > max_points) {
+    if (estimated_points_in_view > max_points) {
         // Use downsampled plot
         if (plot.downsampled_plot) {
             return Plot_get_plot_to_use(plot.downsampled_plot, visible_duration, max_points);

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -9,6 +9,12 @@ export interface Plot {
     downsampled_plot?: Plot;
 }
 
+/**
+ * Returns an array of hovertext strings for the given Plot object.
+ *
+ * @param {Plot} plot
+ * @returns {string[] | null} An array of hovertext strings, or null if no hovertext is available.
+ */
 export function Plot_get_hovertext(plot: Plot) {
     if (plot.hovertext) {
         return plot.hovertext;
@@ -17,6 +23,13 @@ export function Plot_get_hovertext(plot: Plot) {
     } else return null;
 }
 
+/**
+ * Returns the hovertext value for a give Plot at a given index.
+ *
+ * @param {Plot} plot
+ * @param {number} index
+ * @returns {string | null} The hovertext string at the given index, or null if no hovertext is available.
+ */
 export function Plot_get_hovertext_by_index(plot: Plot, index: number) {
     if (plot.hovertext) {
         return plot.hovertext[index] ?? null;
@@ -26,6 +39,14 @@ export function Plot_get_hovertext_by_index(plot: Plot, index: number) {
     } else return null;
 }
 
+/**
+ * Returns an array of hovertext values for a subrange of a Plot object's data.
+ *
+ * @param {Plot} plot
+ * @param {number} start_index
+ * @param {number} end_index
+ * @returns {string[] | null} An array of hovertext strings for the specified range, or null if no hovertext is available.
+ */
 export function Plot_get_hovertext_by_range(plot: Plot, start_index: number, end_index: number) {
     if (plot.hovertext) {
         return plot.hovertext.slice(start_index, end_index);
@@ -35,6 +56,17 @@ export function Plot_get_hovertext_by_range(plot: Plot, start_index: number, end
     } else return null;
 }
 
+/**
+ * Recursively generates downsampled Plot objects for a given plot and max_points value.
+ * It downsamples the plots by 2x, using an algorithm similar to a min/max bucket downsample,
+ * to preserve peaks and valleys at all zoom levels.  The 2x downsampled plot is placed in
+ * `plot.downsampled_plot`, and the 2x downsample of that plot is placed in its
+ * `plot.downsampled_plot` field, etc., until the last downsampled plot has fewer than
+ * `max_points` data points in it.
+ *
+ * @param {Plot} plot
+ * @param {number} max_points The maximum number of data points for the last downsampled Plot object.
+ */
 export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) {
     if (plot.downsampled_plot) {
         // Already downsampled
@@ -94,6 +126,16 @@ export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) 
     plot.downsampled_plot = new_plot;
 }
 
+/**
+ * Return the appropriate Plot object to use for a given visible_duration in time units
+ * (microseconds), such that the resulting time window probably has fewer than max_points data points.
+ * If the series has a very irregular sampling rate, this is only an estimate.
+ *
+ * @param {Plot} plot The Plot object to evaluate.
+ * @param {number} visible_duration Duration of the visible time window in microseconds.
+ * @param {number} max_points Maximum allowed data points in the visible time window.
+ * @returns {Plot} The Plot object to use (either the original or a downsampled version).
+ */
 export function Plot_get_plot_to_use(
     plot: Plot,
     visible_duration: number,

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -6,6 +6,7 @@ export interface Plot {
     hovertext_map?: { [key: number]: string };
     hovertext?: string[];
     path: string;
+    downsampled_plot?: Plot;
 }
 
 export function Plot_get_hovertext(plot: Plot) {
@@ -23,4 +24,93 @@ export function Plot_get_hovertext_by_index(plot: Plot, index: number) {
         const y_value = plot.series_y[index];
         return plot.hovertext_map[y_value] ?? String(y_value);
     } else return null;
+}
+
+export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) {
+    if (plot.downsampled_plot) {
+        // Already downsampled
+        return;
+    }
+
+    if (plot._utime_.length <= max_points) {
+        // No need to downsample
+        return;
+    }
+
+    let new_plot: Plot = {
+        title: plot.title,
+        y_axis_title: plot.y_axis_title,
+        _utime_: [] as number[],
+        series_y: [] as number[],
+        hovertext_map: plot.hovertext_map,
+        path: plot.path,
+    };
+
+    if (plot.hovertext) {
+        new_plot.hovertext = [];
+    }
+
+    // Downsample
+    const N = plot._utime_.length;
+    let last_y = 0;
+    for (let i = 0; i < N; i += 2) {
+        let best_index: number = null;
+        let largest_abs_delta = 0;
+
+        // Find the point with the largest delta in this segment
+        for (let j = i; j < i + 2; j++) {
+            let abs_delta = Math.abs(plot.series_y[j] - last_y);
+            if (best_index === null || abs_delta > largest_abs_delta) {
+                best_index = j;
+                largest_abs_delta = abs_delta;
+            }
+        }
+
+        // Add the best point to the new plot
+        new_plot._utime_.push(plot._utime_[best_index]);
+        new_plot.series_y.push(plot.series_y[best_index]);
+
+        if (plot.hovertext) {
+            new_plot.hovertext.push(plot.hovertext[best_index]);
+        }
+
+        // This is the last y for the next segment
+        last_y = plot.series_y[best_index];
+    }
+
+    console.debug(`Downsampled plot ${plot.title} from ${N} to ${new_plot._utime_.length} points`);
+
+    // Recursively downsample until we are under the max points
+    Plot_generate_downsampled_plots(new_plot, max_points);
+    plot.downsampled_plot = new_plot;
+}
+
+export function Plot_get_plot_to_use(
+    plot: Plot,
+    visible_duration: number,
+    max_points: number,
+): Plot {
+    const total_duration = plot._utime_[plot._utime_.length - 1] - plot._utime_[0];
+    const actual_visible_duration = Math.min(visible_duration, total_duration); // Avoid division by zero
+    const esimated_points_in_view =
+        (actual_visible_duration / total_duration) * plot._utime_.length;
+
+    console.debug(
+        `Plot ${plot.title} has total duration ${total_duration}s, visible duration ${actual_visible_duration}s, estimated points in view ${esimated_points_in_view}, max points ${max_points}`,
+    );
+
+    if (esimated_points_in_view > max_points) {
+        // Use downsampled plot
+        if (plot.downsampled_plot) {
+            return Plot_get_plot_to_use(plot.downsampled_plot, visible_duration, max_points);
+        } else {
+            console.warn(
+                `Plot ${plot.title} needs downsampling but no downsampled plot is available`,
+            );
+            return plot;
+        }
+    } else {
+        // Use full resolution plot
+        return plot;
+    }
 }

--- a/src/web/jdv/client/src/model/Plot.ts
+++ b/src/web/jdv/client/src/model/Plot.ts
@@ -26,6 +26,15 @@ export function Plot_get_hovertext_by_index(plot: Plot, index: number) {
     } else return null;
 }
 
+export function Plot_get_hovertext_by_range(plot: Plot, start_index: number, end_index: number) {
+    if (plot.hovertext) {
+        return plot.hovertext.slice(start_index, end_index);
+    } else if (plot.hovertext_map) {
+        const y_values = plot.series_y.slice(start_index, end_index);
+        return y_values.map((y_value) => plot.hovertext_map[y_value] ?? String(y_value));
+    } else return null;
+}
+
 export function Plot_generate_downsampled_plots(plot: Plot, max_points: number) {
     if (plot.downsampled_plot) {
         // Already downsampled

--- a/src/web/jdv/client/src/ui/App.tsx
+++ b/src/web/jdv/client/src/ui/App.tsx
@@ -112,7 +112,7 @@ export class App extends React.Component {
             </div>
         ) : null;
 
-        console.log("Rendering App with state:", this.state);
+        console.debug("Rendering App with state:", this.state);
 
         return (
             <div className="vertical flexbox maximized">

--- a/src/web/jdv/client/src/ui/App.tsx
+++ b/src/web/jdv/client/src/ui/App.tsx
@@ -50,7 +50,6 @@ interface State {
     tMin: number | null; // Minimum time for these logs
     tMax: number | null; // Maximum time for these logs
     visibleTimeRange: number[]; // Time range visible on plots and map
-    plotMode: string | null; // Mode for lines and/or markers (null means automatic depending on zoom level)
 
     // Modal busy indicator
     isBusy: boolean;
@@ -75,7 +74,6 @@ export class App extends React.Component {
             chosenLogs: [],
             chosenLogName: "",
             plots: [],
-            plotMode: null,
             layerSwitcherVisible: false,
             measureResultVisible: false,
             measureMagnitude: "",
@@ -142,7 +140,6 @@ export class App extends React.Component {
                         t={this.state.t}
                         delegate={this}
                         visibleTimeRange={this.state.visibleTimeRange}
-                        plotMode={this.state.plotMode}
                     />
 
                     <div id="mapPane" className="rounded clipped shadowed margin">
@@ -483,10 +480,6 @@ export class App extends React.Component {
 
     setPlots(plots: Plot[]) {
         this.setState({ plots });
-    }
-
-    setPlotMode(plotMode: string | null) {
-        this.setState({ plotMode });
     }
 
     setVisibleTimeRange(timeRange?: number[]) {

--- a/src/web/jdv/client/src/ui/Plots.css
+++ b/src/web/jdv/client/src/ui/Plots.css
@@ -20,3 +20,32 @@
         padding-right: 1em;
     }
 }
+
+#plotInfoDialog {
+    position: fixed;
+    top: 20%;
+    left: 50%;
+    transform: translate(-50%, -20%);
+    background-color: white;
+    border: 2pt solid black;
+    z-index: 1000;
+    padding: 16pt;
+    width: 400pt;
+    max-height: 80%;
+    box-shadow: 0 4pt 8pt rgba(0, 0, 0, 0.2);
+}
+
+#plotInfoDialog p {
+    text-align: justify;
+}
+
+#plotInfoDialogHeader {
+    width: 100%;
+    justify-content: stretch;
+    align-items: center;
+}
+
+#plotInfoDialog .text {
+    max-height: 60vh;
+    overflow-y: auto;
+}

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -18,7 +18,7 @@ import { ISODateToMicros, microsToDate } from "../tools/date";
 import {
     Plot,
     Plot_generate_downsampled_plots,
-    Plot_get_hovertext,
+    Plot_get_hovertext_by_range,
     Plot_get_plot_to_use,
 } from "../model/Plot";
 import { PlotProfiles } from "../model/PlotProfiles";
@@ -253,15 +253,27 @@ export function Plots(props: PlotsProps) {
                 visibleTimeRange ? visibleTimeRange[1] : Number.MAX_SAFE_INTEGER,
             );
 
-            const x_values = plot_to_use._utime_
-                .slice(start_index, end_index)
-                .map((t) => microsToDate(t));
-            const y_values = plot_to_use.series_y.slice(start_index, end_index);
-            const customdata = plot_to_use._utime_.slice(start_index, end_index);
+            // Add margin of 100% on each side if not at the edges
+            const total_points = plot_to_use._utime_.length;
+            const index_range = end_index - start_index;
+            const margin = index_range; // 100% margin
+
+            const adjusted_start_index = Math.max(0, start_index - margin);
+            const adjusted_end_index = Math.min(total_points, end_index + margin);
+
+            const utime = plot_to_use._utime_.slice(adjusted_start_index, adjusted_end_index);
+            const x_values = utime.map((t) => microsToDate(t));
+            const y_values = plot_to_use.series_y.slice(adjusted_start_index, adjusted_end_index);
+            const customdata = plot_to_use._utime_.slice(adjusted_start_index, adjusted_end_index);
+            const hovertext = Plot_get_hovertext_by_range(
+                plot_to_use,
+                adjusted_start_index,
+                adjusted_end_index,
+            );
 
             update.x.push(x_values);
             update.y.push(y_values);
-            update.hovertext.push(Plot_get_hovertext(plot_to_use));
+            update.hovertext.push(hovertext);
             update.customdata.push(customdata);
             update.mode.push(auto_mode);
         }

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -7,6 +7,7 @@ import {
     mdiDownload,
     mdiTrashCan,
     mdiClose,
+    mdiInformation,
 } from "@mdi/js";
 import Icon from "@mdi/react";
 
@@ -29,8 +30,6 @@ import { OpenPlotSet } from "./OpenPlotSet";
 import { DataTable } from "./DataTable";
 import { CustomAlert } from "../shared/CustomAlert";
 
-import { Switch } from "@mui/material";
-
 import "./Plots.css";
 
 export interface PlotsDelegate {
@@ -51,6 +50,7 @@ export interface PlotsProps {
 export function Plots(props: PlotsProps) {
     const [isPathSelectorDisplayed, setIsPathSelectorDisplayed] = React.useState(false);
     const [isOpenPlotSetDisplayed, setIsOpenPlotSetDisplayed] = React.useState(false);
+    const [isPlotInfoDisplayed, setIsPlotInfoDisplayed] = React.useState(false);
 
     function deletePlotClicked(plotIndex: number) {
         let { plots } = props;
@@ -382,11 +382,63 @@ export function Plots(props: PlotsProps) {
                 >
                     <Icon path={mdiTrashCan} size={1} style={{ verticalAlign: "middle" }}></Icon>
                 </button>
+                <button
+                    title="Plot Info"
+                    className="plotButton"
+                    onClick={() => {
+                        setIsPlotInfoDisplayed(!isPlotInfoDisplayed);
+                    }}
+                >
+                    <Icon path={mdiInformation} size={1} style={{ verticalAlign: "middle" }}></Icon>
+                </button>
             </div>
         );
     } else {
         actionBar = null;
     }
+
+    // Plot Info Dialog
+    const plotInfo = isPlotInfoDisplayed ? (
+        <div className="centered dialog" id="plotInfoDialog">
+            <div className="horizontal flexbox" id="plotInfoDialogHeader">
+                <h3 style={{ flex: 1 }}>Notes</h3>
+                <button className="plotButton" onClick={() => setIsPlotInfoDisplayed(false)}>
+                    <Icon path={mdiClose} size={1} style={{ verticalAlign: "middle" }}></Icon>
+                </button>
+            </div>
+            <div className="text" style={{ bottom: "10pt" }}>
+                <h4>Plot Downsampling</h4>
+                <p>
+                    The displayed plot data is recursively downsampled to improve performance when
+                    viewing large datasets. When zoomed out, fewer data points are shown to provide
+                    an overview of the data. As you zoom in, more data points are displayed to
+                    reveal finer details.
+                </p>
+                <h4>Full-Resolution Display</h4>
+                <p>
+                    When the plot is zoomed in far enough that all data points can be displayed
+                    without downsampling, the plot will switch to showing the full-resolution data.
+                    In this mode, both lines and markers are used to represent the data points,
+                    providing a clear view of the exact values.
+                </p>
+                <h4>Peak Preservation</h4>
+                <p>
+                    This downsampling process preserves significant features of the data, such as
+                    peaks and valleys, ensuring that important trends remain visible at all zoom
+                    levels. When downsampled, only lines are used to represent the data points.
+                </p>
+                <h4>Data Export</h4>
+                <p>
+                    The downsampling algorithm only affects the visual representation of the data
+                    and does not modify the underlying dataset. When exporting data as CSV, for
+                    example, the data is downsampled using a separate algorithm that ensures all
+                    data points within the selected time range are included in the export, at
+                    1-second intervals.
+                </p>
+            </div>
+        </div>
+    ) : null;
+    //////////////////////
 
     var pathSelector: JSX.Element | null;
     if (isPathSelectorDisplayed) {
@@ -456,7 +508,7 @@ export function Plots(props: PlotsProps) {
     return (
         <div className="plotcontainer rounded shadowed margin padding">
             <h2>Plots</h2>
-            {actionBar} {pathSelector}
+            {actionBar} {plotInfo} {pathSelector}
             <div className="horizontal flexbox">
                 <div id="plot" key="plot" className="plot">
                     {noSelectedSeriesMessage}

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -195,17 +195,22 @@ export function Plots(props: PlotsProps) {
 
             // Zooming into plots
             plot_div_element.on("plotly_relayout", function (eventdata: Plotly.PlotRelayoutEvent) {
+                console.debug("Relayout event:", eventdata);
+
                 // When autorange, zoom out to the whole set of points
                 if (eventdata["xaxis.autorange"]) {
                     props.delegate.setVisibleTimeRange(null);
                     return;
                 }
 
-                const t0 = ISODateToMicros(String(eventdata["xaxis.range[0]"])) ?? 0;
-                const t1 =
-                    ISODateToMicros(String(eventdata["xaxis.range[1]"])) ?? Number.MAX_SAFE_INTEGER;
+                if (eventdata["xaxis.range[0]"] && eventdata["xaxis.range[1]"]) {
+                    const t0 = ISODateToMicros(String(eventdata["xaxis.range[0]"])) ?? 0;
+                    const t1 =
+                        ISODateToMicros(String(eventdata["xaxis.range[1]"])) ??
+                        Number.MAX_SAFE_INTEGER;
 
-                props.delegate.setVisibleTimeRange([t0, t1]);
+                    props.delegate.setVisibleTimeRange([t0, t1]);
+                }
             });
         });
     };
@@ -216,6 +221,8 @@ export function Plots(props: PlotsProps) {
         console.debug("Refreshing plot data");
 
         const { plots, visibleTimeRange } = props;
+
+        console.debug(`Time range: ${visibleTimeRange}`);
 
         if (plots.length == 0) return;
 

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -245,7 +245,7 @@ export function Plots(props: PlotsProps) {
             const plot_to_use = Plot_get_plot_to_use(series, visible_duration, MAX_DATA_POINTS);
 
             // Use lines+markers for the full series, to indicate full resolution
-            const auto_mode = plot_to_use == series ? "lines+markers" : "lines";
+            const auto_mode = plot_to_use === series ? "lines+markers" : "lines";
 
             const [start_index, end_index] = getIndexRange(
                 plot_to_use,

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -17,6 +17,7 @@ import { bisect } from "../tools/bisect";
 import { ISODateToMicros, microsToDate } from "../tools/date";
 import {
     Plot,
+    Plot_calculate_yminmax_indices,
     Plot_generate_downsampled_plots,
     Plot_get_hovertext_by_range,
     Plot_get_plot_to_use,
@@ -226,7 +227,8 @@ export function Plots(props: PlotsProps) {
 
         if (plots.length == 0) return;
 
-        const MAX_DATA_POINTS = 400;
+        // Maximum number of points to show in the visible range (plus scrub margins).
+        const MAX_VISIBLE_POINTS = 600;
 
         let update: any = {
             x: [],
@@ -244,15 +246,28 @@ export function Plots(props: PlotsProps) {
         };
 
         for (let [plot_index, series] of plots.entries()) {
+            if (series._utime_.length == 0) {
+                // No data points
+                update.x.push([]);
+                update.y.push([]);
+                update.hovertext.push([]);
+                update.customdata.push([]);
+                update.mode.push("lines");
+                continue;
+            }
+
+            const series_total_duration =
+                series._utime_[series._utime_.length - 1] - series._utime_[0];
+
             const visible_duration = visibleTimeRange
                 ? visibleTimeRange[1] - visibleTimeRange[0]
-                : series._utime_[series._utime_.length - 1] - series._utime_[0];
+                : series_total_duration;
 
-            Plot_generate_downsampled_plots(series, MAX_DATA_POINTS);
-            const plot_to_use = Plot_get_plot_to_use(series, visible_duration, MAX_DATA_POINTS);
+            Plot_generate_downsampled_plots(series, MAX_VISIBLE_POINTS);
+            const plot_to_use = Plot_get_plot_to_use(series, visible_duration, MAX_VISIBLE_POINTS);
 
             // Use lines+markers for the full series, to indicate full resolution
-            const auto_mode = plot_to_use === series ? "lines+markers" : "lines";
+            const auto_mode = plot_to_use.is_full_series ? "lines+markers" : "lines";
 
             const [start_index, end_index] = getIndexRange(
                 plot_to_use,
@@ -277,6 +292,38 @@ export function Plots(props: PlotsProps) {
                 adjusted_start_index,
                 adjusted_end_index,
             );
+
+            // Add ymin and ymax padding points for better autoscaling
+            const insert_data_point = (src_index: number) => {
+                let dst_index: number;
+
+                if (src_index < adjusted_start_index) {
+                    dst_index = 0;
+                } else if (src_index >= adjusted_end_index) {
+                    dst_index = x_values.length;
+                } else {
+                    return;
+                }
+
+                console.log(
+                    "adjusted_start_index:",
+                    adjusted_start_index,
+                    "adjusted_end_index:",
+                    adjusted_end_index,
+                );
+                console.log("Inserting data point at src index", src_index, "dst index", dst_index);
+
+                x_values.splice(dst_index, 0, microsToDate(plot_to_use._utime_[src_index]));
+                y_values.splice(dst_index, 0, plot_to_use.series_y[src_index]);
+                customdata.splice(dst_index, 0, plot_to_use._utime_[src_index]);
+                hovertext?.splice(dst_index, 0, "");
+            };
+
+            console.log(plot_to_use.ymin_index, plot_to_use.ymax_index);
+
+            Plot_calculate_yminmax_indices(plot_to_use);
+            insert_data_point(plot_to_use.ymin_index);
+            insert_data_point(plot_to_use.ymax_index);
 
             update.x.push(x_values);
             update.y.push(y_values);

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -213,7 +213,7 @@ export function Plots(props: PlotsProps) {
     useEffect(createPlots, [props.chosenLogs, props.plots]);
 
     const refreshPlotData = () => {
-        console.log("Refreshing plot data");
+        console.debug("Refreshing plot data");
 
         const { plots, visibleTimeRange } = props;
 

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -261,7 +261,7 @@ export function Plots(props: PlotsProps) {
 
             update.x.push(x_values);
             update.y.push(y_values);
-            update.hovertext.push(Plot_get_hovertext(series));
+            update.hovertext.push(Plot_get_hovertext(plot_to_use));
             update.customdata.push(customdata);
             update.mode.push(auto_mode);
         }

--- a/src/web/jdv/client/src/ui/Plots.tsx
+++ b/src/web/jdv/client/src/ui/Plots.tsx
@@ -15,7 +15,12 @@ const Plotly = require("plotly.js-dist");
 import { downloadCSV } from "../tools/DownloadCSV";
 import { bisect } from "../tools/bisect";
 import { ISODateToMicros, microsToDate } from "../tools/date";
-import { Plot, Plot_get_hovertext } from "../model/Plot";
+import {
+    Plot,
+    Plot_generate_downsampled_plots,
+    Plot_get_hovertext,
+    Plot_get_plot_to_use,
+} from "../model/Plot";
 import { PlotProfiles } from "../model/PlotProfiles";
 
 import PathSelector from "./PathSelector";
@@ -29,7 +34,6 @@ import "./Plots.css";
 
 export interface PlotsDelegate {
     setPlots: (plots: Plot[]) => void;
-    setPlotMode: (plotMode: string | null) => void;
     setPaths: (paths: string[]) => void;
     setTime: (t_micros: number | null) => void;
     setVisibleTimeRange: (timeRange: number[] | null) => void;
@@ -41,13 +45,11 @@ export interface PlotsProps {
     plots: Plot[];
     t: number;
     visibleTimeRange: number[];
-    plotMode: string | null;
 }
 
 export function Plots(props: PlotsProps) {
     const [isPathSelectorDisplayed, setIsPathSelectorDisplayed] = React.useState(false);
     const [isOpenPlotSetDisplayed, setIsOpenPlotSetDisplayed] = React.useState(false);
-    const [shouldUseAllData, setShouldUseAllData] = React.useState(true);
 
     function deletePlotClicked(plotIndex: number) {
         let { plots } = props;
@@ -158,7 +160,7 @@ export function Plots(props: PlotsProps) {
                 xaxis: "x",
                 yaxis: yaxis,
                 hovertext: [],
-                type: "scatter",
+                type: "scattergl",
                 mode: "lines+markers",
             };
 
@@ -211,7 +213,9 @@ export function Plots(props: PlotsProps) {
     useEffect(createPlots, [props.chosenLogs, props.plots]);
 
     const refreshPlotData = () => {
-        const { plots, visibleTimeRange, plotMode } = props;
+        console.log("Refreshing plot data");
+
+        const { plots, visibleTimeRange } = props;
 
         if (plots.length == 0) return;
 
@@ -225,105 +229,46 @@ export function Plots(props: PlotsProps) {
             customdata: [],
         };
 
-        const getIndexRange = (series: Plot, t_start: number, t_end: number, increment: number) => {
-            const start_index_raw = bisect(series._utime_, (t) => t_start - t)?.index ?? 0;
-            const end_index_raw =
+        const getIndexRange = (series: Plot, t_start: number, t_end: number) => {
+            const start_index = bisect(series._utime_, (t) => t_start - t)?.index ?? 0;
+            const end_index =
                 bisect(series._utime_, (t) => t_end - t)?.index ?? series._utime_.length;
-            return [
-                start_index_raw - (start_index_raw % increment),
-                Math.min(
-                    end_index_raw - (end_index_raw % increment) + increment,
-                    series._utime_.length,
-                ),
-            ];
+            return [start_index, Math.min(end_index + 2, series._utime_.length)];
         };
 
         for (let [plot_index, series] of plots.entries()) {
-            if (shouldUseAllData) {
-                update.x.push(series._utime_.map((t_micros) => microsToDate(t_micros)));
-                update.y.push(series.series_y);
+            const visible_duration = visibleTimeRange
+                ? visibleTimeRange[1] - visibleTimeRange[0]
+                : series._utime_[series._utime_.length - 1] - series._utime_[0];
 
-                update.hovertext.push(Plot_get_hovertext(series));
-                update.customdata.push(series._utime_);
+            Plot_generate_downsampled_plots(series, MAX_DATA_POINTS);
+            const plot_to_use = Plot_get_plot_to_use(series, visible_duration, MAX_DATA_POINTS);
 
-                const auto_mode = "lines+markers";
-                update.mode.push(plotMode == "auto" ? auto_mode : plotMode);
-                continue;
-            }
+            // Use lines+markers for the full series, to indicate full resolution
+            const auto_mode = plot_to_use == series ? "lines+markers" : "lines";
 
-            // Plotly optimization:  only use the data within the plot time range, and only use a maximum number of data points.
-            // This greatly improves GUI responsiveness.
-            const utime = series._utime_;
-            const num_points = utime.length;
-            const min_utime = utime[0];
-            const max_utime = utime[num_points - 1];
-            const series_duration = max_utime - min_utime;
-            const visible_duration = Math.min(
-                visibleTimeRange[1] - visibleTimeRange[0],
-                series_duration,
+            const [start_index, end_index] = getIndexRange(
+                plot_to_use,
+                visibleTimeRange ? visibleTimeRange[0] : Number.MIN_SAFE_INTEGER,
+                visibleTimeRange ? visibleTimeRange[1] : Number.MAX_SAFE_INTEGER,
             );
 
-            const num_visible_points_estimate = Math.ceil(
-                (num_points * visible_duration) / series_duration,
-            );
-
-            const inside_index_step = Math.ceil(num_visible_points_estimate / MAX_DATA_POINTS);
-            const [inside_index_min, inside_index_max] = getIndexRange(
-                series,
-                visibleTimeRange[0],
-                visibleTimeRange[1],
-                inside_index_step,
-            );
-
-            const outside_index_step = inside_index_step * 4;
-            const outside_time_min = visibleTimeRange[0] - visible_duration;
-            const outside_time_max = visibleTimeRange[1] + visible_duration;
-            const [outside_index_min, outside_index_max] = getIndexRange(
-                series,
-                outside_time_min,
-                outside_time_max,
-                outside_index_step,
-            );
-
-            let x_values = [];
-            let customdata = [];
-            let y_values = [];
-
-            let data_index = outside_index_min;
-
-            while (data_index < outside_index_max) {
-                customdata.push(series._utime_[data_index]);
-                x_values.push(microsToDate(series._utime_[data_index]));
-                y_values.push(series.series_y[data_index]);
-
-                if (
-                    data_index + inside_index_step > inside_index_min &&
-                    data_index < inside_index_max
-                ) {
-                    data_index += inside_index_step;
-                } else {
-                    data_index += outside_index_step;
-                }
-            }
-
-            const auto_mode = inside_index_step > 1 ? "lines" : "lines+markers"; // Use lines and markers to indicate that we've got full resolution
+            const x_values = plot_to_use._utime_
+                .slice(start_index, end_index)
+                .map((t) => microsToDate(t));
+            const y_values = plot_to_use.series_y.slice(start_index, end_index);
+            const customdata = plot_to_use._utime_.slice(start_index, end_index);
 
             update.x.push(x_values);
             update.y.push(y_values);
             update.hovertext.push(Plot_get_hovertext(series));
             update.customdata.push(customdata);
-            update.mode.push(plotMode == "auto" ? auto_mode : plotMode);
+            update.mode.push(auto_mode);
         }
         Plotly.restyle("plot", update);
     };
 
-    useEffect(refreshPlotData, [
-        props.chosenLogs,
-        props.plots,
-        props.visibleTimeRange,
-        props.plotMode,
-        shouldUseAllData,
-    ]);
+    useEffect(refreshPlotData, [props.chosenLogs, props.plots, props.visibleTimeRange]);
 
     var actionBar: JSX.Element | null;
 
@@ -371,28 +316,6 @@ export function Plots(props: PlotsProps) {
                 >
                     <Icon path={mdiTrashCan} size={1} style={{ verticalAlign: "middle" }}></Icon>
                 </button>
-                <div>
-                    <label>Chart Style:</label>
-                    <select
-                        name="mode"
-                        id="modeSelect"
-                        onChange={(e) => {
-                            props.delegate.setPlotMode(e.target.value);
-                        }}
-                    >
-                        <option value="lines">Lines</option>
-                        <option value="markers">Markers</option>
-                        <option value="lines+markers">Lines & Markers</option>
-                        <option value="auto">Auto</option>
-                    </select>
-                </div>
-                <div>
-                    <label>Downsample Data:</label>
-                    <Switch
-                        checked={!shouldUseAllData}
-                        onChange={(_, checked) => setShouldUseAllData(!checked)}
-                    />
-                </div>
             </div>
         );
     } else {


### PR DESCRIPTION
Use recursive 2x downsampling and window the data to the visible time range for Plotly responsiveness.