### PR TITLE
task/turn-off-auto-apt-update-upgrade

### DIFF
--- a/debian/jaiabot-embedded.postinst
+++ b/debian/jaiabot-embedded.postinst
@@ -228,6 +228,12 @@ fi
 
 echo "jaiabot-embedded version: $(dpkg-query --show --showformat='${Version}' jaiabot-embedded)" > /etc/jaiabot/software_version
 
+if [ ! -f /etc/apt/apt.conf.d/99disable-auto-upgrades ]; then
+    echo 'APT::Periodic::Update-Package-Lists "0";' > /etc/apt/apt.conf.d/99disable-auto-upgrades
+    echo 'APT::Periodic::Unattended-Upgrade "0";' >> /etc/apt/apt.conf.d/99disable-auto-upgrades
+    systemctl disable --now apt-daily.timer apt-daily-upgrade.timer
+fi
+
 #DEBHELPER#
 
 exit 0

--- a/rootfs/customization/includes.chroot/etc/apt/apt-conf.d/99disable-auto-upgrades
+++ b/rootfs/customization/includes.chroot/etc/apt/apt-conf.d/99disable-auto-upgrades
@@ -1,0 +1,2 @@
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Unattended-Upgrade "0";

--- a/rootfs/customization/includes.chroot/etc/jaiabot/init/common-first-boot.yml
+++ b/rootfs/customization/includes.chroot/etc/jaiabot/init/common-first-boot.yml
@@ -56,6 +56,8 @@ runcmd:
   - /etc/jaiabot/init/install-hub-ssh-keys.sh
   # Format overlay to btrfs (if not already)
   - mkfs.btrfs -f $(blkid -L overlay) -L overlay
+  # Disable apt timers to prevent lock contention and background updates
+  - systemctl disable --now apt-daily.timer apt-daily-upgrade.timer
 
   
 # Reboot for overlay to take effect


### PR DESCRIPTION
## Description

Removing auto apt upgrades on image creation and on updating of jaia software.

Without this unattended upgrades would occur locking the user out of upgrading the jaia software.

Example:

```
Waiting for cache lock: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4019 (unattended-upgr)
```

## Tests
* Tested on bot 2 fleet 1