### PR TITLE
bug/2.y/task-packet-selection-crash

### DIFF
--- a/src/web/components/DepthMap3D/depth-map-3D.ts
+++ b/src/web/components/DepthMap3D/depth-map-3D.ts
@@ -30,7 +30,7 @@ export function buildDepthMap() {
     const bottomDivePackets = taskPackets
         .getIncludedTaskPackets()
         .map((taskPackets) => taskPackets.dive)
-        .filter((dive) => dive.bottom_dive);
+        .filter((dive) => dive?.bottom_dive);
 
     if (bottomDivePackets.length === 0) {
         return false;

--- a/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
+++ b/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useMemo, useState } from "react";
 import { JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 import { TaskPackets } from "../../data/task_packets/task-packets";
-import { TaskPacket, TaskType } from "../../types/protobuf-types";
+import { TaskPacket } from "../../types/protobuf-types";
 import { PanelActions, TaskPacketVisibility } from "../../types/context-types";
 import { MapFeatureTypes } from "../../types/openlayers-types";
 import { SelectedTaskPacket } from "../../types/jaia-system-types";
@@ -21,35 +21,27 @@ const DECIMALS = 2;
  * Displays task packet data to the operator in a tabular format
  */
 export default function TaskPacketPanel(props: Props) {
-    const [selectCount, setSelectCount] = useState(0);
+    const jaiaDispatch = useContext(JaiaDispatchContext);
+    const [prevSelected, setPrevSelected] = useState({ ...props.selectedTaskPacket });
 
-    useEffect(() => {
-        if (isNewTaskPacket(taskPacket, props.selectedTaskPacket)) {
-            setSelectCount(selectCount + 1);
-        }
-    });
-
-    /**
-     * Retrieves the data associated with the selected task packet
-     *
-     * @returns {TaskPacket}
-     */
     const getTaskPacket = () => {
-        const allTaskPackets = props.taskPackets
-            .getIncludedTaskPackets()
-            .concat(props.taskPackets.getExcludedTaskPackets());
-        for (const taskPacket of allTaskPackets) {
-            if (
-                taskPacket.start_time === props.selectedTaskPacket.startTime &&
-                taskPacket.bot_id === props.selectedTaskPacket.botID
-            ) {
-                return taskPacket;
-            }
-        }
+        return props.taskPackets.getTaskPacket(
+            props.selectedTaskPacket.botID,
+            props.selectedTaskPacket.startTime,
+        );
     };
 
-    // Call getTaskPacket on initial render and task packet selection changes
-    const taskPacket = useMemo(() => getTaskPacket(), [selectCount]);
+    const taskPacket = useMemo(() => getTaskPacket(), [prevSelected]);
+
+    useEffect(() => {
+        if (
+            prevSelected.botID !== props.selectedTaskPacket.botID ||
+            prevSelected.startTime !== props.selectedTaskPacket.startTime ||
+            prevSelected.type !== props.selectedTaskPacket.type
+        ) {
+            setPrevSelected({ ...props.selectedTaskPacket });
+        }
+    });
 
     /**
      * Gets the ID used by the server for querying task packet data
@@ -73,14 +65,6 @@ export default function TaskPacketPanel(props: Props) {
         return `${date.getHours()}:${date.getMinutes()} ${date.getMonth()}/${date.getDay()}/${date.getFullYear()}`;
     };
 
-    const jaiaDispatch = useContext(JaiaDispatchContext);
-
-    useEffect(() => {
-        return () => {
-            jaiaDispatch({ type: JaiaActions.CLOSED_TASK_PACKET_PANEL });
-        };
-    }, []);
-
     /**
      * Dispatches action to close panel
      *
@@ -98,8 +82,6 @@ export default function TaskPacketPanel(props: Props) {
 
     switch (props.selectedTaskPacket.type) {
         case MapFeatureTypes.DIVE:
-            // Handle transition between state and memo updates
-            // when switching between task packets
             if (!taskPacket.dive) {
                 return;
             }
@@ -130,9 +112,7 @@ export default function TaskPacketPanel(props: Props) {
             );
 
         case MapFeatureTypes.DRIFT:
-            // Handle transition between state and memo updates
-            // when switching between task packets
-            if (!taskPacket.drift) {
+            if (!taskPacket.drift.estimated_drift) {
                 return;
             }
             return (
@@ -194,22 +174,4 @@ function VisibilityButtons(props: Props) {
             <button onClick={() => handleClick(TaskPacketVisibility.INCLUDE)}>Include</button>
         </div>
     );
-}
-
-/**
- * Detects a change between the previously clicked task packet and the
- * latest clicked task packet
- *
- * @param {TaskPacket} taskPacket Task packet displaying in TaskPacketPanel
- * @param {SelectedTaskPacket} selectedTaskPacket Task packet clicked by operator
- * @returns {boolean} True if the operator clicked a new task packet, false otherwise
- */
-function isNewTaskPacket(taskPacket: TaskPacket, selectedTaskPacket: SelectedTaskPacket) {
-    if (
-        `${taskPacket.bot_id}_${taskPacket.start_time}` !==
-        `${selectedTaskPacket.botID}_${selectedTaskPacket.startTime}`
-    ) {
-        return true;
-    }
-    return false;
 }

--- a/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
+++ b/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
@@ -80,6 +80,8 @@ export default function TaskPacketPanel(props: Props) {
     const startTime = formatDate(taskPacket.start_time);
     const endTime = formatDate(taskPacket.end_time);
 
+    // We use the guards because props.selectedTaskPacket is one step
+    // ahead of the taskPacket variable when a task icon is clicked
     switch (props.selectedTaskPacket.type) {
         case MapFeatureTypes.DIVE:
             if (!taskPacket.dive) {
@@ -112,7 +114,7 @@ export default function TaskPacketPanel(props: Props) {
             );
 
         case MapFeatureTypes.DRIFT:
-            if (!taskPacket.drift.estimated_drift) {
+            if (!taskPacket.drift || !taskPacket.drift.estimated_drift) {
                 return;
             }
             return (

--- a/src/web/context/handlers/handler-utils.ts
+++ b/src/web/context/handlers/handler-utils.ts
@@ -5,6 +5,7 @@ import { rallyLayer } from "../../openlayers/layers/vector/rally-layer";
 import { diveLayer } from "../../openlayers/layers/vector/dive-layer";
 import { driftLayer } from "../../openlayers/layers/vector/drift-layer";
 import { contourLayer } from "../../openlayers/layers/vector/contour-layer";
+import { excludedTaskPacketsLayer } from "../../openlayers/layers/vector/excluded-task-packets-layer";
 
 /**
  * Repaints the map layers using the latest data
@@ -22,4 +23,5 @@ export function syncTaskLayers() {
     diveLayer.updateFeatures();
     driftLayer.updateFeatures();
     contourLayer.updateFeatures();
+    excludedTaskPacketsLayer.updateFeatures();
 }

--- a/src/web/context/handlers/panel-handlers.ts
+++ b/src/web/context/handlers/panel-handlers.ts
@@ -9,7 +9,7 @@ import { NodeTypes } from "../../types/jaia-system-types";
 import { MapFeatureTypes } from "../../types/openlayers-types";
 import { ButtonNames, JaiaAction, JaiaContextType, PanelActions } from "../../types/context-types";
 import { UNASSIGNED_ID } from "../../utils/constants";
-import { resetSelectedWaypoint } from "./waypoint-handlers";
+import { syncTaskLayers } from "./handler-utils";
 
 /**
  * Closes the Bot or Hub details panel
@@ -41,7 +41,7 @@ export function handleClosedWaypointPanel(mutableState: JaiaContextType, action:
         mission.getWaypoints()[jaiaGlobal.getSelectedWaypoint().waypointNum - 1] = action.waypoint;
         missionLayer.updateFeatures();
     }
-    resetSelectedWaypoint(mutableState);
+    jaiaGlobal.resetSelectedWaypoint();
     mutableState.visiblePanel = ButtonNames.NONE;
     return mutableState;
 }
@@ -54,20 +54,9 @@ export function handleClosedWaypointPanel(mutableState: JaiaContextType, action:
  * @returns {JaiaContextType} Updated mutable state object
  */
 export function handleClosedTaskPacketPanel(mutableState: JaiaContextType, action: JaiaAction) {
-    if (action.panelAction === PanelActions.CLOSE) {
-        mutableState.visiblePanel = ButtonNames.NONE;
-        // useEffect in TaskPacketPanel will be triggered to conduct remaining cleanup
-        return mutableState;
-    }
-
-    jaiaGlobal.setSelectedTaskPacket({
-        botID: UNASSIGNED_ID,
-        startTime: 0,
-        type: MapFeatureTypes.NONE,
-    });
-    diveLayer.updateFeatures();
-    driftLayer.updateFeatures();
-    excludedTaskPacketsLayer.updateFeatures();
+    mutableState.visiblePanel = ButtonNames.NONE;
+    jaiaGlobal.resetSelectedTaskPacket();
+    syncTaskLayers();
     return mutableState;
 }
 

--- a/src/web/context/handlers/selection-handlers.ts
+++ b/src/web/context/handlers/selection-handlers.ts
@@ -9,8 +9,7 @@ import { handleMapModeChange } from "../../openlayers/maps/map";
 import { MapModes } from "../../types/openlayers-types";
 import { JaiaContextType, JaiaAction, ButtonNames, ButtonTypes } from "../../types/context-types";
 import { UNASSIGNED_ID } from "../../utils/constants";
-import { syncOpenLayers } from "./handler-utils";
-import { resetSelectedWaypoint } from "./waypoint-handlers";
+import { syncOpenLayers, syncTaskLayers } from "./handler-utils";
 import { gridPlan, GridPlanningStates } from "../../data/survey_planner/grid-plan";
 
 /**
@@ -96,7 +95,12 @@ export function handleClickedButton(mutableState: JaiaContextType, action: JaiaA
 
     // Resets
     if (jaiaGlobal.getSelectedWaypoint().waypointNum !== UNASSIGNED_ID) {
-        resetSelectedWaypoint(mutableState);
+        jaiaGlobal.resetSelectedWaypoint();
+    }
+
+    if (jaiaGlobal.getSelectedTaskPacket().botID !== UNASSIGNED_ID) {
+        jaiaGlobal.resetSelectedTaskPacket();
+        syncTaskLayers();
     }
 
     if (gridPlan.getState() !== GridPlanningStates.ACCEPTING_MISSION_START_LOCATION) {

--- a/src/web/context/handlers/waypoint-handlers.ts
+++ b/src/web/context/handlers/waypoint-handlers.ts
@@ -216,17 +216,3 @@ export function handleChangeTaskPacketVisibility(
     });
     return mutableState;
 }
-
-/**
- * Sets the selected waypoint to its default settings
- *
- * @param {JaiaContextType} mutableState State object ref for making modifications
- * @returns {void}
- */
-export function resetSelectedWaypoint(mutableState: JaiaContextType) {
-    jaiaGlobal.setSelectedWaypoint({
-        waypointNum: UNASSIGNED_ID,
-        missionID: UNASSIGNED_ID,
-        isMoveable: false,
-    });
-}

--- a/src/web/data/jaia_global/jaia-global.ts
+++ b/src/web/data/jaia_global/jaia-global.ts
@@ -112,6 +112,22 @@ export class JaiaGlobal {
         this.controllingClientID = controllingClientID;
     }
 
+    resetSelectedWaypoint() {
+        this.selectedWaypoint = {
+            waypointNum: UNASSIGNED_ID,
+            missionID: UNASSIGNED_ID,
+            isMoveable: false,
+        };
+    }
+
+    resetSelectedTaskPacket() {
+        this.selectedTaskPacket = {
+            botID: UNASSIGNED_ID,
+            startTime: 0,
+            type: MapFeatureTypes.NONE,
+        };
+    }
+
     /**
      * Captures snapshot of JaiaGlobal
      *

--- a/src/web/data/task_packets/task-packets.ts
+++ b/src/web/data/task_packets/task-packets.ts
@@ -33,6 +33,15 @@ export class TaskPackets {
     setVersion(version: number) {
         this.version = version;
     }
+
+    getTaskPacket(botID: number, startTime: number) {
+        const allTaskPackets = this.includedTaskPackets.concat(this.excludedTaskPackets);
+        for (const taskPacket of allTaskPackets) {
+            if (taskPacket.start_time === startTime && taskPacket.bot_id === botID) {
+                return taskPacket;
+            }
+        }
+    }
 }
 
 export const taskPackets = new TaskPackets();

--- a/src/web/style/stylesheets/panel.less
+++ b/src/web/style/stylesheets/panel.less
@@ -5,7 +5,7 @@
     top: @panel-top;
     right: @panel-right;
     max-height: @panel-max-height;
-    z-index: jaia-panel-z-index;
+    z-index: @jaia-panel-z-index;
 
     background-color: @overlay-background;
     padding: 12px;


### PR DESCRIPTION
### Summary
Clicking between dives and drifts caused the JCC to crash. What https://github.com/jaiarobotics/jaiabot/pull/1434 did not account for is a dive packet also contains the drift property which caused the drift data to render before the useMemo update occurred. We now check one layer deeper for `estimated_drift` because a dive with a 0 second drift will not contain this property.

### Testing
Clicked between dives and drifts that previously caused the JCC to crash
