### PR TITLE
bug/mission-speeds-not-initialized

### DIFF
--- a/src/web/data/mission_set/mission-set.ts
+++ b/src/web/data/mission_set/mission-set.ts
@@ -78,6 +78,7 @@ export class MissionSet {
         const missionID = this.getNextMissionID();
         this.missions.set(missionID, mission);
         mission.setMissionID(missionID);
+        mission.setSpeeds(this.missionSpeeds);
         this.setMissionIDInEditMode(missionID);
         this.setNextMissionID(this.getNextMissionID() + 1);
         return missionID;

--- a/src/web/data/mission_set/mission.ts
+++ b/src/web/data/mission_set/mission.ts
@@ -18,7 +18,8 @@ export default class Mission {
     private bottomDepthSafetyParams: BottomDepthSafetyParams;
 
     constructor() {
-        // missionID assigned by missions singleton
+        // missionID assigned by missionSet singleton
+        // speeds set by missionSet singleton
         this.waypoints = [];
         this.repeats = 1;
     }


### PR DESCRIPTION
### Summary
The mission speeds did not get initialized for an individual mission if the speed slider was not changed. This pull request makes sure the speed object is passed on mission creation.