### PR TITLE
bug/srp-omitted-multiple-lanes-per-bot

### DIFF
--- a/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
+++ b/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
@@ -110,10 +110,10 @@ export default function TaskPacketPanel(props: Props) {
                         <div>{taskPacket.bot_id}</div>
                         <div className="line-break"></div>
                         <div className="label">Depth Achieved:</div>
-                        <div>{taskPacket.dive.depth_achieved.toFixed(DECIMALS)} m</div>
+                        <div>{taskPacket.dive.depth_achieved.toFixed(DECIMALS) ?? ""} m</div>
                         <div className="line-break"></div>
                         <div className="label">Dive Rate:</div>
-                        <div>{taskPacket.dive.dive_rate.toFixed(DECIMALS)} m/s</div>
+                        <div>{taskPacket.dive.dive_rate.toFixed(DECIMALS) ?? ""} m/s</div>
                         <div className="line-break"></div>
                         <div className="label">Bottom Dive:</div>
                         <div>{taskPacket.dive.bottom_dive ? "Yes" : "No"}</div>
@@ -142,18 +142,24 @@ export default function TaskPacketPanel(props: Props) {
                         <div>{taskPacket.bot_id}</div>
                         <div className="line-break"></div>
                         <div className="label">Duration:</div>
-                        <div>{taskPacket.drift.drift_duration.toFixed(DECIMALS)} s</div>
+                        <div>{taskPacket.drift.drift_duration.toFixed(DECIMALS) ?? ""} s</div>
                         <div className="line-break"></div>
                         <div className="label">Speed:</div>
-                        <div>{taskPacket.drift.estimated_drift.speed.toFixed(DECIMALS)} m/s</div>
+                        <div>
+                            {taskPacket.drift.estimated_drift.speed.toFixed(DECIMALS) ?? ""} m/s
+                        </div>
                         <div className="line-break"></div>
                         <div className="label">Direction:</div>
-                        <div>{taskPacket.drift.estimated_drift.heading.toFixed(DECIMALS)} deg</div>
+                        <div>
+                            {taskPacket.drift.estimated_drift.heading.toFixed(DECIMALS) ?? ""} deg
+                        </div>
                         <div className="line-break"></div>
                         <div className="label">
                             Sig Wave Height<br></br>Beta:
                         </div>
-                        <div>{taskPacket.drift.significant_wave_height.toFixed(DECIMALS)} m</div>
+                        <div>
+                            {taskPacket.drift.significant_wave_height.toFixed(DECIMALS) ?? ""} m
+                        </div>
                         <div className="line-break"></div>
                         <div className="label">Start Time:</div>
                         <div>{startTime}</div>

--- a/src/web/context/handlers/survey-handlers.ts
+++ b/src/web/context/handlers/survey-handlers.ts
@@ -9,7 +9,7 @@ import { missionLayer } from "../../openlayers/layers/vector/mission-layer";
 import { handleMapModeChange, map } from "../../openlayers/maps/map";
 import { MISSION_ENDPOINTS, UNASSIGNED_ID } from "../../utils/constants";
 import { MapModes } from "../../types/openlayers-types";
-import { BottomDepthSafetyParams, TaskType } from "../../types/protobuf-types";
+import { TaskType } from "../../types/protobuf-types";
 import { ButtonNames, JaiaAction, JaiaContextType } from "../../types/context-types";
 
 /**
@@ -73,22 +73,11 @@ export function handleChangeGridPlanningState(mutableState: JaiaContextType, act
                         waypoints[i].setTask(cloneDeep(gridPlan.getSurveyTask()));
                     }
                 }
-                if (gridPlan.getSRPTask().getType() === TaskType.CONSTANT_HEADING) {
-                    const constantHeadingParams = gridPlan
-                        .getSRPTask()
-                        .getConstantHeadingParameters();
-                    const bottomDepthSafetyParams: BottomDepthSafetyParams = {
-                        constant_heading: constantHeadingParams.constant_heading.toString(),
-                        constant_heading_speed:
-                            constantHeadingParams.constant_heading_speed.toString(),
-                        constant_heading_time:
-                            constantHeadingParams.constant_heading_time.toString(),
-                        safety_depth: gridPlan.getSRPTask().getSafetyDepth().toString(),
-                    };
-                    mission.setBottomDepthSafetyParams(bottomDepthSafetyParams);
-                }
             }
             gridPlan.fitLanesToBots();
+            if (gridPlan.getSRPTask().getType() === TaskType.CONSTANT_HEADING) {
+                gridPlan.applySafetyReturnParameters();
+            }
             missionSet.setMissions(cloneDeep(gridPlan.getMissions()));
             missionSet.setMissionIDInEditMode(UNASSIGNED_ID);
             missionSet.setNextMissionID(gridPlan.getMissions().size + 1);

--- a/src/web/data/survey_planner/grid-plan.ts
+++ b/src/web/data/survey_planner/grid-plan.ts
@@ -2,7 +2,7 @@ import cloneDeep from "lodash/cloneDeep";
 import Task from "../tasks/task";
 import Mission from "../mission_set/mission";
 import { UNASSIGNED_ID, MAX_WAYPOINTS } from "../../utils/constants";
-import { GeographicCoordinate } from "../../types/protobuf-types";
+import { BottomDepthSafetyParams, GeographicCoordinate } from "../../types/protobuf-types";
 
 export enum GridPlanningStates {
     ACCEPTING_MISSION_START_LOCATION = 1,
@@ -247,6 +247,25 @@ export class GridPlan {
             this.missions.set(baseMission.getMissionID(), baseMission);
             lanesCovered += updatedLanesPerBot;
             missionID += 1;
+        }
+    }
+
+    /**
+     * Attaches the safety return parameters to each mission
+     * in the grid plan mission set
+     *
+     * @returns {void}
+     */
+    applySafetyReturnParameters() {
+        for (const mission of this.missions.values()) {
+            const constantHeadingParams = this.srpTask.getConstantHeadingParameters();
+            const bottomDepthSafetyParams: BottomDepthSafetyParams = {
+                constant_heading: constantHeadingParams.constant_heading.toString(),
+                constant_heading_speed: constantHeadingParams.constant_heading_speed.toString(),
+                constant_heading_time: constantHeadingParams.constant_heading_time.toString(),
+                safety_depth: gridPlan.getSRPTask().getSafetyDepth().toString(),
+            };
+            mission.setBottomDepthSafetyParams(bottomDepthSafetyParams);
         }
     }
 


### PR DESCRIPTION
### Bug
When a Bot is assigned to multiple lanes in a survey, the SRP settings are ignored.

### Resolution
Apply the SRP settings to the missions after the adjustments are made to fit multiple lanes to a single Bot

### Testing
Set a minimum depth of 20m in sim for a survey that involves Bots assigned to multiple lanes. The Bot will SRP on the first waypoint.