### PR TITLE
task/enable-iridium-subscription-retries

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -209,7 +209,8 @@ if common.CommsMode.IRIDIUM in common.jaia_comms_modes:
     subscribes_block+='''subscribe {
     link: LINK_IRIDIUM
     subscribe_on_start: true
-    resubscribe: false
+    resubscribe: true
+    resubscribe_interval: 300
 }\n'''
         
     link_block += config.template_substitute(templates_dir+'/link_iridium.pb.cfg.in',

--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -210,7 +210,7 @@ if common.CommsMode.IRIDIUM in common.jaia_comms_modes:
     link: LINK_IRIDIUM
     subscribe_on_start: true
     resubscribe: true
-    resubscribe_interval: 300
+    resubscribe_interval: 270
 }\n'''
         
     link_block += config.template_substitute(templates_dir+'/link_iridium.pb.cfg.in',

--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -210,7 +210,7 @@ if common.CommsMode.IRIDIUM in common.jaia_comms_modes:
     link: LINK_IRIDIUM
     subscribe_on_start: true
     resubscribe: true
-    resubscribe_interval: 270
+    resubscribe_interval: 150
 }\n'''
         
     link_block += config.template_substitute(templates_dir+'/link_iridium.pb.cfg.in',


### PR DESCRIPTION
Enables subscription retry on a 2 1/2 minute interval. Currently, if the Bot tries to send a subscription message over Iridium and is unsuccessful, it will never retry. 