### PR TITLE
task/2.y/add-back-ghost-layer

### DIFF
--- a/src/web/components/BotDetails/BotDetails.tsx
+++ b/src/web/components/BotDetails/BotDetails.tsx
@@ -198,7 +198,7 @@ export default function BotDetails() {
                                         </tr>
                                         <tr>
                                             <td>Wi-Fi Link Quality</td>
-                                            <td>{bot.getWifiLinkQuality() ?? "" + "%"}</td>
+                                            <td>{bot.getWifiLinkQuality() ?? ""}</td>
                                         </tr>
                                         <tr>
                                             <td>Data Logging</td>

--- a/src/web/components/SettingsPanel/LayerSwitcherMenu/LayerSwitcherMenu.tsx
+++ b/src/web/components/SettingsPanel/LayerSwitcherMenu/LayerSwitcherMenu.tsx
@@ -217,6 +217,15 @@ export default function LayerSwitcherMenu() {
                         </div>
                         <div className="layer-container">
                             <Checkbox
+                                onClick={() => handleLayerClick(LayerTitles.GHOST_MISSION_LAYER)}
+                                checked={layerCheckedStates.get(LayerTitles.GHOST_MISSION_LAYER)}
+                                sx={getCheckboxStyle()}
+                                data-testid={`${LayerTitles.GHOST_MISSION_LAYER}-checkbox`}
+                            />
+                            <p>Ghost Missions</p>
+                        </div>
+                        <div className="layer-container">
+                            <Checkbox
                                 onClick={() => handleLayerClick(LayerTitles.RALLY_LAYER)}
                                 checked={layerCheckedStates.get(LayerTitles.RALLY_LAYER)}
                                 sx={getCheckboxStyle()}

--- a/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
+++ b/src/web/components/TaskPacketPanel/TaskPacketPanel.tsx
@@ -62,7 +62,9 @@ export default function TaskPacketPanel(props: Props) {
      */
     const formatDate = (timestamp: number) => {
         const date = new Date(timestamp / 1_000);
-        return `${date.getHours()}:${date.getMinutes()} ${date.getMonth()}/${date.getDay()}/${date.getFullYear()}`;
+        const minutes = date.getMinutes();
+        const minutesFormated = minutes < 10 ? `0${minutes}` : minutes;
+        return `${date.getHours()}:${minutesFormated} ${date.getMonth()}/${date.getDay()}/${date.getFullYear()}`;
     };
 
     /**

--- a/src/web/context/action-configs.ts
+++ b/src/web/context/action-configs.ts
@@ -93,7 +93,7 @@ export const actionConfigs: Map<JaiaActions, ActionConfig> = new Map([
     ],
     [
         JaiaActions.CHANGE_TASK_PACKET_VISIBILITY,
-        { handler: handleChangeTaskPacketVisibility, tracked: true },
+        { handler: handleChangeTaskPacketVisibility, tracked: false },
     ],
 
     // Survey Actions

--- a/src/web/context/handlers/command-handlers.ts
+++ b/src/web/context/handlers/command-handlers.ts
@@ -49,4 +49,6 @@ function handleSentMissionPlanCommand(mutableState: JaiaContextType, command: Co
     if (missionSet.getMissionIDInEditMode() === missionID) {
         missionSet.setMissionIDInEditMode(UNASSIGNED_ID);
     }
+    missionSet.deleteGhostMission(missionID);
+    console.log(missionSet.getGhostMissions());
 }

--- a/src/web/context/handlers/command-handlers.ts
+++ b/src/web/context/handlers/command-handlers.ts
@@ -5,6 +5,7 @@ import { BotModes } from "../../types/jaia-system-types";
 import { JaiaContextType, JaiaAction } from "../../types/context-types";
 import { Command, CommandType, MovementType } from "../../types/protobuf-types";
 import { UNASSIGNED_ID } from "../../utils/constants";
+import { ghostMissionLayer } from "../../openlayers/layers/vector/mission-layer";
 
 /**
  * Sets the mode of the Bot based on the command sent
@@ -49,6 +50,32 @@ function handleSentMissionPlanCommand(mutableState: JaiaContextType, command: Co
     if (missionSet.getMissionIDInEditMode() === missionID) {
         missionSet.setMissionIDInEditMode(UNASSIGNED_ID);
     }
-    missionSet.deleteGhostMission(missionID);
-    console.log(missionSet.getGhostMissions());
+
+    manageGhostLayer(command.bot_id, missionID);
+}
+
+/**
+ * Loops through the missions to update the ghost parameters
+ *
+ * @param {number} botID Used to reset ghost mission params
+ * @param {number} missionID Used to delete the ghost mission
+ * @returns {void}
+ */
+function manageGhostLayer(botID: number, missionID: number) {
+    for (const mission of missionSet.getMissions().values()) {
+        // Reset ghost parameters if Bot assignment changed
+        if (mission.getGhostParameters().botID === botID) {
+            mission.resetGhostParameters();
+        }
+    }
+
+    for (const mission of missionSet.getGhostMissions().values()) {
+        // Bot started new mission, remove ghost mission from map
+        if (mission.getGhostParameters().botID === botID) {
+            missionSet.deleteGhostMission(mission.getMissionID());
+        }
+    }
+
+    missionSet.getMission(missionID).setGhostParameters({ hasStarted: true, botID: botID });
+    ghostMissionLayer.updateFeatures();
 }

--- a/src/web/context/handlers/command-handlers.ts
+++ b/src/web/context/handlers/command-handlers.ts
@@ -62,15 +62,19 @@ function handleSentMissionPlanCommand(mutableState: JaiaContextType, command: Co
  * @returns {void}
  */
 function manageGhostLayer(botID: number, missionID: number) {
+    if (!missionSet.getMission(missionID)) {
+        return;
+    }
+
     for (const mission of missionSet.getMissions().values()) {
-        // Reset ghost parameters if Bot assignment changed
+        // Reset ghost parameters on previously assigned mission
         if (mission.getGhostParameters().botID === botID) {
             mission.resetGhostParameters();
         }
     }
 
     for (const mission of missionSet.getGhostMissions().values()) {
-        // Bot started new mission, remove ghost mission from map
+        // Bot started new mission, remove ghost mission
         if (mission.getGhostParameters().botID === botID) {
             missionSet.deleteGhostMission(mission.getMissionID());
         }

--- a/src/web/context/handlers/handler-utils.ts
+++ b/src/web/context/handlers/handler-utils.ts
@@ -6,6 +6,8 @@ import { diveLayer } from "../../openlayers/layers/vector/dive-layer";
 import { driftLayer } from "../../openlayers/layers/vector/drift-layer";
 import { contourLayer } from "../../openlayers/layers/vector/contour-layer";
 import { excludedTaskPacketsLayer } from "../../openlayers/layers/vector/excluded-task-packets-layer";
+import { bots } from "../../data/bots/bots";
+import { missionsManager } from "../../data/missions_manager/missions-manager";
 
 /**
  * Repaints the map layers using the latest data
@@ -24,4 +26,13 @@ export function syncTaskLayers() {
     driftLayer.updateFeatures();
     contourLayer.updateFeatures();
     excludedTaskPacketsLayer.updateFeatures();
+}
+
+export function isActiveMission(missionID: number) {
+    const botID = missionsManager.getBotID(missionID);
+    const bot = bots.getBot(botID);
+    if (bot && bot.getMissionStatus().targetWaypoint) {
+        return true;
+    }
+    return false;
 }

--- a/src/web/context/handlers/handler-utils.ts
+++ b/src/web/context/handlers/handler-utils.ts
@@ -1,6 +1,6 @@
 import { botLayer } from "../../openlayers/layers/vector/bot-layer";
 import { hubLayer } from "../../openlayers/layers/vector/hub-layer";
-import { missionLayer } from "../../openlayers/layers/vector/mission-layer";
+import { ghostMissionLayer, missionLayer } from "../../openlayers/layers/vector/mission-layer";
 import { rallyLayer } from "../../openlayers/layers/vector/rally-layer";
 import { diveLayer } from "../../openlayers/layers/vector/dive-layer";
 import { driftLayer } from "../../openlayers/layers/vector/drift-layer";
@@ -18,6 +18,7 @@ export function syncOpenLayers() {
     botLayer.updateFeatures();
     hubLayer.updateFeatures();
     missionLayer.updateFeatures();
+    ghostMissionLayer.updateFeatures();
     rallyLayer.updateFeatures();
 }
 
@@ -26,13 +27,4 @@ export function syncTaskLayers() {
     driftLayer.updateFeatures();
     contourLayer.updateFeatures();
     excludedTaskPacketsLayer.updateFeatures();
-}
-
-export function isActiveMission(missionID: number) {
-    const botID = missionsManager.getBotID(missionID);
-    const bot = bots.getBot(botID);
-    if (bot && bot.getMissionStatus().targetWaypoint) {
-        return true;
-    }
-    return false;
 }

--- a/src/web/context/handlers/mission-handlers.ts
+++ b/src/web/context/handlers/mission-handlers.ts
@@ -9,7 +9,7 @@ import { missionLayer } from "../../openlayers/layers/vector/mission-layer";
 import { NodeTypes } from "../../types/jaia-system-types";
 import { JaiaAction, JaiaContextType } from "../../types/context-types";
 import { UNASSIGNED_ID } from "../../utils/constants";
-import { syncOpenLayers } from "./handler-utils";
+import { isActiveMission, syncOpenLayers } from "./handler-utils";
 
 /**
  * Makes a call to add a new, default mission to the data model
@@ -40,10 +40,15 @@ export function handleAddMission(mutableState: JaiaContextType) {
  * @returns {JaiaContextType} Updated mutable state object
  */
 export function handleDeleteMission(mutableState: JaiaContextType, action: JaiaAction) {
+    if (isActiveMission(action.missionID)) {
+        missionSet.addGhostMission(action.missionID);
+    }
     missionSet.deleteMission(action.missionID);
     missionsManager.removeAssignment(action.missionID);
 
     missionLayer.updateFeatures();
+
+    console.log(missionSet.getGhostMissions());
 
     return mutableState;
 }
@@ -76,12 +81,19 @@ export function handleDuplicateMission(mutableState: JaiaContextType, action: Ja
  * @returns {JaiaContextType} Updated mutable state object
  */
 export function handleDeleteAllMissions(mutableState: JaiaContextType) {
+    for (const mission of missionSet.getMissions().values()) {
+        if (isActiveMission(mission.getMissionID())) {
+            missionSet.addGhostMission(mission.getMissionID());
+        }
+    }
     missionSet.deleteAllMissions();
     missionsManager.clear();
 
     mutableState.missionAccordionStates = {};
 
     missionLayer.updateFeatures();
+
+    console.log(missionSet.getGhostMissions());
 
     return mutableState;
 }

--- a/src/web/context/handlers/mission-handlers.ts
+++ b/src/web/context/handlers/mission-handlers.ts
@@ -5,11 +5,11 @@ import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
 import { missionSet } from "../../data/mission_set/mission-set";
 import { missionsManager } from "../../data/missions_manager/missions-manager";
 
-import { missionLayer } from "../../openlayers/layers/vector/mission-layer";
+import { ghostMissionLayer, missionLayer } from "../../openlayers/layers/vector/mission-layer";
 import { NodeTypes } from "../../types/jaia-system-types";
 import { JaiaAction, JaiaContextType } from "../../types/context-types";
 import { UNASSIGNED_ID } from "../../utils/constants";
-import { isActiveMission, syncOpenLayers } from "./handler-utils";
+import { syncOpenLayers } from "./handler-utils";
 
 /**
  * Makes a call to add a new, default mission to the data model
@@ -40,13 +40,14 @@ export function handleAddMission(mutableState: JaiaContextType) {
  * @returns {JaiaContextType} Updated mutable state object
  */
 export function handleDeleteMission(mutableState: JaiaContextType, action: JaiaAction) {
-    if (isActiveMission(action.missionID)) {
+    if (missionSet.getMission(action.missionID).getGhostParameters().hasStarted) {
         missionSet.addGhostMission(action.missionID);
     }
     missionSet.deleteMission(action.missionID);
     missionsManager.removeAssignment(action.missionID);
 
     missionLayer.updateFeatures();
+    ghostMissionLayer.updateFeatures();
 
     console.log(missionSet.getGhostMissions());
 
@@ -82,7 +83,7 @@ export function handleDuplicateMission(mutableState: JaiaContextType, action: Ja
  */
 export function handleDeleteAllMissions(mutableState: JaiaContextType) {
     for (const mission of missionSet.getMissions().values()) {
-        if (isActiveMission(mission.getMissionID())) {
+        if (mission.getGhostParameters().hasStarted) {
             missionSet.addGhostMission(mission.getMissionID());
         }
     }
@@ -92,8 +93,7 @@ export function handleDeleteAllMissions(mutableState: JaiaContextType) {
     mutableState.missionAccordionStates = {};
 
     missionLayer.updateFeatures();
-
-    console.log(missionSet.getGhostMissions());
+    ghostMissionLayer.updateFeatures();
 
     return mutableState;
 }

--- a/src/web/context/handlers/mission-handlers.ts
+++ b/src/web/context/handlers/mission-handlers.ts
@@ -48,9 +48,6 @@ export function handleDeleteMission(mutableState: JaiaContextType, action: JaiaA
 
     missionLayer.updateFeatures();
     ghostMissionLayer.updateFeatures();
-
-    console.log(missionSet.getGhostMissions());
-
     return mutableState;
 }
 

--- a/src/web/context/handlers/rally-point-handlers.ts
+++ b/src/web/context/handlers/rally-point-handlers.ts
@@ -1,6 +1,7 @@
 import { missionsManager } from "../../data/missions_manager/missions-manager";
 import RallyPoint from "../../data/rally_points/rally-point";
 import { rallyPoints } from "../../data/rally_points/rally-points";
+import { missionSet } from "../../data/mission_set/mission-set";
 import { rallyLayer } from "../../openlayers/layers/vector/rally-layer";
 import { handleMapModeChange } from "../../openlayers/maps/map";
 import { MapModes } from "../../types/openlayers-types";
@@ -47,6 +48,11 @@ export function handleDeleteRallyPoint(mutableState: JaiaContextType) {
  */
 export function handleSendRallyMission(mutableState: JaiaContextType) {
     missionsManager.unassignAll();
+    missionSet.deleteAllGhostMissions();
+
+    for (const mission of missionSet.getMissions().values()) {
+        mission.resetGhostParameters();
+    }
     rallyPoints.setSelectedRallyPointID(UNASSIGNED_ID);
     mutableState.visiblePanel = ButtonNames.NONE;
 

--- a/src/web/context/handlers/selection-handlers.ts
+++ b/src/web/context/handlers/selection-handlers.ts
@@ -120,12 +120,16 @@ export function handleClickedButton(mutableState: JaiaContextType, action: JaiaA
  * @returns {JaiaContextType} Updated mutable state object
  */
 export function handleClickedWaypoint(mutableState: JaiaContextType, action: JaiaAction) {
-    jaiaGlobal.setSelectedWaypoint(action.clickedWaypoint);
-
-    mutableState.visiblePanel = ButtonNames.WAYPOINT_PANEL;
-
+    if (!missionSet.getMission(action.clickedWaypoint.missionID)) {
+        jaiaGlobal.resetSelectedWaypoint();
+        if (mutableState.visiblePanel === ButtonNames.WAYPOINT_PANEL) {
+            mutableState.visiblePanel = ButtonNames.NONE;
+        }
+    } else {
+        jaiaGlobal.setSelectedWaypoint(action.clickedWaypoint);
+        mutableState.visiblePanel = ButtonNames.WAYPOINT_PANEL;
+    }
     missionLayer.updateFeatures();
-
     return mutableState;
 }
 

--- a/src/web/context/handlers/survey-handlers.ts
+++ b/src/web/context/handlers/survey-handlers.ts
@@ -11,6 +11,7 @@ import { MISSION_ENDPOINTS, UNASSIGNED_ID } from "../../utils/constants";
 import { MapModes } from "../../types/openlayers-types";
 import { TaskType } from "../../types/protobuf-types";
 import { ButtonNames, JaiaAction, JaiaContextType } from "../../types/context-types";
+import { isActiveMission } from "./handler-utils";
 
 /**
  * Makes map and grid plan changes based on survey state change
@@ -75,9 +76,19 @@ export function handleChangeGridPlanningState(mutableState: JaiaContextType, act
                 }
             }
             gridPlan.fitLanesToBots();
+
             if (gridPlan.getSRPTask().getType() === TaskType.CONSTANT_HEADING) {
                 gridPlan.applySafetyReturnParameters();
             }
+
+            for (const mission of missionSet.getMissions().values()) {
+                if (isActiveMission(mission.getMissionID())) {
+                    missionSet.addGhostMission(mission.getMissionID());
+                } else {
+                    missionSet.deleteGhostMission(mission.getMissionID());
+                }
+            }
+
             missionSet.setMissions(cloneDeep(gridPlan.getMissions()));
             missionSet.setMissionIDInEditMode(UNASSIGNED_ID);
             missionSet.setNextMissionID(gridPlan.getMissions().size + 1);
@@ -88,6 +99,7 @@ export function handleChangeGridPlanningState(mutableState: JaiaContextType, act
             handleMapModeChange(MapModes.DEFAULT);
             mutableState.visiblePanel = ButtonNames.NONE;
             missionLayer.updateFeatures();
+            console.log(missionSet.getGhostMissions());
             break;
     }
     return mutableState;

--- a/src/web/context/handlers/survey-handlers.ts
+++ b/src/web/context/handlers/survey-handlers.ts
@@ -5,13 +5,12 @@ import { missionSet } from "../../data/mission_set/mission-set";
 import { missionsManager } from "../../data/missions_manager/missions-manager";
 import { gridPlan, GridPlanningStates } from "../../data/survey_planner/grid-plan";
 import { gridLayer } from "../../openlayers/layers/vector/grid-layer";
-import { missionLayer } from "../../openlayers/layers/vector/mission-layer";
+import { ghostMissionLayer, missionLayer } from "../../openlayers/layers/vector/mission-layer";
 import { handleMapModeChange, map } from "../../openlayers/maps/map";
 import { MISSION_ENDPOINTS, UNASSIGNED_ID } from "../../utils/constants";
 import { MapModes } from "../../types/openlayers-types";
 import { TaskType } from "../../types/protobuf-types";
 import { ButtonNames, JaiaAction, JaiaContextType } from "../../types/context-types";
-import { isActiveMission } from "./handler-utils";
 
 /**
  * Makes map and grid plan changes based on survey state change
@@ -82,7 +81,7 @@ export function handleChangeGridPlanningState(mutableState: JaiaContextType, act
             }
 
             for (const mission of missionSet.getMissions().values()) {
-                if (isActiveMission(mission.getMissionID())) {
+                if (mission.getGhostParameters().hasStarted) {
                     missionSet.addGhostMission(mission.getMissionID());
                 } else {
                     missionSet.deleteGhostMission(mission.getMissionID());
@@ -99,6 +98,7 @@ export function handleChangeGridPlanningState(mutableState: JaiaContextType, act
             handleMapModeChange(MapModes.DEFAULT);
             mutableState.visiblePanel = ButtonNames.NONE;
             missionLayer.updateFeatures();
+            ghostMissionLayer.updateFeatures();
             console.log(missionSet.getGhostMissions());
             break;
     }

--- a/src/web/context/handlers/survey-handlers.ts
+++ b/src/web/context/handlers/survey-handlers.ts
@@ -99,7 +99,6 @@ export function handleChangeGridPlanningState(mutableState: JaiaContextType, act
             mutableState.visiblePanel = ButtonNames.NONE;
             missionLayer.updateFeatures();
             ghostMissionLayer.updateFeatures();
-            console.log(missionSet.getGhostMissions());
             break;
     }
     return mutableState;

--- a/src/web/data/mission_set/mission-set.ts
+++ b/src/web/data/mission_set/mission-set.ts
@@ -18,6 +18,7 @@ export interface MissionSetSnapshot {
 
 export class MissionSet {
     private missions: Map<number, Mission>;
+    private ghostMissions: Map<number, Mission>;
     private nextMissionID: number;
     private missionIDInEditMode: number;
     private missionSpeeds: Speeds;
@@ -25,6 +26,7 @@ export class MissionSet {
 
     constructor() {
         this.missions = new Map<number, Mission>();
+        this.ghostMissions = new Map<number, Mission>();
         this.nextMissionID = 1;
         this.missionIDInEditMode = UNASSIGNED_ID;
         this.missionSpeeds = { transit: 2, stationkeep_outer: 2 };
@@ -37,6 +39,14 @@ export class MissionSet {
 
     setMissions(missions: Map<number, Mission>) {
         this.missions = missions;
+    }
+
+    getGhostMissions() {
+        return this.ghostMissions;
+    }
+
+    setGhostMissions(missions: Map<number, Mission>) {
+        this.ghostMissions = missions;
     }
 
     getNextMissionID() {
@@ -107,6 +117,14 @@ export class MissionSet {
         this.missions.clear();
         this.setMissionIDInEditMode(UNASSIGNED_ID);
         this.setNextMissionID(1);
+    }
+
+    addGhostMission(missionID: number) {
+        this.ghostMissions.set(missionID, cloneDeep(this.missions.get(missionID)));
+    }
+
+    deleteGhostMission(missionID: number) {
+        this.ghostMissions.delete(missionID);
     }
 
     /**

--- a/src/web/data/mission_set/mission-set.ts
+++ b/src/web/data/mission_set/mission-set.ts
@@ -127,6 +127,10 @@ export class MissionSet {
         this.ghostMissions.delete(missionID);
     }
 
+    deleteAllGhostMissions() {
+        this.ghostMissions.clear();
+    }
+
     /**
      * Captures a snapshot of the MissionSet
      *

--- a/src/web/data/mission_set/mission.ts
+++ b/src/web/data/mission_set/mission.ts
@@ -9,6 +9,8 @@ import {
 } from "../../types/protobuf-types";
 import Waypoint from "../waypoints/waypoint";
 import Task from "../tasks/task";
+import { GhostParameters } from "../../types/jaia-system-types";
+import { UNASSIGNED_ID } from "../../utils/constants";
 
 export default class Mission {
     private missionID: number;
@@ -16,12 +18,14 @@ export default class Mission {
     private speeds: Speeds;
     private repeats: number;
     private bottomDepthSafetyParams: BottomDepthSafetyParams;
+    private ghostParameters: GhostParameters;
 
     constructor() {
         // missionID assigned by missionSet singleton
         // speeds set by missionSet singleton
         this.waypoints = [];
         this.repeats = 1;
+        this.ghostParameters = { hasStarted: false, botID: UNASSIGNED_ID };
     }
 
     getMissionID() {
@@ -63,6 +67,18 @@ export default class Mission {
 
     setBottomDepthSafetyParams(bottomDepthSafetyParams: BottomDepthSafetyParams) {
         this.bottomDepthSafetyParams = bottomDepthSafetyParams;
+    }
+
+    getGhostParameters() {
+        return this.ghostParameters;
+    }
+
+    setGhostParameters(ghostParameters: GhostParameters) {
+        this.ghostParameters = ghostParameters;
+    }
+
+    resetGhostParameters() {
+        this.ghostParameters = { hasStarted: false, botID: UNASSIGNED_ID };
     }
 
     getWaypoint(waypointNum: number) {

--- a/src/web/jcc/App.less
+++ b/src/web/jcc/App.less
@@ -47,15 +47,15 @@ body {
     visibility: hidden;
 
     width: 300px;
-    padding: 30px;
-    border-radius: 3px;
+    padding: 18px 0;
+    border: 1px solid #000;
     background-color: @error-color;
     box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
 
     display: flex;
     justify-content: center;
 
-    top: 20%;
+    bottom: 30px;
     left: 50%;
     transform: translate(-50%, 0);
 

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -60,7 +60,7 @@ export default function App() {
                 <TakeControl />
             </JaiaContextProvider>
             <div id="connection-warning">Connection to Hub Dropped</div>
-            <div id="congestion-warning">Network Congestion Warning</div>
+            <div id="congestion-warning">Slow Hub WiFi Speeds</div>
         </div>
     );
 }

--- a/src/web/jcc/index.tsx
+++ b/src/web/jcc/index.tsx
@@ -7,7 +7,7 @@ import { taskPackets } from "../data/task_packets/task-packets";
 import { PortalBotStatus, PortalHubStatus } from "../shared/PortalStatus";
 import { botLayer } from "../openlayers/layers/vector/bot-layer";
 import { hubLayer } from "../openlayers/layers/vector/hub-layer";
-import { missionLayer } from "../openlayers/layers/vector/mission-layer";
+import { ghostMissionLayer, missionLayer } from "../openlayers/layers/vector/mission-layer";
 import { diveLayer } from "../openlayers/layers/vector/dive-layer";
 import { driftLayer } from "../openlayers/layers/vector/drift-layer";
 import { contourLayer } from "../openlayers/layers/vector/contour-layer";
@@ -152,6 +152,7 @@ function updateOpenLayers() {
     botLayer.updateFeatures();
     hubLayer.updateFeatures();
     missionLayer.updateFeatures();
+    ghostMissionLayer.updateFeatures();
     hubCommsLayer.updateFeatures();
 }
 

--- a/src/web/openlayers/features/waypoint-feature.ts
+++ b/src/web/openlayers/features/waypoint-feature.ts
@@ -6,6 +6,7 @@ import { Fill, Icon, Style, Stroke, Text } from "ol/style";
 
 import { view } from "../views/view";
 import Task from "../../data/tasks/task";
+import Mission from "../../data/mission_set/mission";
 import { bots } from "../../data/bots/bots";
 import { missionSet } from "../../data/mission_set/mission-set";
 import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
@@ -33,13 +34,13 @@ import missionFlagIcon from "../../style/icons/mission-flag.svg";
  *
  * @param {GeographicCoordinate} location Lat/lon of waypoint
  * @param {number} waypointNum Positon of waypoint in mission sequence (to be displayed on icon)
- * @param {number} missionID Used to determine color of waypoint
+ * @param {Mission} mission Used to determine color of waypoint
  * @returns {Feature} Waypoint icon to display on map
  */
 export function generateWaypointFeature(
     location: GeographicCoordinate,
     waypointNum: number,
-    missionID: number,
+    mission: Mission,
 ) {
     if (!location) {
         return new Feature();
@@ -52,8 +53,8 @@ export function generateWaypointFeature(
 
     feature.set("type", MapFeatureTypes.WAYPOINT);
     feature.set("waypointNum", waypointNum);
-    feature.set("missionID", missionID);
-    feature.setStyle(generateWaypointStyle(waypointNum, missionID));
+    feature.set("missionID", mission.getMissionID());
+    feature.setStyle(generateWaypointStyle(waypointNum, mission));
     return feature;
 }
 
@@ -61,17 +62,17 @@ export function generateWaypointFeature(
  * Creates the style to be applied to a waypoint icon on the map
  *
  * @param {number} waypointNum Positon of waypoint in mission sequence (to be displayed on icon)
- * @param {number} missionID Used to determine color of waypoint
+ * @param {Mission} mission Used to determine color of waypoint
  * @returns {Style} Style to be applied to a waypoint feature
  */
-function generateWaypointStyle(waypointNum: number, missionID: number) {
-    const task = missionSet.getMission(missionID).getWaypoint(waypointNum).getTask();
+function generateWaypointStyle(waypointNum: number, mission: Mission) {
+    const task = mission.getWaypoint(waypointNum).getTask();
 
     return new Style({
         image: new Icon({
             src: getWaypointSrc(task),
             anchor: [0.5, 1],
-            color: getWaypointColor(missionID, waypointNum),
+            color: getWaypointColor(mission, waypointNum),
         }),
         stroke: new Stroke({
             color: OpenLayersColors.OUTLINE,
@@ -85,7 +86,7 @@ function generateWaypointStyle(waypointNum: number, missionID: number) {
             }),
             offsetY: -15,
         }),
-        zIndex: getWaypointZIndex(missionID, waypointNum),
+        zIndex: getWaypointZIndex(mission, waypointNum),
     });
 }
 
@@ -95,14 +96,14 @@ function generateWaypointStyle(waypointNum: number, missionID: number) {
  * @param {GeographicCoordinate} startLocation Lat/lon of previous waypoint
  * @param {GeographicCoordinate} endLocation  Lat/lon of next waypoint
  * @param {LineType} lineType Solid or dashed line
- * @param {number} missionID Used to determine color of the line segment
+ * @param {Mission} mission Used to determine color of the line segment
  * @returns {Feature} Line segment that connects two waypoints
  */
 export function generateWaypointLineFeature(
     startLocation: GeographicCoordinate,
     endLocation: GeographicCoordinate,
     lineType: LineType,
-    missionID: number,
+    mission: Mission,
 ) {
     if (!startLocation || !endLocation) {
         return new Feature();
@@ -116,9 +117,7 @@ export function generateWaypointLineFeature(
     const feature = new Feature({
         geometry: new LineString([startCoordinate, endCoordinate]),
     });
-    feature.setStyle(
-        generateWaypointLineStyle(startCoordinate, endCoordinate, lineType, missionID),
-    );
+    feature.setStyle(generateWaypointLineStyle(startCoordinate, endCoordinate, lineType, mission));
     return feature;
 }
 
@@ -128,14 +127,14 @@ export function generateWaypointLineFeature(
  * @param {GeographicCoordinate} startCoordinate Used in midpoint calculation for arrow
  * @param {GeographicCoordinate} endCoordinate Used in midpoint calculation for arrow
  * @param {LineType} lineType Solid or dashed line
- * @param {number} missionID Used to determine color of the line segment
+ * @param {Mission} mission Used to determine color of the line segment
  * @returns {Style[]} Array of styles applied to line segment connecting waypoints
  */
 function generateWaypointLineStyle(
     startCoordinate: Coordinate,
     endCoordinate: Coordinate,
     lineType: LineType,
-    missionID: number,
+    mission: Mission,
 ) {
     const lineDash = lineType === LineType.DASHED ? [6, 12] : null;
     const underlayStyle = new Style({
@@ -144,16 +143,16 @@ function generateWaypointLineStyle(
             color: OpenLayersColors.OUTLINE,
             lineDash: lineDash,
         }),
-        zIndex: getWaypointZIndex(missionID),
+        zIndex: getWaypointZIndex(mission),
     });
 
     const overlayStyle = new Style({
         stroke: new Stroke({
             width: 2,
-            color: getWaypointColor(missionID),
+            color: getWaypointColor(mission),
             lineDash: lineDash,
         }),
-        zIndex: getWaypointZIndex(missionID),
+        zIndex: getWaypointZIndex(mission),
     });
 
     const dx = endCoordinate[0] - startCoordinate[0];
@@ -169,9 +168,9 @@ function generateWaypointLineStyle(
             rotateWithView: true,
             // OpenLayers rotates clockwise, while atan2 calculates a counter-clockwise rotation (as is customary in trig)
             rotation: -rotation,
-            color: getWaypointColor(missionID),
+            color: getWaypointColor(mission),
         }),
-        zIndex: getWaypointZIndex(missionID),
+        zIndex: getWaypointZIndex(mission),
     });
 
     return [underlayStyle, overlayStyle, midpointStyle];
@@ -180,41 +179,41 @@ function generateWaypointLineStyle(
 /** Creates the flag positioned above the first waypoint of each mission
  *
  * @param {GeographicCoordinate} location Used to position the flag
- * @param {number} missionID Used to style the flag
+ * @param {Mission} mission Used to style the flag
  * @returns {Feature} Flag located above first waypoint of a mission
  */
-export function generateMissionFlagFeature(location: GeographicCoordinate, missionID: number) {
+export function generateMissionFlagFeature(location: GeographicCoordinate, mission: Mission) {
     const coordinate: Coordinate = [location.lon, location.lat];
     const feature = new Feature({
         geometry: new Point(fromLonLat(coordinate, view.getProjection())),
     });
-    feature.setStyle(generateMissionFlagStyle(missionID));
+    feature.setStyle(generateMissionFlagStyle(mission));
     return feature;
 }
 
 /**
  * Styles the flag above the first waypoint of a mission
  *
- * @param {number} missionID Used to distinguish missions + get task type
+ * @param {number} mission Used to distinguish missions + get task type
  * @returns {Style} Style to be applied to the mission flag feature
  */
-function generateMissionFlagStyle(missionID: number) {
-    const taskType = missionSet.getMission(missionID).getWaypoint(1).getTask().getType();
+function generateMissionFlagStyle(mission: Mission) {
+    const taskType = mission.getWaypoint(1).getTask().getType();
 
     return new Style({
         image: new Icon({
             src: missionFlagIcon,
-            color: getWaypointColor(missionID),
+            color: getWaypointColor(mission),
             anchor: taskType === TaskType.NONE ? [0.21, 1.62] : [0.21, 1.92],
         }),
         text: new Text({
-            text: `M${missionID}`,
+            text: `M${mission.getMissionID()}`,
             font: "12pt sans-serif",
             fill: new Fill({ color: "black" }),
             offsetY: taskType === TaskType.NONE ? -61.2175 : -76.75,
             offsetX: 20,
         }),
-        zIndex: getWaypointZIndex(missionID),
+        zIndex: getWaypointZIndex(mission),
     });
 }
 
@@ -248,20 +247,22 @@ export function getWaypointSrc(task: Task) {
 /**
  * Supplies the color for a waypoint based on edit and selection states
  *
- * @param {number} missionID Used to determine color of the line segment
+ * @param {Mission} mission Used to determine color of the line segment
  * @param {number} waypointNum Makes color change for target waypoint
  * @returns {OpenLayersColors} Color to be applied to waypoint
  */
-function getWaypointColor(missionID: number, waypointNum?: number) {
-    if (waypointNum && shouldColorTargetWaypoint(missionID, waypointNum)) {
-        return OpenLayersColors.TARGET;
+function getWaypointColor(mission: Mission, waypointNum?: number) {
+    if (mission.getGhostParameters().hasStarted) {
+        if (waypointNum && shouldColorTargetWaypoint(mission, waypointNum)) {
+            return OpenLayersColors.TARGET;
+        }
+    } else {
+        if (mission.getMissionID() === missionSet.getMissionIDInEditMode()) {
+            return OpenLayersColors.EDIT;
+        }
     }
 
-    if (missionID === missionSet.getMissionIDInEditMode()) {
-        return OpenLayersColors.EDIT;
-    }
-
-    if (isAssignedToSelectedBot(missionID)) {
+    if (isAssignedToSelectedBot(mission)) {
         return OpenLayersColors.SELECT;
     }
 
@@ -271,7 +272,7 @@ function getWaypointColor(missionID: number, waypointNum?: number) {
 /**
  * Supplies the zIndex for waypoints and lines based on edit mode
  *
- * @param {number} missionID Used to determine zIndex for waypoints and lines
+ * @param {Mission} mission Used to determine zIndex for waypoints and lines
  * @param {number} waypointNum Used to determine zIndex for waypoints, leave unassigned for lines
  * @returns {number} zIndex to be applied to waypoint and lines
  *
@@ -279,22 +280,22 @@ function getWaypointColor(missionID: number, waypointNum?: number) {
  * Less than 1000 missions
  * Less than 100 waypoints per mission
  */
-function getWaypointZIndex(missionID: number, waypointNum?: number) {
+function getWaypointZIndex(mission: Mission, waypointNum?: number) {
     let waypointZIndex = 0;
     // Provide proper mission stacking
-    if (missionID === missionSet.getMissionIDInEditMode()) {
+    if (mission.getMissionID() === missionSet.getMissionIDInEditMode()) {
         waypointZIndex = 1100;
-    } else if (isAssignedToSelectedBot(missionID)) {
+    } else if (isAssignedToSelectedBot(mission)) {
         waypointZIndex = 1000;
     } else {
-        waypointZIndex = missionID;
+        waypointZIndex = mission.getMissionID();
     }
     // Provide proper waypoint stacking
     if (waypointNum) {
         waypointZIndex = waypointZIndex + waypointNum;
         if (
             waypointNum === jaiaGlobal.getSelectedWaypoint().waypointNum &&
-            missionID === missionSet.getMissionIDInEditMode()
+            mission.getMissionID() === missionSet.getMissionIDInEditMode()
         ) {
             waypointZIndex = waypointZIndex + 100;
         }
@@ -307,26 +308,44 @@ function getWaypointZIndex(missionID: number, waypointNum?: number) {
  * Checks the bot and mission conditions to determine if the waypoint needs
  * the TARGET color applied
  *
- * @param {number} missionID Identifies the mission containing the waypoint
+ * @param {Mission} mission Containing the waypoint
  * @param waypointNum Identifies the waypoint to be rendered
  * @returns {boolean} True if the target waypoint needs the TARGET color
  */
-function shouldColorTargetWaypoint(missionID: number, waypointNum: number) {
-    if (missionSet.getMissionIDInEditMode() === missionID) {
+function shouldColorTargetWaypoint(mission: Mission, waypointNum: number) {
+    if (mission.getGhostParameters().hasStarted) {
+        const ghostBotID = mission.getGhostParameters().botID;
+        return confirmTargetWaypoint(ghostBotID, waypointNum);
+    }
+
+    if (missionSet.getMissionIDInEditMode() === mission.getMissionID()) {
         return false;
     }
 
-    const botID = missionsManager.getBotID(missionID);
+    const botID = missionsManager.getBotID(mission.getMissionID());
     if (botID === UNASSIGNED_ID) {
         return false;
     }
 
+    return confirmTargetWaypoint(botID, waypointNum);
+}
+
+/**
+ * Checks whether a waypoint is the Bot's target waypoint
+ *
+ * @param {number} botID Needed to access target waypoint property
+ * @param {number} waypointNum Waypoint of interest
+ * @returns {boolean} True if the waypoint is the target waypoint
+ */
+function confirmTargetWaypoint(botID: number, waypointNum: number) {
     const bot = bots.getBot(botID);
+    if (!bot) {
+        return false;
+    }
     const targetWaypoint = bot.getMissionStatus().targetWaypoint;
     if (targetWaypoint && targetWaypoint === waypointNum) {
         return true;
     }
-
     return false;
 }
 
@@ -334,16 +353,18 @@ function shouldColorTargetWaypoint(missionID: number, waypointNum: number) {
  * Informs whether or not the waypoint is part of the mission assigned to the
  * selected Bot
  *
- * @param {number} missionID Identifies the mission containing the waypoint
+ * @param {Mission} mission Mission containing the waypoint
  * @returns {boolean} True if waypoint is part of mission assigned to selected Bot
  */
-function isAssignedToSelectedBot(missionID: number) {
+function isAssignedToSelectedBot(mission: Mission) {
     const selectedNode = jaiaGlobal.getSelectedNode();
-    if (
-        selectedNode.type === NodeTypes.BOT &&
-        missionsManager.getMissionID(selectedNode.id) === missionID
-    ) {
-        return true;
+    if (selectedNode.type === NodeTypes.BOT) {
+        if (missionsManager.getMissionID(selectedNode.id) === mission.getMissionID()) {
+            return true;
+        }
+        if (mission.getGhostParameters().botID === selectedNode.id) {
+            return true;
+        }
     }
     return false;
 }

--- a/src/web/openlayers/layers/layers.ts
+++ b/src/web/openlayers/layers/layers.ts
@@ -6,7 +6,7 @@ import { noaaENCLayer } from "./tile/noaa-enc-layer";
 // Vector layers
 import { botLayer } from "./vector/bot-layer";
 import { hubLayer } from "./vector/hub-layer";
-import { missionLayer } from "./vector/mission-layer";
+import { ghostMissionLayer, missionLayer } from "./vector/mission-layer";
 import { gridLayer } from "./vector/grid-layer";
 import { rallyLayer } from "./vector/rally-layer";
 import { diveLayer } from "./vector/dive-layer";
@@ -30,6 +30,7 @@ class Layers {
         this.layers.set(LayerTitles.BOT_LAYER, botLayer.getVectorLayer());
         this.layers.set(LayerTitles.HUB_LAYER, hubLayer.getVectorLayer());
         this.layers.set(LayerTitles.MISSION_LAYER, missionLayer.getVectorLayer());
+        this.layers.set(LayerTitles.GHOST_MISSION_LAYER, ghostMissionLayer.getVectorLayer());
         this.layers.set(LayerTitles.GRID_LAYER, gridLayer.getVectorLayer());
         this.layers.set(LayerTitles.RALLY_LAYER, rallyLayer.getVectorLayer());
         this.layers.set(LayerTitles.DIVE_LAYER, diveLayer.getVectorLayer());

--- a/src/web/openlayers/layers/vector/mission-layer.ts
+++ b/src/web/openlayers/layers/vector/mission-layer.ts
@@ -1,4 +1,5 @@
 import JaiaVectorLayer from "./jaia-vector-layer";
+import Mission from "../../../data/mission_set/mission";
 import { missionSet } from "../../../data/mission_set/mission-set";
 import { TaskType } from "../../../types/protobuf-types";
 import { LayerTitles, LineType } from "../../../types/openlayers-types";
@@ -11,25 +12,25 @@ import {
 } from "../../features/waypoint-feature";
 
 class MissionLayer extends JaiaVectorLayer {
-    constructor() {
-        super(LayerTitles.MISSION_LAYER, layersZIndexes.get(LayerTitles.MISSION_LAYER));
+    constructor(layerTitle: LayerTitles) {
+        super(layerTitle, layersZIndexes.get(layerTitle));
+        this.styleLayer(layerTitle);
     }
 
     /**
      * Adds a waypoint and connecting line (if needed) to the mission layer
      *
-     * @param {number} missionID Used to access waypoint and determine color of line segment
+     * @param {Mission} mission Used to access waypoint and determine color of line segment
      * @param {number} waypointNum Positon of waypoint in mission sequence (to be displayed on icon)
      * @returns {void}
      */
-    buildMission(missionID: number, waypointNum: number) {
-        const mission = missionSet.getMission(missionID);
+    buildMission(mission: Mission, waypointNum: number) {
         const waypoint = mission.getWaypoint(waypointNum);
         const source = this.getVectorLayer().getSource();
 
         // Add mission flag
         if (waypointNum === 1) {
-            source.addFeature(generateMissionFlagFeature(waypoint.getLocation(), missionID));
+            source.addFeature(generateMissionFlagFeature(waypoint.getLocation(), mission));
         }
         // Add connecting line
         else {
@@ -49,13 +50,13 @@ class MissionLayer extends JaiaVectorLayer {
                     lineStartLocation,
                     waypoint.getLocation(),
                     LineType.SOLID,
-                    missionID,
+                    mission,
                 ),
             );
         }
 
         // Add waypoint
-        source.addFeature(generateWaypointFeature(waypoint.getLocation(), waypointNum, missionID));
+        source.addFeature(generateWaypointFeature(waypoint.getLocation(), waypointNum, mission));
 
         // Add projected constant heading track
         if (waypoint.getTask().getType() === TaskType.CONSTANT_HEADING) {
@@ -64,7 +65,7 @@ class MissionLayer extends JaiaVectorLayer {
                     waypoint.getLocation(),
                     constantHeadingParamsToLocation(waypoint.getLocation(), waypoint.getTask()),
                     LineType.DASHED,
-                    missionID,
+                    mission,
                 ),
             );
         }
@@ -78,12 +79,39 @@ class MissionLayer extends JaiaVectorLayer {
     updateFeatures() {
         this.getVectorLayer().getSource().clear();
 
-        for (let [missionID, mission] of missionSet.getMissions()) {
+        const layerTitle = this.getVectorLayer().getProperties()["title"];
+
+        if (
+            layerTitle === LayerTitles.GHOST_MISSION_LAYER &&
+            missionSet.getGhostMissions().size === 0
+        ) {
+            return;
+        }
+
+        let missions = missionSet.getMissions();
+        if (layerTitle === LayerTitles.GHOST_MISSION_LAYER) {
+            missions = missionSet.getGhostMissions();
+        }
+
+        for (let [missionID, mission] of missions) {
             for (let [index, waypoint] of mission.getWaypoints().entries()) {
-                this.buildMission(missionID, index + 1);
+                this.buildMission(mission, index + 1);
             }
+        }
+    }
+
+    /**
+     * Applies a reduced opactiy to the ghost mission layee
+     *
+     * @param {LayerTitles} layerTitle Identifies mission layer type
+     * @returns {void}
+     */
+    styleLayer(layerTitle: LayerTitles) {
+        if (layerTitle === LayerTitles.GHOST_MISSION_LAYER) {
+            this.getVectorLayer().setOpacity(0.5);
         }
     }
 }
 
-export const missionLayer = new MissionLayer();
+export const missionLayer = new MissionLayer(LayerTitles.MISSION_LAYER);
+export const ghostMissionLayer = new MissionLayer(LayerTitles.GHOST_MISSION_LAYER);

--- a/src/web/openlayers/layers/zindex.ts
+++ b/src/web/openlayers/layers/zindex.ts
@@ -2,11 +2,12 @@ import { LayerTitles } from "../../types/openlayers-types";
 
 export const layersZIndexes = new Map<LayerTitles, number>();
 
-layersZIndexes.set(LayerTitles.MEASURE_LAYER, 8);
-layersZIndexes.set(LayerTitles.BOT_LAYER, 7);
-layersZIndexes.set(LayerTitles.HUB_LAYER, 6);
-layersZIndexes.set(LayerTitles.MISSION_LAYER, 5);
-layersZIndexes.set(LayerTitles.GRID_LAYER, 5);
+layersZIndexes.set(LayerTitles.MEASURE_LAYER, 9);
+layersZIndexes.set(LayerTitles.BOT_LAYER, 8);
+layersZIndexes.set(LayerTitles.HUB_LAYER, 7);
+layersZIndexes.set(LayerTitles.MISSION_LAYER, 6);
+layersZIndexes.set(LayerTitles.GRID_LAYER, 6);
+layersZIndexes.set(LayerTitles.GHOST_MISSION_LAYER, 5);
 layersZIndexes.set(LayerTitles.RALLY_LAYER, 4);
 layersZIndexes.set(LayerTitles.DIVE_LAYER, 3);
 layersZIndexes.set(LayerTitles.DRIFT_LAYER, 3);

--- a/src/web/types/jaia-system-types.ts
+++ b/src/web/types/jaia-system-types.ts
@@ -61,6 +61,11 @@ export interface TaskParameterPair {
     value: number;
 }
 
+export interface GhostParameters {
+    hasStarted: boolean;
+    botID: number;
+}
+
 export enum SystemButtonTypes {
     SHUTDOWN = 1,
     REBOOT = 2,

--- a/src/web/types/openlayers-types.ts
+++ b/src/web/types/openlayers-types.ts
@@ -8,6 +8,7 @@ export enum LayerTitles {
     HUB_LAYER = "hub-layer",
     HUB_COMMS_LAYER = "hub-comms-layer",
     MISSION_LAYER = "mission-layer",
+    GHOST_MISSION_LAYER = "ghost-mission-layer",
     GRID_LAYER = "grid-layer",
     DIVE_LAYER = "dive-layer",
     DRIFT_LAYER = "drift-layer",


### PR DESCRIPTION
### Summary 
This pull request adds back the ghost layer. This layer can be useful for mission planning while Bots are running. When a mission is deleted that is currently underway, it will remain on the map with a reduced opacity so an operator can still see the mission while making new plans.

### Implementation
The `Mission` class now has a property `ghostParameters` which has the properties `hasStarted` and `botID`. These values are updated when a mission is sent to a Bot. They are used by the OpenLayers side to correctly style the missions. Additionally, the `MissionSet` class has a map of ghost missions. Missions are added to this map when a mission that has started is deleted, and mission are removed from this map when a Bot running a mission is given a new mission.

### Testing
* Deleting survey missions
* Deleting individual missions
* Unassigning and reassigning Bots to new missions when one is already underway

<img width="3839" height="1744" alt="image" src="https://github.com/user-attachments/assets/555248be-de39-4d91-aa32-9d7605b0a3b5" />
