### PR TITLE
bug/2.y/restoring-map-mode-on-undo

### DIFF
--- a/src/web/context/handlers/history-handlers.ts
+++ b/src/web/context/handlers/history-handlers.ts
@@ -7,6 +7,7 @@ import {
     JaiaContextDataSnapshot,
     ButtonNames,
 } from "../../types/context-types";
+import { MapModes } from "../../types/openlayers-types";
 import { historyManager } from "../../data/history/histroy-manager";
 import { missionSet } from "../../data/mission_set/mission-set";
 import { missionsManager } from "../../data/missions_manager/missions-manager";
@@ -41,8 +42,8 @@ export function handleClickedUndo(mutableState: JaiaContextType) {
     // Clear the grid layer to remove left over features after undo
     gridLayer.getVectorLayer().getSource().clear();
 
-    // Reset the MapMode based on restored state
-    handleMapModeChange(mutableState.jaiaGlobal.getMapMode());
+    // Reset the map mode
+    handleMapModeChange(MapModes.DEFAULT);
 
     syncOpenLayers();
     return mutableState;


### PR DESCRIPTION
### Summary
The map mode property is not always correctly reset when undo is clicked because the snapshot is taken before the action handling. Jeff Roy has a complete solution for this matter. In the meantime, I want to push a small fix to prevent an operator from entering a confusing state.

### Testing
* Planned a survey mission, clicked undo, and the map mode reset to `DEFAULT` instead of `SURVEY_PLANNING`  