### PR TITLE
bug/bots-pending-data-offload-not-populating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ filter-template-debian-builds: &filter-template-debian-builds
       only: /.*/
     branches:
       only:
-        - "2.y"
+        - "bug/bots-pending-data-offload-not-populating"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ filter-template-debian-builds: &filter-template-debian-builds
       only: /.*/
     branches:
       only:
-        - "bug/bots-pending-data-offload-not-populating"
+        - "2.y"
 
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -519,6 +519,10 @@ void jaiabot::apps::HubManager::loop()
         latest_hub_status_.mutable_bot_offload()->set_bot_id(current_offload_bot_id_);
         latest_hub_status_.mutable_bot_offload()->set_data_offload_percentage(
             data_offload_percentage_);
+        for (int bot_id : bots_pending_data_offload_)
+        { 
+            latest_hub_status_.mutable_bot_offload()->add_bots_pending(bot_id); 
+        }
 
         if (offload_complete_)
         {
@@ -546,12 +550,6 @@ void jaiabot::apps::HubManager::loop()
     {
         start_dataoffload(bots_pending_data_offload_.front());
         bots_pending_data_offload_.pop_front();
-    }
-
-    // Outside of offload conditional to prevent flickering in UI queue
-    for (int bot_id : bots_pending_data_offload_)
-    { 
-        latest_hub_status_.mutable_bot_offload()->add_bots_pending(bot_id); 
     }
 
     if (last_health_report_time_ + std::chrono::seconds(cfg().health_report_timeout_seconds()) <

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -519,6 +519,10 @@ void jaiabot::apps::HubManager::loop()
         latest_hub_status_.mutable_bot_offload()->set_bot_id(current_offload_bot_id_);
         latest_hub_status_.mutable_bot_offload()->set_data_offload_percentage(
             data_offload_percentage_);
+        for (int bot_id : bots_pending_data_offload_)
+        { 
+            latest_hub_status_.mutable_bot_offload()->add_bots_pending(bot_id); 
+        }
 
         if (offload_complete_)
         {
@@ -546,8 +550,6 @@ void jaiabot::apps::HubManager::loop()
     {
         start_dataoffload(bots_pending_data_offload_.front());
         bots_pending_data_offload_.pop_front();
-        for (int bot_id : bots_pending_data_offload_)
-        { latest_hub_status_.mutable_bot_offload()->add_bots_pending(bot_id); }
     }
 
     if (last_health_report_time_ + std::chrono::seconds(cfg().health_report_timeout_seconds()) <

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -546,6 +546,8 @@ void jaiabot::apps::HubManager::loop()
     {
         start_dataoffload(bots_pending_data_offload_.front());
         bots_pending_data_offload_.pop_front();
+        for (int bot_id : bots_pending_data_offload_)
+        { latest_hub_status_.mutable_bot_offload()->add_bots_pending(bot_id); }
     }
 
     if (last_health_report_time_ + std::chrono::seconds(cfg().health_report_timeout_seconds()) <

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -519,10 +519,6 @@ void jaiabot::apps::HubManager::loop()
         latest_hub_status_.mutable_bot_offload()->set_bot_id(current_offload_bot_id_);
         latest_hub_status_.mutable_bot_offload()->set_data_offload_percentage(
             data_offload_percentage_);
-        for (int bot_id : bots_pending_data_offload_)
-        { 
-            latest_hub_status_.mutable_bot_offload()->add_bots_pending(bot_id); 
-        }
 
         if (offload_complete_)
         {
@@ -550,6 +546,12 @@ void jaiabot::apps::HubManager::loop()
     {
         start_dataoffload(bots_pending_data_offload_.front());
         bots_pending_data_offload_.pop_front();
+    }
+
+    // Outside of offload conditional to prevent flickering in UI queue
+    for (int bot_id : bots_pending_data_offload_)
+    { 
+        latest_hub_status_.mutable_bot_offload()->add_bots_pending(bot_id); 
     }
 
     if (last_health_report_time_ + std::chrono::seconds(cfg().health_report_timeout_seconds()) <

--- a/src/lib/messages/hub.proto
+++ b/src/lib/messages/hub.proto
@@ -43,8 +43,9 @@ message HubStatus
     message BotOffloadData
     {
         required uint32 bot_id = 1;
-        optional int32 data_offload_percentage = 2;
+        optional uint32 data_offload_percentage = 2;
         optional bool offload_succeeded = 3;
+        repeated uint32 bots_pending = 4;
     }
     optional BotOffloadData bot_offload = 13;
 

--- a/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllDialog.tsx
+++ b/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllDialog.tsx
@@ -89,7 +89,7 @@ export function DataOffloadAllDialog(props: DialogProps) {
                 subMessage += `because ${botIDs.length > 1 ? "they do not have comms with the Hub." : "it does not have comms with the Hub."}`;
                 break;
             case DisabledCodes.MISSION_STATE:
-                subMessage += `because ${botIDs.length > 1 ? "they are not in an idle state." : "it is not in an idle state."}`;
+                subMessage += `because ${botIDs.length > 1 ? "they are not stopped or the offload already occured." : "it is not stopped or the offload already occured."}`;
                 break;
             case DisabledCodes.WIFI_QUALITY:
                 subMessage += `because ${botIDs.length > 1 ? "they are not connected to the Hub Wi-Fi network." : "it is not connected to the Hub Wi-Fi network."}`;

--- a/src/web/components/__buttons__/DataOffloadButton/data-offload-messages.ts
+++ b/src/web/components/__buttons__/DataOffloadButton/data-offload-messages.ts
@@ -5,7 +5,7 @@ export const messages = new Map<DisabledCodes, string>([
     [DisabledCodes.NO_COMMS, "The Bot does not have comms with the Hub."],
     [
         DisabledCodes.MISSION_STATE,
-        "Cannot start a data offload because the Bot is not in an idle state. Try sending the stop command first.",
+        "Cannot start a data offload because the Bot is not in a stopped state or the offload already occured.",
     ],
     [
         DisabledCodes.WIFI_QUALITY,


### PR DESCRIPTION
### Summary
While preparing to merge the developer friendly JCC into `2.y`, we left out the changes made to the `hub_manager` application. These changes include adding a field to the `HubStatus` message called `bots_pending` to make the array of Bots in the queue accessible to the web code.

### Testing
* Performed a data offload with 5 Bots in simulation
* Performed a data offload with 2 Bots at the office
* *The queue populated as expected*