### PR TITLE
task/populate-ctd-message

### DIFF
--- a/src/bin/mission_manager/app.cpp
+++ b/src/bin/mission_manager/app.cpp
@@ -223,6 +223,15 @@ jaiabot::apps::MissionManager::MissionManager()
             machine_->process_event(ev);
         });
 
+    
+    interprocess().subscribe<jaiabot::groups::pressure_adjusted>(
+        [this](const jaiabot::protobuf::PressureAdjustedData& pa)
+        {
+            statechart::EvMeasurement ev;
+            ev.sensor_depth = pa.sensor_depth_with_units();
+            machine_->process_event(ev);
+        });
+
     // subscribe for salinity data
     interprocess().subscribe<jaiabot::groups::salinity>(
         [this](const jaiabot::protobuf::SalinityData& sal)
@@ -231,6 +240,7 @@ jaiabot::apps::MissionManager::MissionManager()
             {
                 statechart::EvMeasurement ev;
                 ev.salinity = sal.salinity();
+                ev.conductivity = sal.conductivity();
                 machine_->process_event(ev);
             }
         });

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -1031,6 +1031,12 @@ jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::~Unpowere
 
     context<Dive>().dive_packet().set_unpowered_rise_rate_with_units(rise_rate *
                                                                      boost::units::si::velocity());
+
+    interprocess().publish<jaiabot::groups::ctd>(latest_ctd_profile_);
+    latest_ctd_profile_.clear_snapshots();
+    glog.is_debug1() && glog << "Published CTD profile" << std::endl;
+
+                                                                     
 }
 
 void jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::loop(const EvLoop&)

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -11,8 +11,6 @@ using goby::glog;
 namespace si = boost::units::si;
 using boost::units::quantity;
 
-const CTDUpdateRate = 100000; // 0.1 seconds
-
 jaiabot::protobuf::IvPBehaviorUpdate
 create_transit_update(const jaiabot::protobuf::GeographicCoordinate& location,
                       quantity<si::velocity> speed, const goby::util::UTMGeodesy& geodesy,
@@ -1119,21 +1117,21 @@ void jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::coll
     auto now = goby::time::SystemClock::now<goby::time::MicroTime>();
 
     if (ev.conductivity.has_value()) {
-        latest_ctd_snapshot.set_conductivity(ev.conductivity.value());
+        latest_ctd_snapshot_.set_conductivity(ev.conductivity.value());
     }
 
     if (ev.temperature.has_value()) {
-        latest_ctd_snapshot.set_temperature(ev.temperature->value());
+        latest_ctd_snapshot_.set_temperature(ev.temperature->value());
     }
 
     if (ev.sensor_depth.has_value()) {
-        latest_ctd_snapshot.set_depth(ev.sensor_depth->value());
+        latest_ctd_snapshot_.set_depth(ev.sensor_depth->value());
     }
 
-    if (now.value() - last_snapshot_time.value() >= CTDUpdateRate) {
+    if (now.value() - last_snapshot_time_.value() >= CTDUpdateRate) {
         glog.is_debug1() && glog << "Adding CTD snapshot to profile" << std::endl;
-        latest_ctd_profile.add_snapshots()->CopyFrom(latest_ctd_snapshot);
-        last_snapshot_time = now;
+        latest_ctd_profile_.add_snapshots()->CopyFrom(latest_ctd_snapshot_);
+        last_snapshot_time_ = now;
     }
 }
 

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -1034,9 +1034,7 @@ jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::~Unpowere
 
     interprocess().publish<jaiabot::groups::ctd>(latest_ctd_profile_);
     latest_ctd_profile_.clear_snapshots();
-    glog.is_debug1() && glog << "Published CTD profile" << std::endl;
-
-                                                                     
+    glog.is_debug1() && glog << "Published CTD profile" << std::endl;                                                                    
 }
 
 void jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::loop(const EvLoop&)

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -1134,7 +1134,7 @@ void jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::coll
 
     if (now.value() - last_snapshot_time_.value() >= CTDUpdateRate) {
         glog.is_debug1() && glog << "Adding CTD snapshot to profile" << std::endl;
-        latest_ctd_profile_.add_snapshots()->CopyFrom(latest_ctd_snapshot_);
+        latest_ctd_profile_.add_snapshot()->CopyFrom(latest_ctd_snapshot_);
         last_snapshot_time_ = now;
     }
 }

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -1033,7 +1033,7 @@ jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::~Unpowere
                                                                      boost::units::si::velocity());
 
     interprocess().publish<jaiabot::groups::ctd>(latest_ctd_profile_);
-    latest_ctd_profile_.clear_snapshots();
+    latest_ctd_profile_.clear_snapshot();
     glog.is_debug1() && glog << "Published CTD profile" << std::endl;                                                                    
 }
 

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -1111,6 +1111,31 @@ void jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::dept
              << std::endl;
 }
 
+void jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::collectCTD(
+    const EvMeasurement& ev)
+{
+    auto now = goby::time::SystemClock::now<goby::time::MicroTime>();
+
+    if (ev.conductivity.has_value()) {
+        latest_ctd_snapshot.set_conductivity(ev.conductivity.value());
+    }
+
+    if (ev.temperature.has_value()) {
+        latest_ctd_snapshot.set_temperature(ev.temperature->value());
+    }
+
+    if (ev.pressure_raw.has_value()) {
+        latest_ctd_snapshot.set_depth(ev.pressure_raw.value());
+    }
+
+    if (now.value() - latest_measurement_time.value() >= 0.1) {
+        glog.is_debug1() && glog << "Adding CTD snapshot to profile" << std::endl;
+        latest_ctd_profile.add_snapshots()->CopyFrom(latest_ctd_snapshot);
+    }
+    latest_measurement_time = now;
+    glog.is_debug1() && glog << "New CTD measurement" << std::endl;
+}
+
 // Task::Dive::PoweredAscent
 jaiabot::statechart::inmission::underway::task::dive::PoweredAscent::PoweredAscent(
     typename StateBase::my_context c)

--- a/src/bin/mission_manager/machine.cpp
+++ b/src/bin/mission_manager/machine.cpp
@@ -11,6 +11,8 @@ using goby::glog;
 namespace si = boost::units::si;
 using boost::units::quantity;
 
+const CTDUpdateRate = 100000; // 0.1 seconds
+
 jaiabot::protobuf::IvPBehaviorUpdate
 create_transit_update(const jaiabot::protobuf::GeographicCoordinate& location,
                       quantity<si::velocity> speed, const goby::util::UTMGeodesy& geodesy,
@@ -1124,16 +1126,15 @@ void jaiabot::statechart::inmission::underway::task::dive::UnpoweredAscent::coll
         latest_ctd_snapshot.set_temperature(ev.temperature->value());
     }
 
-    if (ev.pressure_raw.has_value()) {
-        latest_ctd_snapshot.set_depth(ev.pressure_raw.value());
+    if (ev.sensor_depth.has_value()) {
+        latest_ctd_snapshot.set_depth(ev.sensor_depth->value());
     }
 
-    if (now.value() - latest_measurement_time.value() >= 0.1) {
+    if (now.value() - last_snapshot_time.value() >= CTDUpdateRate) {
         glog.is_debug1() && glog << "Adding CTD snapshot to profile" << std::endl;
         latest_ctd_profile.add_snapshots()->CopyFrom(latest_ctd_snapshot);
+        last_snapshot_time = now;
     }
-    latest_measurement_time = now;
-    glog.is_debug1() && glog << "New CTD measurement" << std::endl;
 }
 
 // Task::Dive::PoweredAscent

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -127,9 +127,9 @@ struct EvMeasurement : boost::statechart::event<EvMeasurement>
     boost::optional<
         boost::units::quantity<boost::units::absolute<boost::units::celsius::temperature>>>
         temperature;
-    boost::optional<double> pressure_raw;
     boost::optional<double> salinity;
     boost::optional<double> conductivity;
+    boost::optional<boost::units::quantity<boost::units::si::length>> sensor_depth;
 };
 
 struct EvVehicleGPS : boost::statechart::event<EvVehicleGPS>
@@ -1813,7 +1813,7 @@ struct UnpoweredAscent
     boost::units::quantity<boost::units::si::length> last_depth_{context<Dive>().current_depth()};
     goby::time::MicroTime last_depth_change_time_{
         goby::time::SystemClock::now<goby::time::MicroTime>()};
-    goby::time::MicroTime latest_measurement_time{goby::time::SystemClock::now<goby::time::MicroTime>()};
+    goby::time::MicroTime last_snapshot_time{goby::time::SystemClock::now<goby::time::MicroTime>()};
     jaiabot::protobuf::CTDSnapshot latest_ctd_snapshot;
     jaiabot::protobuf::CTDProfile latest_ctd_profile;
 

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -32,6 +32,7 @@
 
 #include "jaiabot/messages/echo.pb.h"
 #include "jaiabot/messages/imu.pb.h"
+#include "jaiabot/messages/ctd.pb.h"
 #include "jaiabot/utils/mission_manager_utils.h"
 using jaiabot::protobuf::EchoCommand;
 using jaiabot::protobuf::IMUCommand;
@@ -126,7 +127,9 @@ struct EvMeasurement : boost::statechart::event<EvMeasurement>
     boost::optional<
         boost::units::quantity<boost::units::absolute<boost::units::celsius::temperature>>>
         temperature;
+    boost::optional<double> pressure_raw;
     boost::optional<double> salinity;
+    boost::optional<double> conductivity;
 };
 
 struct EvVehicleGPS : boost::statechart::event<EvVehicleGPS>
@@ -1789,7 +1792,8 @@ struct UnpoweredAscent
 
     void loop(const EvLoop&);
     void depth(const EvVehicleDepth& ev);
-
+    void collectCTD(const EvMeasurement& ev);
+ 
     using reactions = boost::mpl::list<
         boost::statechart::transition<EvSurfacingTimeout, PoweredAscent>,
         boost::statechart::transition<EvSurfaced, ReacquireGPS>,
@@ -1806,6 +1810,10 @@ struct UnpoweredAscent
     boost::units::quantity<boost::units::si::length> last_depth_{context<Dive>().current_depth()};
     goby::time::MicroTime last_depth_change_time_{
         goby::time::SystemClock::now<goby::time::MicroTime>()};
+    goby::time::MicroTime latest_measurement_time{goby::time::SystemClock::now<goby::time::MicroTime>()};
+    jaiabot::protobuf::CTDSnapshot latest_ctd_snapshot;
+    jaiabot::protobuf::CTDProfile latest_ctd_profile;
+
 };
 
 struct PoweredAscent

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -1799,7 +1799,10 @@ struct UnpoweredAscent
         boost::statechart::transition<EvSurfaced, ReacquireGPS>,
         boost::statechart::in_state_reaction<EvLoop, UnpoweredAscent, &UnpoweredAscent::loop>,
         boost::statechart::in_state_reaction<EvVehicleDepth, UnpoweredAscent,
-                                             &UnpoweredAscent::depth>>;
+                                             &UnpoweredAscent::depth>,
+        boost::statechart::in_state_reaction<EvMeasurement, UnpoweredAscent, &UnpoweredAscent::collectCTD>
+    >;
+        
 
   private:
     goby::time::MicroTime detect_depth_changes_init_timeout_{

--- a/src/bin/mission_manager/machine.h
+++ b/src/bin/mission_manager/machine.h
@@ -1790,6 +1790,8 @@ struct UnpoweredAscent
     UnpoweredAscent(typename StateBase::my_context c);
     ~UnpoweredAscent();
 
+    const int CTDUpdateRate = 100000; // 0.1 seconds
+
     void loop(const EvLoop&);
     void depth(const EvVehicleDepth& ev);
     void collectCTD(const EvMeasurement& ev);
@@ -1813,9 +1815,9 @@ struct UnpoweredAscent
     boost::units::quantity<boost::units::si::length> last_depth_{context<Dive>().current_depth()};
     goby::time::MicroTime last_depth_change_time_{
         goby::time::SystemClock::now<goby::time::MicroTime>()};
-    goby::time::MicroTime last_snapshot_time{goby::time::SystemClock::now<goby::time::MicroTime>()};
-    jaiabot::protobuf::CTDSnapshot latest_ctd_snapshot;
-    jaiabot::protobuf::CTDProfile latest_ctd_profile;
+    goby::time::MicroTime last_snapshot_time_{goby::time::SystemClock::now<goby::time::MicroTime>()};
+    jaiabot::protobuf::CTDSnapshot latest_ctd_snapshot_;
+    jaiabot::protobuf::CTDProfile latest_ctd_profile_;
 
 };
 

--- a/src/lib/groups.h
+++ b/src/lib/groups.h
@@ -48,6 +48,7 @@ constexpr goby::middleware::Group ph{"jaiabot::ph"};
 constexpr goby::middleware::Group fluorometer{"jaiabot::fluorometer"};
 constexpr goby::middleware::Group echo{"jaiabot::echo"};
 constexpr goby::middleware::Group tsys01{"jaiabot::tsys01"};
+constexpr goby::middleware::Group ctd{"jaiabot::ctd"};
 
 constexpr goby::middleware::Group mcu_pb_data_out{
     "jaiabot::sensors::mcu_pb_data_out"}; // parsed SensorRequest

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -50,6 +50,7 @@ protobuf_generate_cpp_full(PROTO_SRCS PROTO_HDRS "jaiabot/messages" ${project_IN
   udp_driver.proto
   link_config.proto
   comms.proto
+  ctd.proto
   ${SENSOR_MESSAGES}
 )
 

--- a/src/lib/messages/ctd.proto
+++ b/src/lib/messages/ctd.proto
@@ -20,7 +20,6 @@ message CTDSnapshot {
             codec: "dccl.time2"
             units { prefix: "micro" derived_dimensions: "time" }
             precision: -6  // second precision
-
         }
     ];
     optional uint64 end_time = 3 [

--- a/src/lib/messages/ctd.proto
+++ b/src/lib/messages/ctd.proto
@@ -1,0 +1,39 @@
+syntax = "proto2";
+
+import "dccl/option_extensions.proto";
+import "jaiabot/messages/geographic_coordinate.proto";
+import "jaiabot/messages/option_extensions.proto";
+
+package jaiabot.protobuf;
+
+message CTD {
+    option (dccl.msg) = {
+        id: 100
+        codec_version: 4
+        unit_system: "si"
+    };
+    optional uint32 bot_id = 1 [
+        (dccl.field) = { min: 0 max: 255 }
+    ];
+    optional uint64 start_time = 2 [
+        (dccl.field) = {
+            codec: "dccl.time2"
+            units { prefix: "micro" derived_dimensions: "time" }
+            precision: -6  // second precision
+
+        }
+    ];
+    optional uint64 end_time = 3 [
+        (dccl.field) = {
+            codec: "dccl.time2"
+            units { prefix: "micro" derived_dimensions: "time" }
+            precision: -6  // second precision
+
+        }
+    ];
+    optional GeographicCoordinate start_location = 4;
+
+    repeated double conductivity = 5;
+    repeated double temperature = 6;
+    repeated double depth = 7;
+}

--- a/src/lib/messages/ctd.proto
+++ b/src/lib/messages/ctd.proto
@@ -6,7 +6,7 @@ import "jaiabot/messages/option_extensions.proto";
 
 package jaiabot.protobuf;
 
-message CTD {
+message CTDSnapshot {
     option (dccl.msg) = {
         id: 100
         codec_version: 4
@@ -33,7 +33,11 @@ message CTD {
     ];
     optional GeographicCoordinate start_location = 4;
 
-    repeated double conductivity = 5;
-    repeated double temperature = 6;
-    repeated double depth = 7;
+    optional double conductivity = 5;
+    optional double temperature = 6;
+    optional double depth = 7;
+}
+
+message CTDProfile {
+    repeated CTDSnapshot snapshots = 1;
 }

--- a/src/lib/messages/ctd.proto
+++ b/src/lib/messages/ctd.proto
@@ -38,5 +38,5 @@ message CTDSnapshot {
 }
 
 message CTDProfile {
-    repeated CTDSnapshot snapshots = 1;
+    repeated CTDSnapshot snapshot = 1;
 }


### PR DESCRIPTION
### Summary
This pull request captures CTD data at 10 Hz while the Bot floats to the surface after diving. The snapshots occur once every 0.1 seconds are are placed into a CTD profile list. This list of snapshots is published when the Bot reaches the surface.

### Testing
Dove a Bot in simulation and viewed the snapshots in the published CTD profile in liaison