### PR TITLE
bug/clang-formatter-not-working

### DIFF
--- a/scripts/git-hooks/clang-format-hooks/apply-format
+++ b/scripts/git-hooks/clang-format-hooks/apply-format
@@ -299,13 +299,29 @@ else # Diff-only.
     read -r -a format_diff_args <<< "$format_diff"
     [ "$in_place" = true ] && format_diff_args+=("-i")
 
+    # FIX: Disable pipefail temporarily to handle clang-format-diff exit code
+    # clang-format-diff (especially LLVM 10-18) returns exit code 1 when it finds
+    # formatting differences, which is not an error - it's expected behavior.
+    # We only want to fail on actual errors (exit code > 1).
+    set +o pipefail
+
     "${git_args[@]}" "$@" \
         | "${format_diff_args[@]}" \
             -p1 \
             -style="$style" \
             -iregex='^.*\.(c|cpp|cxx|cc|h|m|mm|java)$' \
-            > "$patch_dest" \
-        || exit 1
+            > "$patch_dest"
+
+    format_diff_exit_code=$?
+
+    # Re-enable pipefail
+    set -o pipefail
+
+    # Only fail on real errors (exit code > 1)
+    # Exit code 1 from clang-format-diff means "found formatting issues" which is fine
+    if [ $format_diff_exit_code -gt 1 ]; then
+        error_exit "clang-format-diff failed with exit code $format_diff_exit_code"
+    fi
 
     if [ "$apply_to_staged" = true ]; then
         if [ ! -s "$patch_dest" ]; then


### PR DESCRIPTION
## Description

With the help of claude:

https://github.com/barisione/clang-format-hooks/issues/33

Fix apply-format to handle clang-format-diff exit code 1

clang-format-diff (LLVM 10-18) returns exit code 1 when it finds
formatting differences, which caused the pre-commit hook to fail
with a confusing error message. The script now treats exit code 1
as success (formatting issues found) and only fails on exit codes > 1.

