### PR TITLE
Update take_reading_and_send_data() to only send if reading is not None

### DIFF
--- a/src/python/adafruit/jaiabot_imu.py
+++ b/src/python/adafruit/jaiabot_imu.py
@@ -79,12 +79,12 @@ def do_port_loop(imu: IMU, wave_analyzer: AccelerationAnalyzer):
 
             imu_data.imu_type = args.device_type
 
-        address = ('localhost', udp_gateway_port)
+            address = ('localhost', udp_gateway_port)
 
-        envelope = UDPGatewayEnvelope(imu_data=imu_data)
+            envelope = UDPGatewayEnvelope(imu_data=imu_data)
 
-        port_log.debug(f'Sending UDPGatewayEnvelope to jaiabot_udp_gateway at {address}:\n{envelope}')
-        sock.sendto(envelope.SerializeToString(), address)
+            port_log.debug(f'Sending UDPGatewayEnvelope to jaiabot_udp_gateway at {address}:\n{envelope}')
+            sock.sendto(envelope.SerializeToString(), address)
 
 
     while True:


### PR DESCRIPTION
Current implementation in 2.y attempts to send imu_data to the udp_gateway regardless of whether reading is not None, resulting in the script attempting to send an unassigned imu_data variable when reading is None, crashing the jaia_imu_py.service. Fix moves the code which sends imu_data to the udp gateway within the check for whether envelope is not None, guaranteeing imu_data is assigned.

Systemctl logs of jaia_imu_py.service illustrating original bug.
```
-- Boot 1d56e5305e534240bf7a9669fcb747ed --
Feb 06 17:36:02 bot1-fleet14 systemd[1]: Starting jaiabot_imu_py.service - JaiaBot BNO085 IMU Python Driver...
Feb 06 17:36:13 bot1-fleet14 jaiabot_failure_reporter[1414]: jaiabot_failure_reporter [2026-Feb-06 17:36:13.501481]: (Warning): No ack after 5 attempts. quitting.
Feb 06 17:36:13 bot1-fleet14 systemd[1]: Started jaiabot_imu_py.service - JaiaBot BNO085 IMU Python Driver.
Feb 06 18:53:15 bot1-fleet14 python3[1657]:    WARNING       imu.adafruit_bno085 Unexpected RuntimeError trying to get imu data: Didn't find packet end
Feb 06 18:53:15 bot1-fleet14 python3[1657]:    WARNING     jaiabot_imu.port_loop takeReading() returned None
Feb 06 18:53:15 bot1-fleet14 python3[1657]: Exception in thread portThread:
Feb 06 18:53:15 bot1-fleet14 python3[1657]: Traceback (most recent call last):
Feb 06 18:53:15 bot1-fleet14 python3[1657]:   File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
Feb 06 18:53:15 bot1-fleet14 python3[1657]:     self.run()
Feb 06 18:53:15 bot1-fleet14 python3[1657]:   File "/usr/lib/python3.12/threading.py", line 1010, in run
Feb 06 18:53:15 bot1-fleet14 python3[1657]:     self._target(*self._args, **self._kwargs)
Feb 06 18:53:15 bot1-fleet14 python3[1657]:   File "/home/jaia/jaiabot/build/noble-2.y-arm64/share/jaiabot/python/adafruit/jaiabot_imu.py", line 119, in do_port_loop
Feb 06 18:53:15 bot1-fleet14 python3[1657]:     take_reading_and_send_data()
Feb 06 18:53:15 bot1-fleet14 python3[1657]:   File "/home/jaia/jaiabot/build/noble-2.y-arm64/share/jaiabot/python/adafruit/jaiabot_imu.py", line 84, in take_reading_and_send_data
Feb 06 18:53:15 bot1-fleet14 python3[1657]:     envelope = UDPGatewayEnvelope(imu_data=imu_data)
Feb 06 18:53:15 bot1-fleet14 python3[1657]:                                            ^^^^^^^^
Feb 06 18:53:15 bot1-fleet14 python3[1657]: UnboundLocalError: cannot access local variable 'imu_data' where it is not associated with a value
Feb 06 18:53:15 bot1-fleet14 python3[1657]: Soft resetting...OK!
Feb 06 18:53:16 bot1-fleet14 systemd[1]: jaiabot_imu_py.service: Deactivated successfully.
Feb 06 18:53:16 bot1-fleet14 systemd[1]: jaiabot_imu_py.service: Consumed 13min 27.068s CPU time.
Feb 06 19:26:20 bot1-fleet14 systemd[1]: Starting jaiabot_imu_py.service - JaiaBot BNO085 IMU Python Driver...
Feb 06 19:26:21 bot1-fleet14 systemd[1]: Started jaiabot_imu_py.service - JaiaBot BNO085 IMU Python Driver.
```