### PR TITLE
bug/3d-plot-breaks-during-recentering

### DIFF
--- a/src/web/components/DepthMap3D/DepthMap3D.tsx
+++ b/src/web/components/DepthMap3D/DepthMap3D.tsx
@@ -10,9 +10,9 @@ import { DEPTH_MAP_3D_NAME } from "../../utils/constants";
 const Plotly = require("plotly.js-dist");
 
 interface Props {
+    windowPosition: string;
     setWindowPosition: React.Dispatch<React.SetStateAction<string>>;
     onClose: () => void;
-    windowPosition: string;
 }
 
 /**
@@ -38,9 +38,9 @@ export default function DepthMap3D() {
     return (
         <div className={`depth-map-3D-container ${windowPosition}`}>
             <MenuBar
+                windowPosition={windowPosition}
                 setWindowPosition={setWindowPosition}
                 onClose={onClose}
-                windowPosition={windowPosition}
             />
             <div id={DEPTH_MAP_3D_NAME}></div>
         </div>

--- a/src/web/components/DepthMap3D/DepthMap3D.tsx
+++ b/src/web/components/DepthMap3D/DepthMap3D.tsx
@@ -12,6 +12,7 @@ const Plotly = require("plotly.js-dist");
 interface Props {
     setWindowPosition: React.Dispatch<React.SetStateAction<string>>;
     onClose: () => void;
+    windowPosition: string;
 }
 
 /**
@@ -36,7 +37,11 @@ export default function DepthMap3D() {
 
     return (
         <div className={`depth-map-3D-container ${windowPosition}`}>
-            <MenuBar setWindowPosition={setWindowPosition} onClose={onClose} />
+            <MenuBar
+                setWindowPosition={setWindowPosition}
+                onClose={onClose}
+                windowPosition={windowPosition}
+            />
             <div id={DEPTH_MAP_3D_NAME}></div>
         </div>
     );
@@ -52,9 +57,12 @@ function MenuBar(props: Props) {
      * @param {string} windowPosition Where to place the 3D depth map
      * @returns {void}
      */
-    const handleClick = (windowPosition: string) => {
+    const handleClick = (nextPosition: string) => {
+        if (nextPosition === props.windowPosition) {
+            return;
+        }
         Plotly.purge(DEPTH_MAP_3D_NAME);
-        props.setWindowPosition(windowPosition);
+        props.setWindowPosition(nextPosition);
     };
 
     return (


### PR DESCRIPTION
Fixes bug where trying to reposition the 3D depth plot to a position its already in results in a blank plot. 

(https://github.com/user-attachments/files/25193192/Screen.Recording.2026-02-09.141731.zip)
