### PR TITLE
bug/last-depth-not-set-during-powered-ascent

### DIFF
--- a/src/bin/mission_manager/states/inmission/underway/task/dive/powered_ascent.h
+++ b/src/bin/mission_manager/states/inmission/underway/task/dive/powered_ascent.h
@@ -38,8 +38,6 @@ struct PoweredAscent
 
         powered_ascent_motor_off_timeout_ = start_timeout + powered_ascent_motor_off_duration_;
 
-        last_depth_ = context<Dive>().dive_packet().depth_achieved_with_units();
-
         loop(EvLoop());
     }
 


### PR DESCRIPTION
We were setting last_depth_ to the depth achieved of the current dive in the PoweredAscent constructor. Because of this, each time we entered the PoweredAscent state, we would be comparing our current depth to the depth achieved, and if that difference was greater than our epsilon value (default of 0.1 m), we would exit PoweredAscent and go back into UnpoweredAscent. This would generally lead to us leaving the PoweredAscent state almost immediately after the initial iteration. 

The thought is that in most cases, one iteration of pulsing the motor was enough to get the Bot dislodged from the bottom, so we never noticed this bug. In cases where the Bot became stuck on the bottom, we either never retrieved the Bot to see its logs, or the Bot's natural buoyancy was enough to eventually cause the Bot to rise. 

This behavior is only seen when the Bot gets stuck on the bottom, is able to raise more than 0.1 m during its powered ascent state, but is still stuck. In this instance, last_depth_ will be set to the dive's depth_achieved, and then we will consistently exit the Powered Ascent state from there on out because the current depth is > 0.1 m from the depth_achieved (last_depth_). 