### PR TITLE
bug/no-tap-to-move-on-contour-map

### DIFF
--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -67,6 +67,11 @@ export default function Map() {
                 return;
         }
 
+        if (jaiaGlobal.getSelectedWaypoint().isMoveable) {
+            handleMoveWaypointClick(event.coordinate);
+            return;
+        }
+
         const feature = map.forEachFeatureAtPixel(event.pixel, (feature: Feature) => feature, {
             hitTolerance: MAP_FEATURE_HIT_TOLERANCE,
         });
@@ -96,11 +101,6 @@ export default function Map() {
                 default:
                     return;
             }
-        }
-
-        if (jaiaGlobal.getSelectedWaypoint().isMoveable) {
-            handleMoveWaypointClick(event.coordinate);
-            return;
         }
 
         // Prevent generating false ADD_WAYPOINT actions


### PR DESCRIPTION
### Summary
Previously, when putting a waypoint in tap to move, if you clicked on an OpenLayers feature, the waypoint would not move and potentially another panel would open. Now, tap to move takes precedence over feature clicks.

### Testing
Added a waypoint to the map, toggled tap to move, and clicked OpenLayers features. The waypoint moved as expected. Once tap to move is turned off, features can be selected.