### PR TITLE
bug/zero-commands-sent-during-rc-dive

### DIFF
--- a/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
+++ b/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
@@ -75,7 +75,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
         return () => {
             clearInterval(rcCommandInterval);
         };
-    }, [throttleDirection, throttleMagnitude, rudderDirection, rudderMagnitude]);
+    }, [controlType, throttleDirection, throttleMagnitude, rudderDirection, rudderMagnitude]);
 
     /**
      * Sends RC commands periodically unless in dive mode.


### PR DESCRIPTION
### Summary
Hub was sending engineering commands that set the motor and rudder to 0 while the Bot attempted to RC dive. The `useEffect` function did not have the `controlType` dependency so it did not update the value in `handleRCInterval`.

### Testing
The web portal does not receive engineering commands from the client while the RC dive panel is open.