### PR TITLE
bug/tsys02-sensors-not-detected

### DIFF
--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -703,6 +703,21 @@ if 'ppk' in jaia_additional_sensors:
     ]
     jaiabot_apps.extend(jaiabot_ppk)
 
+if jaia_temperature_sensor_type.value == 'tsys01':
+    jaiabot_apps_tsys01 = [
+        {'exe': 'jaiabot_tsys01.py',
+         'description': 'JaiaBot TSYS01 Temperature Sensor Python Driver',
+         'template': 'py-app.service.in',
+         'subdir': 'tsys01_temperature_sensor',
+         'args': f'-p {UDP_GATEWAY_PORT}',
+         'error_on_fail': 'ERROR__FAILED__PYTHON_JAIABOT_TSYS01_TEMPERATURE_SENSOR_DRIVER',
+         'runs_on': [Type.BOT],
+         'runs_when': Mode.RUNTIME, 
+         'wanted_by': 'jaiabot_health.service',
+         'restart': 'on-failure'},
+    ]
+    jaiabot_apps.extend(jaiabot_apps_tsys01)
+
 jaia_firmware = [
     {'exe': 'hub-button-led-poweroff.py',
      'description': 'Hub Button LED Poweroff Mode',


### PR DESCRIPTION
The systemd.py section which created the python driver for our Celsius fast-response temperature sensor was removed by mistake. This PR adds it back, without the C++ side (which is now being handled inside of the UDP app).

Tested on an internal BIO and PAM .

