### PR TITLE
bug/initialize-first-depth-value-ctd

### DIFF
--- a/src/bin/ctd_manager/app.cpp
+++ b/src/bin/ctd_manager/app.cpp
@@ -86,8 +86,7 @@ void jaiabot::apps::CTDManager::handle_ctd_profile(const jaiabot::protobuf::CTDP
       return;
     }
 
-    // first reading is 0.00 because pressure adjusted lags behind pressure temperature group
-    double bottom_depth = ctd_profile.snapshot(1).depth();
+    double bottom_depth = ctd_profile.snapshot(0).depth();
     double top_depth = ctd_profile.snapshot(ctd_profile.snapshot_size() - 1).depth();
 
     glog.is_debug1() && glog << "bottom_depth: " << bottom_depth << std::endl;

--- a/src/bin/mission_manager/states/inmission/underway/task/dive/unpowered_ascent.h
+++ b/src/bin/mission_manager/states/inmission/underway/task/dive/unpowered_ascent.h
@@ -39,7 +39,7 @@ struct UnpoweredAscent
         {
             interprocess().publish<jaiabot::groups::camera>(cfg().stop_camera_command());
         }
-
+        latest_ctd_snapshot_.set_depth(context<Dive>().current_depth().value());
         loop(EvLoop());
     }
 

--- a/src/bin/mission_manager/states/inmission/underway/task/dive/unpowered_ascent.h
+++ b/src/bin/mission_manager/states/inmission/underway/task/dive/unpowered_ascent.h
@@ -35,11 +35,13 @@ struct UnpoweredAscent
         typename StateBase::my_context c)
         : StateBase(c)
     {
+        latest_ctd_snapshot_.set_depth(context<Dive>().current_depth().value());
+
         if (cfg().camera_available() && cfg().has_stop_camera_command())
         {
             interprocess().publish<jaiabot::groups::camera>(cfg().stop_camera_command());
         }
-        latest_ctd_snapshot_.set_depth(context<Dive>().current_depth().value());
+        
         loop(EvLoop());
     }
 

--- a/src/web/components/DataOffloadPanel/CTDOffload/CTDOffload.tsx
+++ b/src/web/components/DataOffloadPanel/CTDOffload/CTDOffload.tsx
@@ -49,8 +49,15 @@ export default function CTDOffload(props: Props) {
      *
      * @param {boolean} deleteCTDFiles Clear the files from the Hub after download
      * @returns {void}
+     *
+     * @notes
+     * Exit full screen prior to download so it can be re-established after
      */
     const handleDownloadCTDClick = () => {
+        if (document.fullscreenElement) {
+            document.exitFullscreen();
+        }
+
         for (const [botID, checkedState] of botCheckedStates.entries()) {
             if (checkedState) {
                 const hub = jaiaContext.hubs.getHubs().values().next()?.value as Hub;
@@ -62,6 +69,7 @@ export default function CTDOffload(props: Props) {
                 sendHubCommand(command).then(() => getCTDFiles(botID));
             }
         }
+
         success("Starting CTD download");
     };
 

--- a/src/web/components/DataOffloadPanel/CTDOffload/CTDOffload.tsx
+++ b/src/web/components/DataOffloadPanel/CTDOffload/CTDOffload.tsx
@@ -1,7 +1,7 @@
 import Icon from "@mdi/react";
 import { mdiClose } from "@mdi/js";
 import { success } from "toastr";
-import { useContext, useMemo, useState } from "react";
+import React, { useContext, useState } from "react";
 
 import Hub from "../../../data/hubs/hub";
 import { JaiaContext } from "../../../context/JaiaContext";
@@ -53,7 +53,8 @@ export default function CTDOffload(props: Props) {
      * @notes
      * Exit full screen prior to download so it can be re-established after
      */
-    const handleDownloadCTDClick = () => {
+    const handleDownloadCTDClick = (event: React.MouseEvent) => {
+        event.stopPropagation();
         if (document.fullscreenElement) {
             document.exitFullscreen();
         }
@@ -138,7 +139,10 @@ export default function CTDOffload(props: Props) {
                     />
                     <label>Remove CTD Files From Hub</label>
                 </div>
-                <button className="download-button" onClick={() => handleDownloadCTDClick()}>
+                <button
+                    className="download-button"
+                    onClick={(event) => handleDownloadCTDClick(event)}
+                >
                     Download
                 </button>
             </div>

--- a/src/web/components/DataOffloadPanel/DataOffloadPanel.tsx
+++ b/src/web/components/DataOffloadPanel/DataOffloadPanel.tsx
@@ -24,6 +24,9 @@ export default function DataOffloadPanel() {
      * @returns {void}
      */
     const handleDownloadKMZ = async () => {
+        if (document.fullscreenElement) {
+            document.exitFullscreen();
+        }
         const kmzFilename = getKMZFilename(taskPackets.getIncludedTaskPackets());
         downloadFile(kmzFilename, await getKMZ(taskPackets.getIncludedTaskPackets()));
     };

--- a/src/web/components/DataOffloadPanel/DataOffloadPanel.tsx
+++ b/src/web/components/DataOffloadPanel/DataOffloadPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import DataOffloadQueue from "./DataOffloadQueue/DataOffloadQueue";
 import CTDOffload from "./CTDOffload/CTDOffload";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -23,7 +23,8 @@ export default function DataOffloadPanel() {
      *
      * @returns {void}
      */
-    const handleDownloadKMZ = async () => {
+    const handleDownloadKMZ = async (event: React.MouseEvent<Element, MouseEvent>) => {
+        event.stopPropagation();
         if (document.fullscreenElement) {
             document.exitFullscreen();
         }
@@ -52,7 +53,7 @@ export default function DataOffloadPanel() {
                 <button onClick={handleDownloadCSV} aria-label={"download-csv"}>
                     CSV
                 </button>
-                <button onClick={handleDownloadKMZ} aria-label={"download-kmz"}>
+                <button onClick={(event) => handleDownloadKMZ(event)} aria-label={"download-kmz"}>
                     KMZ
                 </button>
                 <button onClick={handleDownloadCTD} aria-label={"download-ctd"}>

--- a/src/web/components/MissionsPanel/MissionSetStorage/ExportMissionSetButton/ExportMissionSetDialog.tsx
+++ b/src/web/components/MissionsPanel/MissionSetStorage/ExportMissionSetButton/ExportMissionSetDialog.tsx
@@ -47,6 +47,19 @@ export function ExportMissionSetDialog(props: DialogProps) {
  * For an alert, the button will be Close.
  */
 function ButtonRow(props: ButtonRowProps) {
+    /**
+     * Exits full screen so it can be re-established after the export
+     * and passes the confirm signal to the onClose method
+     *
+     * @returns {void}
+     */
+    const handleExportClick = () => {
+        if (document.fullscreenElement) {
+            document.exitFullscreen();
+        }
+        props.onClose(DialogActions.CONFIRMED);
+    };
+
     switch (props.disabledCode) {
         case DisabledCodes.NONE: {
             return (
@@ -57,10 +70,7 @@ function ButtonRow(props: ButtonRowProps) {
                     >
                         Cancel
                     </button>
-                    <button
-                        className="dialog-button"
-                        onClick={() => props.onClose(DialogActions.CONFIRMED)}
-                    >
+                    <button className="dialog-button" onClick={() => handleExportClick()}>
                         Export
                     </button>
                 </div>

--- a/src/web/components/MissionsPanel/MissionSetStorage/ExportMissionSetButton/ExportMissionSetDialog.tsx
+++ b/src/web/components/MissionsPanel/MissionSetStorage/ExportMissionSetButton/ExportMissionSetDialog.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { DisabledCodes, messages } from "./export-messages";
 import { DialogActions } from "../../../../types/context-types";
 
@@ -53,7 +54,8 @@ function ButtonRow(props: ButtonRowProps) {
      *
      * @returns {void}
      */
-    const handleExportClick = () => {
+    const handleExportClick = (event: React.MouseEvent) => {
+        event.stopPropagation();
         if (document.fullscreenElement) {
             document.exitFullscreen();
         }
@@ -70,7 +72,7 @@ function ButtonRow(props: ButtonRowProps) {
                     >
                         Cancel
                     </button>
-                    <button className="dialog-button" onClick={() => handleExportClick()}>
+                    <button className="dialog-button" onClick={(event) => handleExportClick(event)}>
                         Export
                     </button>
                 </div>

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -52,7 +52,7 @@ export default function App() {
      * @returns {void}
      */
     const handleJCCClick = () => {
-        if (isMobile) {
+        if (!document.fullscreenElement && isMobile) {
             document.documentElement.requestFullscreen();
         }
     };


### PR DESCRIPTION
### Summary
This pull request initializes the depth value in the first CTD snapshot to the current depth so we do not need to check the second snapshot for the first sensor reading. Previously, we checked the second reading because the pressure adjusted lags behind raw pressure by one iteration.

### Testing
1. Logged the initial value and conducted multiple dives in simulation, viewing the UNB file each time.