### PR TITLE
bug/depth-achieved-reported-incorrectly

### DIFF
--- a/src/bin/mission_manager/states/inmission/underway/task/dive/powered_descent.h
+++ b/src/bin/mission_manager/states/inmission/underway/task/dive/powered_descent.h
@@ -194,11 +194,11 @@ struct PoweredDescent
                     context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);
                 }
 
-                // Set the max_acceration
+                // Set the max_acceleration
                 context<Dive>().dive_packet().set_max_acceleration_with_units(
                     this->machine().latest_max_acceleration());
 
-                //Commenting out max acceperation hard/soft determination for bottom type to switch to ascent-based logic
+                //Commenting out max acceleration hard/soft determination for bottom type to switch to ascent-based logic
                 // // Determine Hard/Soft
                 // if (this->machine().latest_max_acceleration().value() >=
                 //     cfg().hard_bottom_type_acceleration())

--- a/src/bin/mission_manager/states/inmission/underway/task/dive/powered_descent.h
+++ b/src/bin/mission_manager/states/inmission/underway/task/dive/powered_descent.h
@@ -146,12 +146,15 @@ struct PoweredDescent
                 << ((now - last_depth_change_time_) >
                     static_cast<decltype(now)>(cfg().bottoming_timeout_with_units()))
                 << std::endl;
-
+ 
         if (boost::units::abs(ev.depth - context<Dive>().goal_depth()) <
             cfg().dive_depth_eps_with_units())
         {
-            // Set depth achieved if we have reached our goal depth
-            context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);
+            // Set depth achieved if we have reached our goal depth and are deeper than current depth achieved
+            if (ev.depth > context<Dive>().dive_packet().depth_achieved_with_units())
+            {
+                context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);
+            }
             dive_pdescent_debug.set_depth_reached(true);
             post_event(EvDepthTargetReached());
         }
@@ -185,8 +188,11 @@ struct PoweredDescent
             {
                 context<Dive>().set_seafloor_reached(ev.depth);
 
-                // Set depth achieved if we had a bottoming timeout
-                context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);
+                // Set depth achieved if we had a bottoming timeout and are deeper than our current depth achieved
+                if (ev.depth > context<Dive>().dive_packet().depth_achieved_with_units())
+                {
+                    context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);
+                }
 
                 // Set the max_acceration
                 context<Dive>().dive_packet().set_max_acceleration_with_units(

--- a/src/bin/mission_manager/states/inmission/underway/task/dive/powered_descent.h
+++ b/src/bin/mission_manager/states/inmission/underway/task/dive/powered_descent.h
@@ -150,7 +150,7 @@ struct PoweredDescent
         if (boost::units::abs(ev.depth - context<Dive>().goal_depth()) <
             cfg().dive_depth_eps_with_units())
         {
-            // Set depth achieved if we have reached our goal depth and are deeper than current depth achieved
+            // Set depth achieved if we have reached our goal depth AND are deeper than current depth achieved
             if (ev.depth > context<Dive>().dive_packet().depth_achieved_with_units())
             {
                 context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);
@@ -188,7 +188,7 @@ struct PoweredDescent
             {
                 context<Dive>().set_seafloor_reached(ev.depth);
 
-                // Set depth achieved if we had a bottoming timeout and are deeper than our current depth achieved
+                // Set depth achieved if we had a bottoming timeout AND are deeper than our current depth achieved
                 if (ev.depth > context<Dive>().dive_packet().depth_achieved_with_units())
                 {
                     context<Dive>().dive_packet().set_depth_achieved_with_units(ev.depth);


### PR DESCRIPTION
This bug was discovered when a Bot dove with 1.5 m intervals and a max depth of 10m. The bot reached the seafloor at ~6.15 m, began its hold, but almost immediately rose to the surface while still in the hold state (we assume because of seaweed). The Bot was not on the bottom long enough to reach its bottoming_timeout config, so when its hold was complete it attempted to dive down to its next increment of 7.5 m. Since the prop was fouled, it was not able to dive and instead detected the "bottom" while sitting on the surface, entered the hold state at the surface, and set its depth_achieved for that dive to 0.8 m (at the surface), even though it had actually reached a depth of 6.15 m. 

Fix was tested in sim by manually stopping the motor when we hit the seafloor (simulate sucking in seaweed) and adding a natural ascent, causing the simulated bot to accurately represent what happened in the real world.

Simulated data with old code - Depth_achieved is set to our surface depth, not the actual depth the bot reached:
<img width="1663" height="1624" alt="Screenshot 2026-03-06 095010" src="https://github.com/user-attachments/assets/ab909379-d71d-48fb-84bd-72a10a5c332a" />

Simulated data with fix - Depth_achieved is set to the deepest depth our bot reached:
<img width="1456" height="1427" alt="Screenshot 2026-03-06 095519" src="https://github.com/user-attachments/assets/c06ddb67-abca-44ab-bf3d-2ed5f80664a0" />