### PR TITLE
bug/repeats-break-when-mission-deleted

### DIFF
--- a/src/web/components/BotDetails/BotDetails.tsx
+++ b/src/web/components/BotDetails/BotDetails.tsx
@@ -29,6 +29,7 @@ import {
     getRepeatProgress,
     getDistToWaypoint,
     isBotLogging,
+    searchGhostMissions,
 } from "./bot-details";
 
 import { accordionTheme, addDropdownListener } from "../../utils/style";
@@ -58,15 +59,17 @@ export default function BotDetails() {
     });
 
     const hub = jaiaContext.hubs.getHubs().values().next()?.value;
-
     const botID = jaiaContext.jaiaGlobal.getSelectedNode().id;
     const bot = jaiaContext.bots.getBot(botID);
-
-    const missionID = missionsManager.getMissionID(botID);
-    const mission = jaiaContext.missionSet.getMission(missionID);
-
     if (!bot || !hub) {
         return;
+    }
+
+    const missionID = missionsManager.getMissionID(botID);
+    let mission = jaiaContext.missionSet.getMission(missionID);
+    if (!mission) {
+        // Mission can still be undefined if ghost mission does not exist
+        mission = searchGhostMissions(botID);
     }
 
     const missionStatus: MissionStatus = bot.getMissionStatus();

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -117,6 +117,10 @@ export function getBotOffloadPercent(botID: number, hub: Hub) {
 export function getRepeatProgress(repeats: number, missionStatus: MissionStatus) {
     let repeatProgress = "N/A";
 
+    if (repeats > 1 && !missionStatus?.repeatIndex) {
+        repeatProgress = `${1} of ${repeats}`;
+    }
+
     if (missionStatus?.repeatIndex) {
         repeatProgress = `${missionStatus.repeatIndex + 1} of ${repeats}`;
     }
@@ -156,4 +160,18 @@ export function getDistToWaypoint(missionStatus: MissionStatus) {
         return missionStatus.distanceToTargetWaypoint + " m";
     }
     return "Distance To Goal > 1000";
+}
+
+/**
+ * Loops through the ghost missions to check if a Bot is carrying out a mission
+ *
+ * @param {number} botID Bot of interest
+ * @returns {Mission} Mission Bot is currently running even if deleted from user interface
+ */
+export function searchGhostMissions(botID: number) {
+    for (const ghostMission of missionSet.getGhostMissions().values()) {
+        if (ghostMission.getGhostParameters().botID === botID) {
+            return ghostMission;
+        }
+    }
 }

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -162,7 +162,7 @@ export function getDistToWaypoint(missionStatus: MissionStatus) {
  * Loops through the ghost missions to check if a Bot is carrying out a mission
  *
  * @param {number} botID Bot of interest
- * @returns {Mission} Mission Bot is currently running even if deleted from user interface
+ * @returns {Mission} Mission the Bot is currently running even if deleted from user interface
  */
 export function searchGhostMissions(botID: number) {
     for (const ghostMission of missionSet.getGhostMissions().values()) {

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -117,10 +117,6 @@ export function getBotOffloadPercent(botID: number, hub: Hub) {
 export function getRepeatProgress(repeats: number, missionStatus: MissionStatus) {
     let repeatProgress = "N/A";
 
-    if (repeats > 1 && !missionStatus?.repeatIndex) {
-        repeatProgress = `${1} of ${repeats}`;
-    }
-
     if (missionStatus?.repeatIndex) {
         repeatProgress = `${missionStatus.repeatIndex + 1} of ${repeats}`;
     }

--- a/src/web/context/handlers/command-handlers.ts
+++ b/src/web/context/handlers/command-handlers.ts
@@ -80,7 +80,13 @@ function manageGhostLayer(botID: number, missionID: number) {
         }
     }
 
-    missionSet.getMission(missionID).setGhostParameters({ hasStarted: true, botID: botID });
+    missionSet
+        .getMission(missionID)
+        .setGhostParameters({
+            hasStarted: true,
+            botID: botID,
+            repeats: missionSet.getMission(missionID).getRepeats(),
+        });
     missionSet.addGhostMission(missionID);
     ghostMissionLayer.updateFeatures();
 }

--- a/src/web/data/mission_set/mission.ts
+++ b/src/web/data/mission_set/mission.ts
@@ -25,7 +25,7 @@ export default class Mission {
         // speeds set by missionSet singleton
         this.waypoints = [];
         this.repeats = 1;
-        this.ghostParameters = { hasStarted: false, botID: UNASSIGNED_ID };
+        this.ghostParameters = { hasStarted: false, botID: UNASSIGNED_ID, repeats: 1 };
     }
 
     getMissionID() {
@@ -78,7 +78,7 @@ export default class Mission {
     }
 
     resetGhostParameters() {
-        this.ghostParameters = { hasStarted: false, botID: UNASSIGNED_ID };
+        this.ghostParameters = { hasStarted: false, botID: UNASSIGNED_ID, repeats: 1 };
     }
 
     getWaypoint(waypointNum: number) {

--- a/src/web/types/jaia-system-types.ts
+++ b/src/web/types/jaia-system-types.ts
@@ -64,6 +64,7 @@ export interface TaskParameterPair {
 export interface GhostParameters {
     hasStarted: boolean;
     botID: number;
+    repeats: number;
     isGhost?: boolean;
 }
 


### PR DESCRIPTION
### Summary
The mission repeats displayed in the Bot details panel went undefined when an active mission was deleted. Now we check to see if a ghost mission exists for that Bot, and if it does, we use that.

### Testing
In simulation, run a bot with repeats greater than 1. After you see 2 of x in the Bot details panel, delete the mission and you will continue to see the total number of repeats .