### PR TITLE
bug/only-download-task-packets/JIRA-2212

### DIFF
--- a/src/python/pyjaia/src/pyjaia/task_packet_database.py
+++ b/src/python/pyjaia/src/pyjaia/task_packet_database.py
@@ -117,6 +117,10 @@ class TaskPacketDatabase:
             self.db.commit()
             self.task_packets_version += 1
 
+    def add_task_packets_from_files(self):
+        """Loads all modified taskpacket files from the offload directory."""
+        with self._lock:
+            self._update()
 
     def query_task_packets(self, bot_ids: Union[Iterable[int], None]=None, start_utime: Union[int, None]=None, end_utime: Union[int, None]=None, included: Union[bool, None]=None):
         """Queries the task packets.
@@ -204,4 +208,3 @@ class TaskPacketDatabase:
             self.db.execute(f'insert or replace into included (id, included) values (?, ?)', (task_packet_id, 1 if included else 0))
             self.db.commit()
             self.task_packets_version += 1
-

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -169,6 +169,10 @@ class Interface:
             if msg.HasField('hub_status'):
                 hubStatus = protobufMessageToDict(msg.hub_status)
 
+                if 'bot_offload' in hubStatus:
+                    if 'offload_succeeded' in hubStatus['bot_offload']:
+                        self.task_packet_database._update()
+
                 # Set the time of last status to now
                 hubStatus['lastStatusReceivedTime'] = now_utime()
 

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -170,7 +170,7 @@ class Interface:
                 hubStatus = protobufMessageToDict(msg.hub_status)
 
                 if 'bot_offload' in hubStatus:
-                    if 'offload_succeeded' in hubStatus['bot_offload']:
+                    if 'offload_succeeded' in hubStatus['bot_offload'] is True:
                         self.task_packet_database._update()
 
                 # Set the time of last status to now

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -170,7 +170,7 @@ class Interface:
                 hubStatus = protobufMessageToDict(msg.hub_status)
 
                 if 'bot_offload' in hubStatus:
-                    if 'offload_succeeded' in hubStatus['bot_offload'] is True:
+                    if hubStatus['bot_offload'].get('offload_succeeded') is True:
                         self.task_packet_database._update()
 
                 # Set the time of last status to now


### PR DESCRIPTION
### Summary
As part of the switch to using a database to store task packets on the Hub, we forgot to update the database when a Bot offload occurs. This offload could include task packets collected outside of radio range with the Hub. This pull request triggers a database update after each Bot completes its data offload.

### Testing
1. Increased verbosity to view arguments passed to `jaiabot-predataoffload.sh`. The `'*.goby'` argument is used to ignore files of that type. This is done with the following line in `bot.py`: `jaia_data_offload_ignore_type="GOBY".`
```
Performing pre-data offload with command: [jaiabot-predataoffload.sh /home/mtwomey/jaia-logs/bot/1 /home/mtwomey/jaia-logs/staging '*.goby' 2>&1]
```
2. End-to-end test
* Remove `/var/log/jaiabot/db`
* Remove ` *.taskpacket` files form `/var/log/jaiabot/bot_offload`
* Restart the server
* Move `*.taskpacket` files into `/var/log/jaiabot/bot_offload` that contain task packets from the last 14 hours
* Open the JCC, verify no task packets appear
* Start a data offload
* On data offload success, the task packets appear in the JCC