### PR TITLE
bug/quick fix for disk space on CloudHub - don't log with goby_logger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,8 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
-
+        - "bug/2.y/cloudhub-primary-runs-out-of-log-space"
+        
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,6 @@ filter-template-debian-builds: &filter-template-debian-builds
     branches:
       only:
         - "2.y"
-        - "bug/2.y/cloudhub-primary-runs-out-of-log-space"
         
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds

--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -286,7 +286,8 @@ elif common.app == 'goby_logger':
                                      app_block=app_common,
                                      interprocess_block = interprocess_common,
                                      goby_logger_dir=log_file_dir,
-                                     goby_logger_group_regex=logger.group_regex))
+                                     goby_logger_group_regex=logger.group_regex,
+                                     log_on_startup='true'))
 elif common.app == 'goby_liaison':
     liaison_port=30000
     if is_simulation():

--- a/config/gen/hub.py
+++ b/config/gen/hub.py
@@ -261,12 +261,18 @@ elif common.app == 'jaiabot_simulator':
                                      app_block=app_common,
                                      interprocess_block = interprocess_common,
                                      hub_gpsd_device=common.hub.gpsd_device())) 
-elif common.app == 'goby_logger':    
+elif common.app == 'goby_logger':
+    log_on_startup='true'
+    if is_cloudhub:
+        # avoid running out of disk space
+        log_on_startup='false'        
+    
     print(config.template_substitute(templates_dir+'/goby_logger.pb.cfg.in',
                                      app_block=app_common,
                                      interprocess_block = interprocess_common,
                                      goby_logger_dir=log_file_dir,
-                                     goby_logger_group_regex=logger.group_regex))
+                                     goby_logger_group_regex=logger.group_regex,
+                                     log_on_startup=log_on_startup))
 elif common.app == 'jaiabot_hub_manager':
     print(config.template_substitute(templates_dir+'/hub/jaiabot_hub_manager.pb.cfg.in',
                                      app_block=app_common,

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -395,8 +395,7 @@ jaiabot_apps = [
      'runs_on': [Type.BOTH],
      'extra_unit': 'BindsTo=var-log.mount\nAfter=var-log.mount',
      'wanted_by': 'jaiabot_health.service',
-     # We run out of disk space on CloudHub if we run the logger
-     'runs_on_cloudhub': CloudHubType.NEVER},
+     'runs_on_cloudhub': CloudHubType.SECONDARY},
     {'exe': 'goby_coroner',
      'description': 'Goby Coroner',
      'template': 'goby-app.service.in',

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -395,7 +395,8 @@ jaiabot_apps = [
      'runs_on': [Type.BOTH],
      'extra_unit': 'BindsTo=var-log.mount\nAfter=var-log.mount',
      'wanted_by': 'jaiabot_health.service',
-     'runs_on_cloudhub': CloudHubType.SECONDARY},
+     # We run out of disk space on CloudHub if we run the logger
+     'runs_on_cloudhub': CloudHubType.NEVER},
     {'exe': 'goby_coroner',
      'description': 'Goby Coroner',
      'template': 'goby-app.service.in',

--- a/config/templates/goby_logger.pb.cfg.in
+++ b/config/templates/goby_logger.pb.cfg.in
@@ -9,3 +9,5 @@ load_shared_library: "libjaiabot_moos_gateway_plugin.so.1"
 
 # exclude internal groups
 group_regex: "$goby_logger_group_regex"
+
+log_at_startup: $log_on_startup


### PR DESCRIPTION
After a while the .goby log files the disk space on CloudHub, causing the machine to hang.

We can consider some more elegant fixes, but this at least keeps the CloudHub up and running.

Possible future fixes:
- Auto log rotation / deletion policy for CloudHub logs
- Ability to run logger only when CloudHub is in active use

## Testing

Tested by installing .deb on chf1. 