### PR TITLE
bug/distance-to-hub-calculation

### DIFF
--- a/src/web/components/BotDetails/BotDetails.tsx
+++ b/src/web/components/BotDetails/BotDetails.tsx
@@ -24,7 +24,6 @@ import { missionsManager } from "../../data/missions_manager/missions-manager";
 import {
     getDistanceToHub,
     getStatusAgeClassName,
-    getWaypontHelperText,
     getBotOffloadPercent,
     getRepeatProgress,
     getDistToWaypoint,
@@ -114,7 +113,6 @@ export default function BotDetails() {
                             ⨯
                         </div>
                     </div>
-                    <h3 className="details-help-text">{getWaypontHelperText(mission)}</h3>
                     <div className="details-toolbar">
                         <StopButton bot={bot} />
                         <StartMissionButton

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -72,22 +72,6 @@ export function getDistanceToHub(botGPS: GPS, hubGPS: GPS) {
 }
 
 /**
- * Provides helper text to operators for creating waypoints
- *
- * @param {Mission} mission Determines what message to display based on properties
- * @returns {string} Helper text for adding waypoints
- *
- * @notes Edit mode toggle and related items will not be functional
- * until mission management refactor is complete
- */
-export function getWaypontHelperText(mission: Mission) {
-    if (!mission || missionSet.getMissionIDInEditMode() === mission.getMissionID()) {
-        return "Click on the map to create waypoints";
-    }
-    return "Click edit toggle to create waypoint";
-}
-
-/**
  * Provides data offload percentage
  *
  * @param {number} botID Used to grab the correct offload data from the Hub

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -8,7 +8,7 @@ import Hub from "../../data/hubs/hub";
 import GPS from "../../data/sensors/gps";
 import Mission from "../../data/mission_set/mission";
 
-import { point, rhumbDistance, Units } from "@turf/turf";
+import { distance, point, Units } from "@turf/turf";
 
 /**
  * Provides a class name that corresponds to styles illustrating comms health
@@ -65,10 +65,10 @@ export function getDistanceToHub(botGPS: GPS, hubGPS: GPS) {
         return "N/A";
     }
 
-    const botLocation = point([botGPS.getLat(), botGPS.getLon()]);
-    const hubLocation = point([hubGPS.getLat(), hubGPS.getLon()]);
+    const botLocation = point([botGPS.getLon(), botGPS.getLat()]);
+    const hubLocation = point([hubGPS.getLon(), hubGPS.getLat()]);
     const options = { units: "meters" as Units };
-    return rhumbDistance(botLocation, hubLocation, options).toFixed(1);
+    return distance(botLocation, hubLocation, options).toFixed(1);
 }
 
 /**

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -8,7 +8,7 @@ import Hub from "../../data/hubs/hub";
 import GPS from "../../data/sensors/gps";
 import Mission from "../../data/mission_set/mission";
 
-import { distance, point, Units } from "@turf/turf";
+import { point, rhumbDistance, Units } from "@turf/turf";
 
 /**
  * Provides a class name that corresponds to styles illustrating comms health
@@ -68,7 +68,7 @@ export function getDistanceToHub(botGPS: GPS, hubGPS: GPS) {
     const botLocation = point([botGPS.getLon(), botGPS.getLat()]);
     const hubLocation = point([hubGPS.getLon(), hubGPS.getLat()]);
     const options = { units: "meters" as Units };
-    return distance(botLocation, hubLocation, options).toFixed(1);
+    return rhumbDistance(botLocation, hubLocation, options).toFixed(1);
 }
 
 /**

--- a/src/web/style/stylesheets/details.less
+++ b/src/web/style/stylesheets/details.less
@@ -21,8 +21,8 @@
         flex-direction: column;
         gap: 16px;
 
-        // 16px aligns the title and X button with the accordion text and ^ icons
-        padding: 12px 16px 16px 16px;
+        // 16px aligns the X button with the accordion ^ icons
+        padding: 12px 16px 12px 12px;
     }
 
     .title-bar {


### PR DESCRIPTION
### Summary
There was a discrepancy between the measure tool and the Distance to Hub value in the Bot details panel. It turns out the lat/lon were flipped in the calculation. This pull request also remove the helper text from the Bot details panel related to mission creation since missions can no longer be created from that window.

### Testing
1. Allow the Bots to drift from the Hub 100+ meters. First verify with the measure tool, then check the Distance to Hub value
2. Inspect the Bot details panel after removing the text at the top 