### PR TITLE
bug/type-error-in-task-packet-db

### DIFF
--- a/src/python/pyjaia/src/pyjaia/task_packet_database.py
+++ b/src/python/pyjaia/src/pyjaia/task_packet_database.py
@@ -35,7 +35,7 @@ def dccl_time_round(utime: int, round_to: int=1_000_000) -> int:
     Returns:
         int: The rounded unix microsecond timestamp.
     """
-    return (utime + round_to // 2) // round_to * round_to
+    return (int(utime) + round_to // 2) // round_to * round_to
 
 
 def sql_set_placeholders(values: list[Any]) -> str:


### PR DESCRIPTION
Utime was being passed as a str in the task packet database. The symptom caused by this was an internal server error (500) when the JCC was accessed after a data offload.