### PR TITLE
bug/data-offload-finished-but-percentage-persists-in-ui/SW-2257

### DIFF
--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -1146,7 +1146,7 @@ void jaiabot::apps::HubManager::start_dataoffload(int bot_id)
                 // Check if the line contains progress information
                 std::string percent_complete_str = "";
                 percent_complete_str.append(buffer.begin(), buffer.begin() + bytes_read);
-                size_t pos = percent_complete_str.find("%");
+                size_t pos = percent_complete_str.rfind("%");
                 if (pos != std::string::npos)
                 {
                     if (pos >= 3)

--- a/src/web/data/hubs/hubs.ts
+++ b/src/web/data/hubs/hubs.ts
@@ -1,4 +1,5 @@
 import { PortalHubStatus } from "../../shared/PortalStatus";
+import { UNASSIGNED_ID } from "../../utils/constants";
 import Hub from "./hub";
 
 /**
@@ -62,7 +63,7 @@ export class Hubs {
             hub.setHubID(hubStatus.hub_id);
         }
 
-        if (hubStatus.fleet_id >= 0) {
+        if (hubStatus.fleet_id && hubStatus.fleet_id >= 0) {
             hub.setFleetID(hubStatus.fleet_id);
         }
 
@@ -101,7 +102,7 @@ export class Hubs {
         if (hubStatus.bot_offload) {
             hub.setBotOffload(hubStatus.bot_offload);
         } else {
-            hub.setBotOffload(undefined);
+            hub.setBotOffload({ bot_id: UNASSIGNED_ID });
         }
 
         // HubSensors

--- a/src/web/data/hubs/hubs.ts
+++ b/src/web/data/hubs/hubs.ts
@@ -100,6 +100,8 @@ export class Hubs {
 
         if (hubStatus.bot_offload) {
             hub.setBotOffload(hubStatus.bot_offload);
+        } else {
+            hub.setBotOffload(undefined);
         }
 
         // HubSensors

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -56,7 +56,7 @@
                 "babel-jest": "^29.7.0",
                 "babel-loader": "^10.1.0",
                 "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-                "copy-webpack-plugin": "14.0.0",
+                "copy-webpack-plugin": "^14.0.0",
                 "css-loader": "^7.1.4",
                 "dotenv-webpack": "^8.1.1",
                 "fake-indexeddb": "^6.2.5",


### PR DESCRIPTION
This PR address potential for Bot Details continues to display a % complete after data download has completed, never gets to 100 and never disappears.
The bug is hard to duplicate.  Analysis identified several things that could cause or contribute to this.

The hub manager only publishes the data offoad status if the data offload thread is running.  On the client side the offload status in context is only updated if it is in the hubStatus message.  The offload percent complete displayed in Bot Details is displayed whenever the offload status exist but is not at 100%.  Likely bug is due to the offload completing on the hub before the client picks up, since the data in context is present and not at 100% it continues to get displayed.  An else clause was added to clear the offload status in context if it is not present in the hubStatus message.

Additionally the hub manager uses find to look for "%" in the percent complete string.  It is possible for there to be 2 %completes in a single string returned from rsync.  The find was changed to rfind so it will pick up the last "%" in the string.

The package-lock was updated to make it in sync with package.json.in, this was accidentally left out of sync when #1508 was submitted.  Matt agreed to piggyback the change here.