### PR TITLE
Add Fleet node and fleet-wide command ACK tracking in JCC

### DIFF
--- a/src/web/components/FleetDetails/FleetDetails.less
+++ b/src/web/components/FleetDetails/FleetDetails.less
@@ -1,0 +1,22 @@
+.fleet-details {
+    .fleet-command-section {
+        margin-bottom: 12px;
+    }
+
+    .command-rollup-row {
+        margin: 4px 0;
+    }
+
+    .fleet-command-table {
+        width: 100%;
+        border-collapse: collapse;
+
+        th,
+        td {
+            text-align: left;
+            padding: 4px 6px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+            font-size: 0.85rem;
+        }
+    }
+}

--- a/src/web/components/FleetDetails/FleetDetails.tsx
+++ b/src/web/components/FleetDetails/FleetDetails.tsx
@@ -1,0 +1,204 @@
+import React, { useContext, useEffect } from "react";
+import { JaiaActions } from "../../context/jaia-actions";
+import { JaiaContext, JaiaDispatchContext } from "../../context/JaiaContext";
+import { JaiaAction, HubAccordionNames } from "../../types/context-types";
+import { NodeTypes } from "../../types/jaia-system-types";
+import { HealthState } from "../../types/protobuf-types";
+import { accordionTheme, addDropdownListener } from "../../utils/style";
+import { convertMicrosecondsToSeconds } from "../../shared/Utilities";
+import { CommandTrackingEntry } from "../../shared/PortalStatus";
+
+import Accordion from "@mui/material/Accordion";
+import Typography from "@mui/material/Typography";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import { ThemeProvider } from "@mui/material";
+
+import "./FleetDetails.less";
+
+function healthToText(health?: HealthState) {
+    switch (health) {
+        case HealthState.HEALTH__FAILED:
+            return "FAILED";
+        case HealthState.HEALTH__DEGRADED:
+            return "WARNING";
+        case HealthState.HEALTH__OK:
+        default:
+            return "OK";
+    }
+}
+
+function linkToText(link?: string) {
+    if (!link) {
+        return "N/A";
+    }
+    return link.replace("LINK_", "");
+}
+
+export default function FleetDetails() {
+    const jaiaContext = useContext(JaiaContext);
+    const jaiaDispatch: React.Dispatch<JaiaAction> = useContext(JaiaDispatchContext);
+
+    useEffect(() => {
+        addDropdownListener("accordion-container", "fleet-details-accordions-container");
+    }, []);
+
+    const selectedNode = jaiaContext.jaiaGlobal.getSelectedNode();
+    if (selectedNode.type !== NodeTypes.FLEET) {
+        return;
+    }
+
+    const hubs = Array.from(jaiaContext.hubs.getHubs().values());
+    const bots = Array.from(jaiaContext.bots.getBots().values());
+    const fleetID = selectedNode.id || hubs[0]?.getFleetID() || 1;
+
+    const botHealth =
+        bots.length === 0
+            ? HealthState.HEALTH__OK
+            : bots.reduce((maxHealth, bot) =>
+                  bot.getHealthState() > maxHealth ? bot.getHealthState() : maxHealth,
+              HealthState.HEALTH__OK);
+    const hubHealth =
+        hubs.length === 0
+            ? HealthState.HEALTH__OK
+            : hubs.reduce((maxHealth, hub) =>
+                  hub.getHealthState() > maxHealth ? hub.getHealthState() : maxHealth,
+              HealthState.HEALTH__OK);
+    const fleetHealth = botHealth > hubHealth ? botHealth : hubHealth;
+
+    const fleetStatusAge = Math.max(
+        0,
+        ...hubs.map((hub) => hub.getStatusAge() || 0),
+        ...bots.map((bot) => bot.getStatusAge() || 0),
+    );
+
+    const commandTracking = jaiaContext.jaiaGlobal.getCommandTracking();
+    const rollups = commandTracking?.rollups ?? [];
+    const commands = commandTracking?.commands ?? [];
+
+    function handleClosePanel() {
+        jaiaDispatch({ type: JaiaActions.CLOSED_DETAILS });
+    }
+
+    function handleAccordionClick(accordionName: HubAccordionNames) {
+        jaiaDispatch({
+            type: JaiaActions.CLICKED_HUB_ACCORDION,
+            hubAccordionName: accordionName,
+        });
+    }
+
+    function getEntryStatus(entry: CommandTrackingEntry) {
+        if (!entry.acked) {
+            return "PENDING";
+        }
+        return entry.ack_result ?? "UNKNOWN";
+    }
+
+    return (
+        <div className="node-details fleet-details">
+            <div className="details-heading">
+                <div className="title-bar">
+                    <h2>{`Fleet ${fleetID}`}</h2>
+                    <div className="close-button" onClick={handleClosePanel}>
+                        ⨯
+                    </div>
+                </div>
+            </div>
+
+            <div className="accordions-container" id="fleet-details-accordions-container">
+                <ThemeProvider theme={accordionTheme}>
+                    <Accordion
+                        expanded={jaiaContext.hubAccordionStates.quickLook}
+                        onChange={() => {
+                            handleAccordionClick(HubAccordionNames.QUICKLOOK);
+                        }}
+                        className="accordion-container"
+                    >
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />} className="accordion-summary">
+                            <Typography>Quick Look</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>Total Bots</td>
+                                        <td>{bots.length}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Bot Health</td>
+                                        <td>{healthToText(botHealth)}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Total Hubs</td>
+                                        <td>{hubs.length}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Hub Health</td>
+                                        <td>{healthToText(hubHealth)}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Fleet Health</td>
+                                        <td>{healthToText(fleetHealth)}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Status Age</td>
+                                        <td>{convertMicrosecondsToSeconds(fleetStatusAge).toFixed(1)} s</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </AccordionDetails>
+                    </Accordion>
+                </ThemeProvider>
+
+                <ThemeProvider theme={accordionTheme}>
+                    <Accordion
+                        expanded={jaiaContext.hubAccordionStates.commands}
+                        onChange={() => {
+                            handleAccordionClick(HubAccordionNames.COMMANDS);
+                        }}
+                        className="accordion-container"
+                    >
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />} className="accordion-summary">
+                            <Typography>Command Delivery</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <div className="fleet-command-section">
+                                <h4>Fleet-wide rollup</h4>
+                                {rollups.length === 0 && <p>No fleet-wide command rollups yet.</p>}
+                                {rollups.map((rollup) => (
+                                    <p key={rollup.group_id} className="command-rollup-row">
+                                        {`${rollup.ack_success}/${rollup.total_targets} bots ACKed, ${rollup.ack_failure} failed, ${rollup.pending} pending (${rollup.command_type})`}
+                                    </p>
+                                ))}
+                            </div>
+                            <div className="fleet-command-section">
+                                <h4>Recent command results</h4>
+                                <table className="fleet-command-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Bot</th>
+                                            <th>Command</th>
+                                            <th>Status</th>
+                                            <th>Link</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {commands.slice(0, 20).map((entry) => (
+                                            <tr key={entry.command_key}>
+                                                <td>{entry.bot_id}</td>
+                                                <td>{entry.command_type}</td>
+                                                <td>{getEntryStatus(entry)}</td>
+                                                <td>{linkToText(entry.ack_link)}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </AccordionDetails>
+                    </Accordion>
+                </ThemeProvider>
+            </div>
+        </div>
+    );
+}

--- a/src/web/components/NodeList/NodeList.less
+++ b/src/web/components/NodeList/NodeList.less
@@ -50,6 +50,19 @@
         }
     }
 
+    .fleet-item {
+        border-radius: 20px;
+        min-width: 70px;
+        font-size: 13px;
+
+        .fleet-label {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            line-height: 1.1;
+        }
+    }
+
     // The order of these matters
     > div.node-item.tracked {
         .node-bgcolor(@tracked-color);

--- a/src/web/components/NodeList/NodeList.tsx
+++ b/src/web/components/NodeList/NodeList.tsx
@@ -11,7 +11,7 @@ import { CLOUD_HUB_ID } from "../../utils/constants";
 import "./NodeList.less";
 
 /**
- * Displays the Hub and Bot tabs on the left side of the JCC
+ * Displays the Fleet, Hub, and Bot tabs on the left side of the JCC
  */
 export default function NodeList() {
     const jaiaContext: JaiaContextType = useContext(JaiaContext);
@@ -24,12 +24,28 @@ export default function NodeList() {
     const hubs = Array.from(jaiaContext.hubs.getHubs().values());
     const bots = Array.from(jaiaContext.bots.getBots().values());
 
+    const fleetID = hubs[0]?.getFleetID() ?? 1;
+
+    const allHealthStates = [
+        ...hubs.map((hub) => hub.getHealthState()),
+        ...bots.map((bot) => bot.getHealthState()),
+    ].filter((healthState) => healthState !== undefined);
+
+    const fleetHealthState =
+        allHealthStates.length === 0
+            ? HealthState.HEALTH__OK
+            : allHealthStates.reduce((maxState, state) =>
+                  state > maxState ? state : maxState,
+              );
+
+    const fleetStatusAge = Math.max(
+        0,
+        ...hubs.map((hub) => hub.getStatusAge()),
+        ...bots.map((bot) => bot.getStatusAge()),
+    );
+
     /**
      * Dispatches the CLICKED_NODE action to JaiaContext for further handling
-     *
-     * @param {NodeTypes} nodeType Indicates Bot or Hub
-     * @param {number} nodeID Provides Bot or Hub ID
-     * @returns {void}
      */
     const handleClick = (nodeType: NodeTypes, nodeID: number) => {
         JaiaDispatch({
@@ -38,16 +54,6 @@ export default function NodeList() {
         });
     };
 
-    /**
-     * Creates the class name that applies the correct style to a node item
-     * based on type, selection, and health
-     *
-     * @param {NodeTypes} nodeType Indicates Bot or Hub
-     * @param {number} nodeID Provides ID of Bot or Hub
-     * @param {HealthState} healthState Determines color of node item
-     * @param {number} statusAge Indicates comms with the node (microsecodns)
-     * @returns {string} Class name that sets correct style
-     */
     function getClassName(
         nodeType: NodeTypes,
         nodeID: number,
@@ -61,7 +67,12 @@ export default function NodeList() {
             [HealthState.HEALTH__FAILED, 2],
         ]);
 
-        const nodeTypeClass = nodeType === NodeTypes.BOT ? "bot-item" : "hub-item";
+        const nodeTypeClass =
+            nodeType === NodeTypes.BOT
+                ? "bot-item"
+                : nodeType === NodeTypes.HUB
+                  ? "hub-item"
+                  : "fleet-item";
         const faultLevelClass = "faultLevel" + faultLevel.get(healthState);
         const selectedNode = jaiaContext.jaiaGlobal.getSelectedNode();
         const selectedClass =
@@ -78,6 +89,16 @@ export default function NodeList() {
 
     return (
         <div id="nodeList" data-testid="nodeList">
+            <div
+                key={`fleet-${fleetID}`}
+                onClick={() => handleClick(NodeTypes.FLEET, fleetID)}
+                className={getClassName(NodeTypes.FLEET, fleetID, fleetHealthState, fleetStatusAge)}
+            >
+                <div className="fleet-label">
+                    <span className="fleet-text">FLEET</span>
+                    <span className="fleet-number">{fleetID}</span>
+                </div>
+            </div>
             {hubs.map((hub) => (
                 <div
                     key={`hub-${hub.getHubID()}`}

--- a/src/web/components/NodeList/__tests__/NodeList.test.tsx
+++ b/src/web/components/NodeList/__tests__/NodeList.test.tsx
@@ -55,12 +55,13 @@ test("Verify all nodes are displayed correctly", () => {
         .getAllByRole("generic")
         .filter((el) => el.classList.contains("node-item"));
 
-    expect(nodeItems).toHaveLength(4);
+    expect(nodeItems).toHaveLength(5);
 
     // Hub textContent is now "HUB1" (hub-text "HUB" + hub-number "1" concatenated)
-    expect(nodeItems.map((div) => div.textContent)).toEqual(["HUB1", "1", "2", "5"]);
+    expect(nodeItems.map((div) => div.textContent)).toEqual(["FLEET1", "HUB1", "1", "2", "5"]);
 
     expect(nodeItems.map((div) => div.className)).toEqual([
+        "node-item fleet-item faultLevel1  ",
         "node-item hub-item faultLevel0  ",
         "node-item bot-item faultLevel0  ",
         "node-item bot-item faultLevel1  ",
@@ -76,22 +77,22 @@ test("Verify node selection updates style", async () => {
         .getAllByRole("generic")
         .filter((el) => el.classList.contains("node-item"));
 
-    expect(nodeItems).toHaveLength(4);
+    expect(nodeItems).toHaveLength(5);
 
     // Verify nothing is selected
     expect(nodeItems.map((div) => div.className)).not.toContain("selected");
 
-    // Select the Hub and verify it is selected
+    // Select the Fleet and verify it is selected
     await userEvent.click(nodeItems[0]);
     expect(nodeItems[0].className).toContain("selected");
 
     // Select a Bot and verify selection changed
-    await userEvent.click(nodeItems[3]);
-    expect(nodeItems[3].className).toContain("selected");
+    await userEvent.click(nodeItems[4]);
+    expect(nodeItems[4].className).toContain("selected");
     expect(nodeItems[0].className).not.toContain("selected");
 
     // Deselect the Bot and verify nothing is selected
-    await userEvent.click(nodeItems[3]);
+    await userEvent.click(nodeItems[4]);
     expect(nodeItems.map((div) => div.className)).not.toContain("selected");
 });
 
@@ -105,11 +106,12 @@ test("Nodes should be displayed in correct order (Hub first, then Bots sorted by
 
     const textContent = nodeItems.map((div) => div.textContent);
 
-    // Hub now renders "HUB" + hub ID concatenated via child spans
-    expect(textContent[0]).toBe("HUB1");
+    // Fleet and Hub labels should lead the list
+    expect(textContent[0]).toBe("FLEET1");
+    expect(textContent[1]).toBe("HUB1");
 
     // Check that Bot IDs are in ascending order
-    const botTexts = textContent.slice(1); // Remove the hub
+    const botTexts = textContent.slice(2); // Remove fleet and hub
     const botIDs = botTexts.map((text) => Number(text));
     const sortedBotIds = [...botIDs].sort((a, b) => a - b);
 

--- a/src/web/data/jaia_global/jaia-global.ts
+++ b/src/web/data/jaia_global/jaia-global.ts
@@ -8,6 +8,7 @@ import {
 } from "../../types/jaia-system-types";
 import { MapFeatureTypes, MapModes } from "../../types/openlayers-types";
 import { Metadata, Version } from "../../types/protobuf-types";
+import { CommandTrackingSnapshot } from "../../shared/PortalStatus";
 import { UNASSIGNED_ID } from "../../utils/constants";
 
 export interface JaiaGlobalSnapshot {
@@ -54,6 +55,7 @@ export class JaiaGlobal {
     private gitHubVersion: Version;
     private isUpgradeAvailable: boolean;
     private isConnectedToInternet: boolean;
+    private commandTracking: CommandTrackingSnapshot;
 
     constructor() {
         this.selectedNode = { type: NodeTypes.NONE, id: UNASSIGNED_ID };
@@ -73,6 +75,7 @@ export class JaiaGlobal {
         this.gitHubVersion = defaultGitHubVersion;
         this.isUpgradeAvailable = false;
         this.isConnectedToInternet = false;
+        this.commandTracking = { commands: [], rollups: [] };
     }
 
     getSelectedNode() {
@@ -162,6 +165,14 @@ export class JaiaGlobal {
         this.isConnectedToInternet = isConnectedToInternet;
     }
 
+
+    getCommandTracking() {
+        return this.commandTracking;
+    }
+
+    setCommandTracking(commandTracking: CommandTrackingSnapshot) {
+        this.commandTracking = commandTracking;
+    }
     resetSelectedWaypoint() {
         this.selectedWaypoint = {
             waypointNum: UNASSIGNED_ID,

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -12,6 +12,7 @@ import NodeList from "../components/NodeList/NodeList";
 import JaiaAbout from "../components/JaiaAbout/JaiaAbout";
 import HubDetails from "../components/HubDetails/HubDetails";
 import BotDetails from "../components/BotDetails/BotDetails";
+import FleetDetails from "../components/FleetDetails/FleetDetails";
 import ButtonList from "../components/ButtonList/ButtonList";
 import HelpWindow from "../components/HelpWindow/HelpWindow";
 import RallyPanel from "../components/RallyPanel/RallyPanel";
@@ -93,6 +94,8 @@ function Details() {
             return <HubDetails />;
         case NodeTypes.BOT:
             return <BotDetails />;
+        case NodeTypes.FLEET:
+            return <FleetDetails />;
         default:
             return;
     }

--- a/src/web/jcc/polling.ts
+++ b/src/web/jcc/polling.ts
@@ -2,7 +2,11 @@ import { bots } from "../data/bots/bots";
 import { hubs } from "../data/hubs/hubs";
 import { jaiaGlobal } from "../data/jaia_global/jaia-global";
 import { taskPackets } from "../data/task_packets/task-packets";
-import { PortalBotStatus, PortalHubStatus } from "../shared/PortalStatus";
+import {
+    PortalBotStatus,
+    PortalHubStatus,
+    CommandTrackingSnapshot,
+} from "../shared/PortalStatus";
 import { botLayer } from "../openlayers/layers/vector/bot-layer";
 import { hubLayer } from "../openlayers/layers/vector/hub-layer";
 import { ghostMissionLayer, missionLayer } from "../openlayers/layers/vector/mission-layer";
@@ -62,7 +66,7 @@ export async function pollStatus() {
             const json = await response.json();
             updateBots(json.bots);
             updateHubs(json.hubs);
-            updateJaiaGlobal(json.controllingClientId);
+            updateJaiaGlobal(json.controllingClientId, json.command_tracking);
             updateOpenLayers();
             if (json.messages.error && json.messages.error === HUB_CONNECTION_ERROR) {
                 updateWarning(CONNECTION_WARNING, true);
@@ -229,8 +233,14 @@ function updateHubs(hubStatuses: { [hubId: string]: PortalHubStatus }) {
  * @param {string} controllingClientID ID from the server
  * @returns {void}
  */
-function updateJaiaGlobal(controllingClientID: string) {
+function updateJaiaGlobal(
+    controllingClientID: string,
+    commandTracking?: CommandTrackingSnapshot,
+) {
     jaiaGlobal.setControllingClientID(controllingClientID);
+    if (commandTracking) {
+        jaiaGlobal.setCommandTracking(commandTracking);
+    }
 }
 
 /**

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -27,6 +27,8 @@ import logging
 
 # Threshold time interval for adding bot locations to the bot_path list (microseconds)
 BOT_PATH_UTIME_THRESHOLD = 2_000_000
+COMMAND_GROUP_WINDOW_UTIME = 2_000_000
+MAX_COMMAND_TRACKING_ENTRIES = 500
 
 
 def protobufMessageToDict(message):
@@ -64,6 +66,12 @@ class Interface:
 
     # Task packet database
     task_packet_database = TaskPacketDatabase()
+
+    # Dict from command key => command tracking entry
+    command_tracking = {}
+
+    # Dict from group_id => rollup tracking
+    command_rollups = {}
 
     def __init__(self, goby_host=('localhost', 40000), read_only=False):
         self.goby_host = goby_host
@@ -188,6 +196,9 @@ class Interface:
                 contact_update = protobufMessageToDict(msg.contact_update)
                 contact_id = contact_update['contact']
                 self.contacts[contact_id] = contact_update
+
+            if msg.HasField('command_comms_result'):
+                self.track_command_comms_result(msg.command_comms_result)
                 
             # If we were disconnected, then report successful reconnection
             if self.pingCount > 1:
@@ -236,7 +247,8 @@ class Interface:
         command = google.protobuf.json_format.ParseDict(command_dict, Command())
 
         logging.debug(f'Sending command: {command}')
-        command.time = now_utime()
+        if command.time <= 0:
+            command.time = now_utime()
 
         if (
                 command.type == Command.MISSION_PLAN
@@ -247,6 +259,7 @@ class Interface:
 
         msg = ClientToPortalMessage()
         msg.command.CopyFrom(command)
+        self.track_sent_command(command, clientId)
 
         if self.send_message_to_portal(msg):
             self.setControllingClientId(clientId)
@@ -407,7 +420,8 @@ class Interface:
             'hubs': self.hubs,
             'bots': self.bots,
             'contacts': self.contacts,
-            'messages': self.messages
+            'messages': self.messages,
+            'command_tracking': self.get_command_tracking_summary()
         }
 
         try:
@@ -461,6 +475,117 @@ class Interface:
         self.send_message_to_portal(msg)
 
         return {'status': 'ok'}
+
+    def get_command_key(self, command):
+        return f"{command.time}:{command.type}:{command.bot_id}"
+
+    def get_command_group_id(self, command, clientId):
+        command_type = int(command.type)
+        now = now_utime()
+        for group in self.command_rollups.values():
+            if (
+                group['command_type'] == command_type
+                and group.get('client_id') == clientId
+                and now - group['sent_time'] <= COMMAND_GROUP_WINDOW_UTIME
+            ):
+                return group['group_id']
+
+        group_id = f"{clientId}:{command_type}:{command.time}"
+        self.command_rollups[group_id] = {
+            'group_id': group_id,
+            'command_type': command_type,
+            'sent_time': command.time,
+            'client_id': clientId,
+            'command_keys': set(),
+            'targets': set(),
+            'acked_success': set(),
+            'acked_failure': set(),
+        }
+        return group_id
+
+    def track_sent_command(self, command, clientId):
+        command_key = self.get_command_key(command)
+        group_id = self.get_command_group_id(command, clientId)
+
+        entry = {
+            'command_key': command_key,
+            'group_id': group_id,
+            'bot_id': int(command.bot_id),
+            'command_type': int(command.type),
+            'command_time': int(command.time),
+            'sent_time': now_utime(),
+            'client_id': clientId,
+            'acked': False,
+        }
+        self.command_tracking[command_key] = entry
+
+        rollup = self.command_rollups[group_id]
+        rollup['command_keys'].add(command_key)
+        rollup['targets'].add(int(command.bot_id))
+
+        if len(self.command_tracking) > MAX_COMMAND_TRACKING_ENTRIES:
+            oldest_key = min(self.command_tracking, key=lambda key: self.command_tracking[key]['sent_time'])
+            del self.command_tracking[oldest_key]
+
+    def track_command_comms_result(self, command_comms_result):
+        result_dict = protobufMessageToDict(command_comms_result)
+        orig_command_dict = result_dict.get('orig_command', {})
+
+        command_key = f"{orig_command_dict.get('time')}:{orig_command_dict.get('type')}:{orig_command_dict.get('bot_id')}"
+
+        entry = self.command_tracking.get(command_key)
+        if entry is None:
+            return
+
+        ack_result = result_dict.get('result')
+        entry['acked'] = True
+        entry['ack_result'] = ack_result
+        entry['ack_link'] = result_dict.get('link')
+        entry['updated_time'] = now_utime()
+
+        rollup = self.command_rollups.get(entry['group_id'])
+        if rollup is None:
+            return
+
+        if ack_result == 'SUCCESS':
+            rollup['acked_success'].add(entry['bot_id'])
+            rollup['acked_failure'].discard(entry['bot_id'])
+        elif ack_result == 'FAILURE':
+            rollup['acked_failure'].add(entry['bot_id'])
+            rollup['acked_success'].discard(entry['bot_id'])
+
+    def get_command_tracking_summary(self):
+        commands = sorted(self.command_tracking.values(), key=lambda x: x['sent_time'], reverse=True)
+
+        rollups = []
+        for rollup in self.command_rollups.values():
+            total_targets = len(rollup['targets'])
+            ack_success = len(rollup['acked_success'])
+            ack_failure = len(rollup['acked_failure'])
+            pending = max(total_targets - ack_success - ack_failure, 0)
+            rollups.append({
+                'group_id': rollup['group_id'],
+                'command_type': Command.CommandType.Name(rollup['command_type']),
+                'sent_time': rollup['sent_time'],
+                'total_targets': total_targets,
+                'ack_success': ack_success,
+                'ack_failure': ack_failure,
+                'pending': pending,
+            })
+
+        rollups = [rollup for rollup in rollups if rollup['total_targets'] > 1]
+        rollups.sort(key=lambda item: item['sent_time'], reverse=True)
+
+        serialized_commands = []
+        for command in commands[:100]:
+            serialized = dict(command)
+            serialized['command_type'] = Command.CommandType.Name(command['command_type'])
+            serialized_commands.append(serialized)
+
+        return {
+            'commands': serialized_commands,
+            'rollups': rollups[:30],
+        }
 
     def process_task_packet(self, task_packet_message):
         task_packet = protobufMessageToDict(task_packet_message)

--- a/src/web/shared/PortalStatus.ts
+++ b/src/web/shared/PortalStatus.ts
@@ -16,6 +16,7 @@ export interface PodStatus {
     bots: { [key: string]: PortalBotStatus };
     contacts: { [key: string]: ContactStatus };
     controllingClientId: string;
+    command_tracking?: CommandTrackingSnapshot;
 }
 
 export interface Version {
@@ -39,4 +40,34 @@ export interface Metadata {
 
 export function isRemoteControlled(mission_state?: MissionState) {
     return mission_state?.includes("REMOTE_CONTROL") || false;
+}
+
+
+export interface CommandTrackingEntry {
+    command_key: string;
+    group_id: string;
+    bot_id: number;
+    command_type: string;
+    command_time: number;
+    sent_time: number;
+    client_id?: string;
+    acked: boolean;
+    ack_result?: string;
+    ack_link?: string;
+    updated_time?: number;
+}
+
+export interface CommandTrackingRollup {
+    group_id: string;
+    command_type: string;
+    sent_time: number;
+    total_targets: number;
+    ack_success: number;
+    ack_failure: number;
+    pending: number;
+}
+
+export interface CommandTrackingSnapshot {
+    commands: CommandTrackingEntry[];
+    rollups: CommandTrackingRollup[];
 }

--- a/src/web/types/jaia-system-types.ts
+++ b/src/web/types/jaia-system-types.ts
@@ -11,6 +11,7 @@ export enum NodeTypes {
     NONE = "NONE",
     BOT = "BOT",
     HUB = "HUB",
+    FLEET = "FLEET",
 }
 
 export interface SelectedNode {


### PR DESCRIPTION
### Motivation
- Provide a single Fleet-level node in the left Node List to show fleet-wide health and let operators inspect fleet-wide summaries. 
- Surface delivery/ACK information for fleet-wide commands so operators can quickly see rollups (e.g. “7/8 bots ACKed”) rather than scanning each bot.
- Ensure command ACKs reported from hubs (via `command_comms_result`) make it through the server into the client UI for display and rollup computation.

### Description
- UI: Added a Fleet node to the Node List and computed fleet health/status-age from all hubs and bots, with styles in `src/web/components/NodeList/NodeList.tsx` and `NodeList.less`, and added `NodeTypes.FLEET` to `src/web/types/jaia-system-types.ts`.
- UI: Implemented a `FleetDetails` panel (`src/web/components/FleetDetails/FleetDetails.tsx` + `.less`) with a Quick Look (total bots/hubs + health) and a Command Delivery accordion that shows fleet rollups and recent per-bot command ACK rows.
- Server: Extended `src/web/server/jaia_portal.py` to track sent bot commands, group likely fleet-wide sends, consume `command_comms_result` messages, correlate ACK/FAIL updates to originating commands, and expose a `command_tracking` summary in the `/jaia/v0/status` payload.
- Client wiring/types: Added `CommandTracking*` interfaces to `src/web/shared/PortalStatus.ts`, stored command tracking in the client global (`src/web/data/jaia_global/jaia-global.ts`), and updated polling (`src/web/jcc/polling.ts`) to pass the server `command_tracking` into the client state; updated `NodeList` tests to include the Fleet node ordering and selection behavior (`src/web/components/NodeList/__tests__/NodeList.test.tsx`).

### Testing
- `python -m py_compile src/web/server/jaia_portal.py` succeeded.
- `python -m py_compile src/web/server/app.py src/web/server/jaia_portal.py` succeeded.
- Attempted `npm test -- NodeList --runInBand` but the test run could not be executed in this environment because `src/web/package.json` is not present (repository snapshot missing web package files), so the updated `NodeList` unit test was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7bde131088328988a0b7b66265796)