### PR TITLE
Exclude disconnected nodes from fleet health calculation and reverse command ACK numbering

### DIFF
--- a/src/web/components/FleetDetails/FleetDetails.tsx
+++ b/src/web/components/FleetDetails/FleetDetails.tsx
@@ -188,7 +188,9 @@ export default function FleetDetails() {
                                                         : "row-all-success"
                                                 }
                                             >
-                                                <td className="cmd-counter">{idx + 1}</td>
+                                                <td className="cmd-counter">
+                                                    {commandGroups.length - idx}
+                                                </td>
                                                 <td className="cmd-type">
                                                     {group.commandType.replace(/_/g, " ")}
                                                 </td>

--- a/src/web/components/NodeList/NodeList.tsx
+++ b/src/web/components/NodeList/NodeList.tsx
@@ -33,11 +33,16 @@ export default function NodeList() {
         [HealthState.HEALTH__FAILED, 2],
     ]);
 
+    const connectedNodes = [...hubs, ...bots].filter(
+        (node) => !isDisconnected(node.getStatusAge(), "getLink" in node ? node.getLink() : undefined),
+    );
+
     const fleetHealthState = fleet.computeWorstHealthState(
-        [
-            ...hubs.map((hub) => hub.getHealthState()),
-            ...bots.map((bot) => bot.getHealthState()),
-        ].filter(Boolean) as HealthState[],
+        connectedNodes.length > 0
+            ? (connectedNodes
+                  .map((node) => node.getHealthState())
+                  .filter(Boolean) as HealthState[])
+            : [HealthState.HEALTH__OK],
     );
 
     const fleetStatusAge = Math.max(


### PR DESCRIPTION
### Motivation
- Ensure fleet health reflects only connected nodes so stale/disconnected nodes do not skew health reporting.
- Avoid passing an empty array into `computeWorstHealthState` by providing a safe default when all nodes are disconnected.
- Make the command ACK list numbering descending so the most recent command appears with counter 1.

### Description
- Added `connectedNodes` which filters out disconnected hubs and bots using `isDisconnected(node.getStatusAge(), node.getLink())` and uses it as the source for health calculations.
- Changed the `fleetHealthState` input to call `fleet.computeWorstHealthState` with health states from `connectedNodes` and fall back to `[HealthState.HEALTH__OK]` when no connected nodes exist.
- Reversed the command ACK counter in `FleetDetails.tsx` to render `commandGroups.length - idx` instead of `idx + 1` so newer commands show as lower numbers.

### Testing
- Ran the TypeScript build with `tsc` and the project compiled successfully. 
- Ran the unit test suite with `yarn test` and all tests passed. 
- Ran linting with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86861e3fc8328903197bab3603d94)