### PR TITLE
task/protect-against-duplicate-messages

### DIFF
--- a/config/templates/bot/jaiabot_fusion.pb.cfg.in
+++ b/config/templates/bot/jaiabot_fusion.pb.cfg.in
@@ -39,7 +39,7 @@ imu_detect_horizontal_pitch: 45 # (default=45 degrees)
 imu_issue_solution: $imu_detection_solution
 
 # Set the period to send bot status in milliseconds
-bot_status_period_ms: $bot_status_period # default ((bot_index * 10) + 1000 milliseconds)
+bot_status_period_ms: $bot_status_period
 
 include_course_error_detection_states: IN_MISSION__UNDERWAY__MOVEMENT__TRANSIT
 include_course_error_detection_states: IN_MISSION__UNDERWAY__TASK__STATION_KEEP

--- a/src/bin/engineering/app.cpp
+++ b/src/bin/engineering/app.cpp
@@ -70,7 +70,7 @@ class JaiabotEngineering : public ApplicationBase
     // Store previous commands time to ensure commands ignore duplicates
     std::set<uint64_t> prev_command_times_;
     // only store up to the last N previous command times to avoid
-    // potential memory leak on very long missions
+    // large memory usage
     constexpr static std::size_t command_history_max_count_{100};
 };
 } // namespace apps

--- a/src/bin/engineering/app.cpp
+++ b/src/bin/engineering/app.cpp
@@ -66,6 +66,12 @@ class JaiabotEngineering : public ApplicationBase
     goby::middleware::protobuf::TransporterConfig latest_command_sub_cfg_;
 
     bool queried_for_status_{false};
+
+    // Store previous commands time to ensure commands ignore duplicates
+    std::set<uint64_t> prev_command_times_;
+    // only store up to the last N previous command times to avoid
+    // potential memory leak on very long missions
+    constexpr static std::size_t command_history_max_count_{100};
 };
 } // namespace apps
 } // namespace jaiabot
@@ -257,8 +263,23 @@ void jaiabot::apps::JaiabotEngineering::intervehicle_subscribe(
     intervehicle().subscribe_dynamic<jaiabot::protobuf::Engineering>(
         [this](const jaiabot::protobuf::Engineering& command)
         {
-            glog.is_debug1() && glog << "Engineering Command: " << command.ShortDebugString()
-                                     << std::endl;
+            glog.is_debug1() &&
+                glog << "Received Engineering Command: " << command.ShortDebugString() << std::endl;
+
+            // Make sure the command is not a repeat
+            // If it is, then we should not handle the command and exit
+            if (prev_command_times_.count(command.time()))
+            {
+                glog.is_debug1() && glog << "Repeat command received! Ignoring..." << std::endl;
+                return;
+            }
+
+            // Keep track of the previous command times to avoid duplicates
+            // (typically from multiple links)
+            // if our buffer overflows, remove the smallest (oldest) timestamp
+            while (prev_command_times_.size() >= command_history_max_count_)
+                prev_command_times_.erase(prev_command_times_.begin());
+            prev_command_times_.insert(command.time());
 
             handle_engineering_command(command);
         },

--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -720,8 +720,12 @@ void jaiabot::apps::Fusion::loop()
         latest_engineering_status.mutable_rf_disable_options()->set_rf_disable_timeout_mins(
             rf_disabled_timeout_mins_);
 
-        latest_bot_status_.clear_active_link();
-        for (auto link : active_links_) latest_bot_status_.add_active_link(link);
+        latest_bot_status_.clear_active_links();
+        for (auto link : active_links_)
+        {
+            auto* active_link = latest_bot_status_.add_active_links();
+            active_link->set_link(link);
+        }
 
         // If we get an engineering query for bot status
         if (latest_engineering_status.query_bot_status())

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -862,7 +862,7 @@ void jaiabot::apps::HubManager::handle_bot_nav(jaiabot::protobuf::BotStatus dccl
         return;
     }
 
-    // Always stamp the current link last-received times into the proto
+    // Stamp all last-received times into the proto
     // so the portal always has up-to-date link age data
     auto& link_times = bot_status_link_last_received_[dccl_nav.bot_id()];
     for (auto& active_link : *dccl_nav.mutable_active_links())

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -142,7 +142,14 @@ class HubManager : public ApplicationBase
     std::set<jaiabot::protobuf::Link> links_to_subscribe_on_;
 
     // Map bot id to previouse task packet timestamp to ignore duplicates
-    std::map<uint16_t, uint64_t> task_packet_id_to_prev_timestamp_;
+    std::map<uint16_t, std::set<uint64_t>> task_packet_id_to_prev_timestamps_;
+    // Map bot id to previouse bot status timestamp to ignore duplicates
+    std::map<uint16_t, std::set<uint64_t>> bot_status_id_to_prev_timestamps_;
+    // Map bot id to previouse eng status timestamp to ignore duplicates
+    std::map<uint16_t, std::set<uint64_t>> eng_status_id_to_prev_timestamps_;
+    // only store up to the last N previous command times to avoid
+    // potential memory leak on very long missions
+    constexpr static std::size_t history_max_count_{100};
 
     bool is_virtualhub_;
     goby::time::SteadyClock::time_point vfleet_shutdown_time_{
@@ -579,6 +586,25 @@ void jaiabot::apps::HubManager::intervehicle_subscribe(int bot_id,
 
                         auto engineering_status = input_engineering_status;
 
+                        // Make sure the engineering_status is not a repeat
+                        // If it is, then we should not handle the bot_status and exit
+                        auto& prev_times = eng_status_id_to_prev_timestamps_[engineering_status.bot_id()];
+
+                        if (prev_times.count(engineering_status.time()))
+                        {
+                            glog.is_debug1() && glog << group("engineering_status")
+                                                    << "Repeat Engineering Status received! Ignoring..." << std::endl;
+                            return;
+                        }
+
+                        // Keep track of previous engineering status times per bot to avoid duplicates
+                        // (typically from multiple comms links: iridium, wifi, xbee)
+                        // If our buffer overflows, remove the smallest (oldest) timestamp
+                        while (prev_times.size() >= history_max_count_)
+                            prev_times.erase(prev_times.begin());
+
+                        prev_times.insert(engineering_status.time());
+
                         // rewarp the time if needed
                         engineering_status.set_time_with_units(
                             goby::time::convert<goby::time::MicroTime>(
@@ -811,6 +837,25 @@ void jaiabot::apps::HubManager::handle_bot_nav(jaiabot::protobuf::BotStatus dccl
         publish_hub2hub_data(&hub2hub_data);
     }
 
+    // Make sure the bot_status is not a repeat
+    // If it is, then we should not handle the bot_status and exit
+    auto& prev_times = bot_status_id_to_prev_timestamps_[dccl_nav.bot_id()];
+
+    if (prev_times.count(dccl_nav.time()))
+    {
+        glog.is_debug1() && glog << group("bot_status")
+                                << "Repeat Bot Status received! Ignoring..." << std::endl;
+        return;
+    }
+
+    // Keep track of previous bot status times per bot to avoid duplicates
+    // (typically from multiple comms links: iridium, wifi, xbee)
+    // If our buffer overflows, remove the smallest (oldest) timestamp
+    while (prev_times.size() >= history_max_count_)
+        prev_times.erase(prev_times.begin());
+
+    prev_times.insert(dccl_nav.time());
+
     // don't shut down the hub while we have bots reporting to us
     if (is_virtualhub_)
         update_vhub_shutdown_time();
@@ -934,27 +979,24 @@ void jaiabot::apps::HubManager::handle_task_packet(const jaiabot::protobuf::Task
         publish_hub2hub_data(&hub2hub_data);
     }
 
-    if (task_packet_id_to_prev_timestamp_.count(task_packet.bot_id()))
-    {
-        auto prev_time = task_packet_id_to_prev_timestamp_.at(task_packet.bot_id());
+    // Make sure the taskpacket is not a repeat
+    // If it is, then we should not handle the taskpacket and exit
+    auto& prev_times = task_packet_id_to_prev_timestamps_[task_packet.bot_id()];
 
-        // Make sure the taskpacket is not a repeat
-        // If it is, then we should not handle the taskpacket and exit
-        if (prev_time == task_packet.start_time())
-        {
-            glog.is_debug1() && glog << group("task_packet")
-                                     << "Repeat taskpacket received! Ignoring..." << std::endl;
-            return;
-        }
-        // Store the previous taskpacket time
-        task_packet_id_to_prev_timestamp_.at(task_packet.bot_id()) = task_packet.start_time();
-    }
-    else
+    if (prev_times.count(task_packet.start_time()))
     {
-        // Insert new bot id to previous task packet time
-        task_packet_id_to_prev_timestamp_.insert(
-            std::make_pair(task_packet.bot_id(), task_packet.start_time()));
+        glog.is_debug1() && glog << group("task_packet")
+                                << "Repeat taskpacket received! Ignoring..." << std::endl;
+        return;
     }
+
+    // Keep track of previous task packet times per bot to avoid duplicates
+    // (typically from multiple comms links: iridium, wifi, xbee)
+    // If our buffer overflows, remove the smallest (oldest) timestamp
+    while (prev_times.size() >= history_max_count_)
+        prev_times.erase(prev_times.begin());
+
+    prev_times.insert(task_packet.start_time());
 
     // Set the mission_name of the task packet based on the current mission id to name mapping for logging purposes
     jaiabot::protobuf::TaskPacket task_packet_copy = task_packet;

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -591,7 +591,7 @@ void jaiabot::apps::HubManager::intervehicle_subscribe(int bot_id,
                         auto engineering_status = input_engineering_status;
 
                         // Make sure the engineering_status is not a repeat
-                        // If it is, then we should not handle the bot_status and exit
+                        // If it is, then we should not handle it and exit
                         auto& prev_times = eng_status_id_to_prev_timestamps_[engineering_status.bot_id()];
 
                         if (prev_times.count(engineering_status.time()))
@@ -842,7 +842,7 @@ void jaiabot::apps::HubManager::handle_bot_nav(jaiabot::protobuf::BotStatus dccl
     }
 
     // Make sure the bot_status is not a repeat
-    // If it is, then we should not handle the bot_status and exit
+    // If it is, then we should not handle it and exit
     auto& prev_times = bot_status_id_to_prev_timestamps_[dccl_nav.bot_id()];
 
     // Update the last-received time for this link on a fresh status
@@ -1004,7 +1004,7 @@ void jaiabot::apps::HubManager::handle_task_packet(const jaiabot::protobuf::Task
     }
 
     // Make sure the taskpacket is not a repeat
-    // If it is, then we should not handle the taskpacket and exit
+    // If it is, then we should not handle it and exit
     auto& prev_times = task_packet_id_to_prev_timestamps_[task_packet.bot_id()];
 
     if (prev_times.count(task_packet.start_time()))

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -151,6 +151,10 @@ class HubManager : public ApplicationBase
     // potential memory leak on very long missions
     constexpr static std::size_t history_max_count_{100};
 
+    // Map from bot_id => (link => last received time)
+    std::map<uint32_t, std::map<Link, goby::time::SteadyClock::time_point>>
+        bot_status_link_last_received_;
+
     bool is_virtualhub_;
     goby::time::SteadyClock::time_point vfleet_shutdown_time_{
         goby::time::SteadyClock::time_point::max()};
@@ -841,11 +845,30 @@ void jaiabot::apps::HubManager::handle_bot_nav(jaiabot::protobuf::BotStatus dccl
     // If it is, then we should not handle the bot_status and exit
     auto& prev_times = bot_status_id_to_prev_timestamps_[dccl_nav.bot_id()];
 
+    // Update the last-received time for this link on a fresh status
+    // Even if we determine it's a duplicate based on the timestamp,
+    // we still want to update the last-received time for this link to ensure accurate tracking of link age
+    if (dccl_nav.has_link())
+        bot_status_link_last_received_[dccl_nav.bot_id()][dccl_nav.link()] =
+            goby::time::SteadyClock::now();
+
     if (prev_times.count(dccl_nav.time()))
     {
         glog.is_debug1() && glog << group("bot_status")
                                 << "Repeat Bot Status received! Ignoring..." << std::endl;
+
         return;
+    }
+
+    // Always stamp the current link last-received times into the proto
+    // so the portal always has up-to-date link age data
+    auto& link_times = bot_status_link_last_received_[dccl_nav.bot_id()];
+    dccl_nav.clear_link_last_received_time();
+    for (const auto& [link, time_point] : link_times)
+    {
+        auto* entry = dccl_nav.add_link_last_received_time();
+        entry->set_link(link);
+        entry->set_time(goby::time::convert<goby::time::MicroTime>(time_point).value());
     }
 
     // Keep track of previous bot status times per bot to avoid duplicates

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -152,7 +152,7 @@ class HubManager : public ApplicationBase
     constexpr static std::size_t history_max_count_{100};
 
     // Map from bot_id => (link => last received time)
-    std::map<uint32_t, std::map<Link, goby::time::SteadyClock::time_point>>
+    std::map<uint32_t, std::map<jaiabot::protobuf::Link, goby::time::MicroTime>>
         bot_status_link_last_received_;
 
     bool is_virtualhub_;
@@ -850,12 +850,14 @@ void jaiabot::apps::HubManager::handle_bot_nav(jaiabot::protobuf::BotStatus dccl
     // we still want to update the last-received time for this link to ensure accurate tracking of link age
     if (dccl_nav.has_link())
         bot_status_link_last_received_[dccl_nav.bot_id()][dccl_nav.link()] =
-            goby::time::SteadyClock::now();
+            goby::time::SystemClock::now<goby::time::MicroTime>();
 
     if (prev_times.count(dccl_nav.time()))
     {
         glog.is_debug1() && glog << group("bot_status")
-                                << "Repeat Bot Status received! Ignoring..." << std::endl;
+                                << "Repeat Bot Status received on link: " 
+                                << jaiabot::protobuf::Link_Name(dccl_nav.link()) 
+                                << "! Ignoring..." << std::endl;
 
         return;
     }
@@ -863,12 +865,11 @@ void jaiabot::apps::HubManager::handle_bot_nav(jaiabot::protobuf::BotStatus dccl
     // Always stamp the current link last-received times into the proto
     // so the portal always has up-to-date link age data
     auto& link_times = bot_status_link_last_received_[dccl_nav.bot_id()];
-    dccl_nav.clear_link_last_received_time();
-    for (const auto& [link, time_point] : link_times)
+    for (auto& active_link : *dccl_nav.mutable_active_links())
     {
-        auto* entry = dccl_nav.add_link_last_received_time();
-        entry->set_link(link);
-        entry->set_time(goby::time::convert<goby::time::MicroTime>(time_point).value());
+        auto it = link_times.find(active_link.link());
+        if (it != link_times.end())
+            active_link.set_last_received_time(it->second.value());
     }
 
     // Keep track of previous bot status times per bot to avoid duplicates

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -148,7 +148,7 @@ class HubManager : public ApplicationBase
     // Map bot id to previouse eng status timestamp to ignore duplicates
     std::map<uint16_t, std::set<uint64_t>> eng_status_id_to_prev_timestamps_;
     // only store up to the last N previous command times to avoid
-    // potential memory leak on very long missions
+    // large memory usage
     constexpr static std::size_t history_max_count_{100};
 
     // Map from bot_id => (link => last received time)

--- a/src/bin/metadata/app.cpp
+++ b/src/bin/metadata/app.cpp
@@ -74,6 +74,11 @@ void jaiabot::apps::Metadata::publish_metadata()
 
     // Set is_simulation, if present in the config
     metadata.set_is_simulation(cfg().has_is_simulation() && cfg().is_simulation());
+    auto test = goby::time::SimulatorSettings::warp_factor;
+    metadata.set_simulation_warp(goby::time::SimulatorSettings::warp_factor);
+    metadata.set_simulation_reference_time(
+        goby::time::convert<goby::time::MicroTime>(goby::time::SimulatorSettings::reference_time)
+            .value());
 
     if (cfg().has_xbee())
     {

--- a/src/bin/metadata/app.cpp
+++ b/src/bin/metadata/app.cpp
@@ -74,8 +74,8 @@ void jaiabot::apps::Metadata::publish_metadata()
 
     // Set is_simulation, if present in the config
     metadata.set_is_simulation(cfg().has_is_simulation() && cfg().is_simulation());
-    auto test = goby::time::SimulatorSettings::warp_factor;
-    metadata.set_simulation_warp(goby::time::SimulatorSettings::warp_factor);
+    auto warp_factor = goby::time::SimulatorSettings::warp_factor;
+    metadata.set_simulation_warp(warp_factor > 0 ? warp_factor : 1);
     metadata.set_simulation_reference_time(
         goby::time::convert<goby::time::MicroTime>(goby::time::SimulatorSettings::reference_time)
             .value());

--- a/src/bin/mission_manager/mission_manager.cpp
+++ b/src/bin/mission_manager/mission_manager.cpp
@@ -535,6 +535,24 @@ void jaiabot::apps::MissionManager::intervehicle_subscribe(
 
     auto command_callback = [this](const protobuf::Command& input_command)
     {
+        glog.is_debug1() && glog << "Received Command: " << input_command.ShortDebugString()
+                                     << std::endl;
+
+        // Make sure the command is not a repeat
+        // If it is, then we should not handle the command and exit
+        if (prev_command_times_.count(input_command.time()))
+        {
+            glog.is_debug1() && glog << "Repeat command received! Ignoring..." << std::endl;
+            return;
+        }
+
+        // Keep track of the previous command times to avoid duplicates
+        // (typically from multiple links)
+        // if our buffer overflows, remove the smallest (oldest) timestamp
+        while (prev_command_times_.size() >= command_history_max_count_)
+            prev_command_times_.erase(prev_command_times_.begin());
+        prev_command_times_.insert(input_command.time());
+
         if (input_command.type() == protobuf::Command::MISSION_PLAN_FRAGMENT)
         {
             protobuf::Command out_command;
@@ -799,21 +817,6 @@ void jaiabot::apps::MissionManager::handle_command(const protobuf::Command& comm
 
     if (command.has_from_hub_id())
         set_hub_id(command.from_hub_id());
-
-    // Make sure the command is not a repeat
-    // If it is, then we should not handle the command and exit
-    if (prev_command_times_.count(command.time()))
-    {
-        glog.is_debug1() && glog << "Repeat command received! Ignoring..." << std::endl;
-        return;
-    }
-
-    // Keep track of the previous command times to avoid duplicates
-    // (typically from multiple links)
-    // if our buffer overflows, remove the smallest (oldest) timestamp
-    while (prev_command_times_.size() >= command_history_max_count_)
-        prev_command_times_.erase(prev_command_times_.begin());
-    prev_command_times_.insert(command.time());
 
     switch (command.type())
     {

--- a/src/bin/mission_manager/mission_manager.cpp
+++ b/src/bin/mission_manager/mission_manager.cpp
@@ -538,21 +538,6 @@ void jaiabot::apps::MissionManager::intervehicle_subscribe(
         glog.is_debug1() && glog << "Received Command: " << input_command.ShortDebugString()
                                      << std::endl;
 
-        // Make sure the command is not a repeat
-        // If it is, then we should not handle the command and exit
-        if (prev_command_times_.count(input_command.time()))
-        {
-            glog.is_debug1() && glog << "Repeat command received! Ignoring..." << std::endl;
-            return;
-        }
-
-        // Keep track of the previous command times to avoid duplicates
-        // (typically from multiple links)
-        // if our buffer overflows, remove the smallest (oldest) timestamp
-        while (prev_command_times_.size() >= command_history_max_count_)
-            prev_command_times_.erase(prev_command_times_.begin());
-        prev_command_times_.insert(input_command.time());
-
         if (input_command.type() == protobuf::Command::MISSION_PLAN_FRAGMENT)
         {
             protobuf::Command out_command;
@@ -817,6 +802,21 @@ void jaiabot::apps::MissionManager::handle_command(const protobuf::Command& comm
 
     if (command.has_from_hub_id())
         set_hub_id(command.from_hub_id());
+
+    // Make sure the command is not a repeat
+    // If it is, then we should not handle the command and exit
+    if (prev_command_times_.count(command.time()))
+    {
+        glog.is_debug1() && glog << "Repeat command received! Ignoring..." << std::endl;
+        return;
+    }
+
+    // Keep track of the previous command times to avoid duplicates
+    // (typically from multiple links)
+    // if our buffer overflows, remove the smallest (oldest) timestamp
+    while (prev_command_times_.size() >= command_history_max_count_)
+        prev_command_times_.erase(prev_command_times_.begin());
+    prev_command_times_.insert(command.time());
 
     switch (command.type())
     {

--- a/src/bin/mission_manager/mission_manager.h
+++ b/src/bin/mission_manager/mission_manager.h
@@ -113,7 +113,7 @@ class MissionManager : public goby::zeromq::MultiThreadApplication<config::Missi
     // Store previous commands time to ensure commands ignore duplicates
     std::set<uint64_t> prev_command_times_;
     // only store up to the last N previous command times to avoid
-    // potential memory leak on very long missions
+    // large memory usage
     constexpr static std::size_t command_history_max_count_{100};
 
     // Data for determining if we are making forward progress

--- a/src/bin/web_portal/app.cpp
+++ b/src/bin/web_portal/app.cpp
@@ -302,7 +302,9 @@ void jaiabot::apps::WebPortal::process_client_message(jaiabot::protobuf::ClientT
 
 void jaiabot::apps::WebPortal::loop()
 {
-    if (device_metadata_.has_jaiabot_version() && device_metadata_.has_is_simulation())
+    if (device_metadata_.has_jaiabot_version() 
+        && device_metadata_.has_simulation_warp() 
+        && device_metadata_.has_is_simulation())
     {
         jaiabot::protobuf::PortalToClientMessage message;
         *message.mutable_device_metadata() = device_metadata_;

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -97,7 +97,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0x23e0cde263d7b879")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0x57fa2ff48bd9844a")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xc2b6ff5101df098c")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0x14ebbe8ed8aed722")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")

--- a/src/lib/messages/jaia_dccl.proto
+++ b/src/lib/messages/jaia_dccl.proto
@@ -199,8 +199,21 @@ message BotStatus
     // link: which link this message traversed from bot to hub
     optional Link link = 8 [(dccl.field).omit = true];
 
+    // Active links with last-received time per link (time written on hub upon receipt, not transmitted over air)
+    message ActiveLink {
+        required Link link = 1;
+        optional uint64 last_received_time = 2 [
+            (dccl.field) = {
+                omit: true
+                units { prefix: "micro" derived_dimensions: "time" }
+            }
+        ];
+    }
+
     // list of all active links on the Bot (based on BotStatus subscription messages)
-    repeated Link active_link = 9 [(dccl.field).max_repeat = 10];
+    repeated ActiveLink active_links = 9 [
+        (dccl.field).max_repeat = 10
+    ];
 
     optional GeographicCoordinate location = 10
         [(jaia.field).rest_api.presence = GUARANTEED];
@@ -365,23 +378,6 @@ message BotStatus
             units { prefix: "micro" derived_dimensions: "time" }
         },
         (jaia.field).rest_api.presence = GUARANTEED
-    ];
-
-    // Map of link => last time a status was received on that link (written on hub upon receipt)
-    message LinkLastReceivedTime {
-        required Link link = 1 [(dccl.field).omit = true];
-        required uint64 time = 2 [
-            (dccl.field) = {
-                omit: true  // hub-side only, not transmitted over air
-                units { prefix: "micro" derived_dimensions: "time" }
-            }
-        ];
-    }
-    repeated LinkLastReceivedTime link_last_received_time = 60 [
-        (dccl.field) = {
-            omit: true
-            max_repeat: 10
-        }
     ];
 
     optional uint64 mission_command_time = 71 [

--- a/src/lib/messages/jaia_dccl.proto
+++ b/src/lib/messages/jaia_dccl.proto
@@ -367,6 +367,23 @@ message BotStatus
         (jaia.field).rest_api.presence = GUARANTEED
     ];
 
+    // Map of link => last time a status was received on that link (written on hub upon receipt)
+    message LinkLastReceivedTime {
+        required Link link = 1 [(dccl.field).omit = true];
+        required uint64 time = 2 [
+            (dccl.field) = {
+                omit: true  // hub-side only, not transmitted over air
+                units { prefix: "micro" derived_dimensions: "time" }
+            }
+        ];
+    }
+    repeated LinkLastReceivedTime link_last_received_time = 60 [
+        (dccl.field) = {
+            omit: true
+            max_repeat: 10
+        }
+    ];
+
     optional uint64 mission_command_time = 71 [
         (dccl.field) = {
             codec: "dccl.time2"

--- a/src/lib/messages/metadata.proto
+++ b/src/lib/messages/metadata.proto
@@ -68,6 +68,13 @@ message DeviceMetadata
     optional uint32 hub_id = 15 [(jaia.field).rest_api.presence = GUARANTEED];
     optional uint32 bot_id = 16 [(jaia.field).rest_api.presence = OMITTED];
 
+    optional uint32 simulation_warp = 17 [
+        (jaia.field).rest_api.presence = GUARANTEED
+    ];
+    optional uint64 simulation_reference_time = 18 [
+        (jaia.field).rest_api.presence = GUARANTEED
+    ];
+
 }
 
 message QueryDeviceMetaData

--- a/src/python/pyjaia/src/pyjaia/utils.py
+++ b/src/python/pyjaia/src/pyjaia/utils.py
@@ -31,13 +31,19 @@ def myip():
         return "localhost"
 
 
-def now_utime():
+def now_utime(warp_factor=1, simulation_reference_time=0):
     """Return the system time as Unix timestamp in microseconds.
+        In real-time operation, equivalent to previous now_utime() implementation.
+        In simulation, time is warped from the reference time by the warp factor.
+    Args:
+        warp_factor (float, optional): A factor to warp the time by. Defaults to 1 (real time).
+        simulation_reference_time (int, optional): The reference time for simulation. Defaults to 0.
 
     Returns:
         int: Unix timestamp in microseconds.
     """
-    return int(datetime.now().timestamp() * 1e6)
+    wall_clock_now_microseconds = int(datetime.now().timestamp() * 1e6)
+    return int(simulation_reference_time + (wall_clock_now_microseconds - simulation_reference_time) * warp_factor)
 
 
 def utime(d: datetime):

--- a/src/web/components/BotDetails/BotDetails.tsx
+++ b/src/web/components/BotDetails/BotDetails.tsx
@@ -149,7 +149,12 @@ export default function BotDetails() {
                             <AccordionDetails>
                                 <table>
                                     <tbody>
-                                        <tr className={getStatusAgeClassName(bot.getStatusAge(), bot.getLink())}>
+                                        <tr
+                                            className={getStatusAgeClassName(
+                                                bot.getStatusAge(),
+                                                bot.getLink(),
+                                            )}
+                                        >
                                             <td>Status Age</td>
                                             <td>
                                                 {convertMicrosecondsToSeconds(
@@ -226,57 +231,6 @@ export default function BotDetails() {
 
                     <ThemeProvider theme={accordionTheme}>
                         <Accordion
-                            expanded={jaiaContext.botAccordionStates.commLinks}
-                            onChange={() => {
-                                handleAccordionClick(BotAccordionNames.COMM_LINKS);
-                            }}
-                            className="accordion-container"
-                        >
-                            <AccordionSummary
-                                expandIcon={<ExpandMoreIcon />}
-                                className="accordion-summary"
-                            >
-                                <Typography>Comm Links</Typography>
-                            </AccordionSummary>
-                            <AccordionDetails>
-                                <table>
-                                    <tbody>
-                                        {bot.getActiveLinks().length > 0 ? (
-                                            bot.getActiveLinks().map((link: string) => {
-                                                const statusAge =
-                                                    bot.getActiveLinkStatusAges()[link] ?? -1;
-
-                                                return (
-                                                    <tr
-                                                        key={link}
-                                                        className={getStatusAgeClassName(
-                                                            statusAge,
-                                                            link as Link,
-                                                        )}
-                                                    >
-                                                        <td>{formatLinkName(link)}</td>
-                                                        <td>
-                                                            {statusAge >= 0
-                                                                ? `${convertMicrosecondsToSeconds(statusAge).toFixed(1)} s`
-                                                                : "N/A"}
-                                                        </td>
-                                                    </tr>
-                                                );
-                                            })
-                                        ) : (
-                                            <tr>
-                                                <td>No active links</td>
-                                                <td>N/A</td>
-                                            </tr>
-                                        )}
-                                    </tbody>
-                                </table>
-                            </AccordionDetails>
-                        </Accordion>
-                    </ThemeProvider>
-
-                    <ThemeProvider theme={accordionTheme}>
-                        <Accordion
                             expanded={jaiaContext.botAccordionStates.commands}
                             onChange={() => {
                                 handleAccordionClick(BotAccordionNames.COMMANDS);
@@ -342,6 +296,51 @@ export default function BotDetails() {
                             </AccordionSummary>
                             <AccordionDetails>
                                 <HealthRow />
+                            </AccordionDetails>
+                        </Accordion>
+                    </ThemeProvider>
+
+                    <ThemeProvider theme={accordionTheme}>
+                        <Accordion
+                            expanded={jaiaContext.botAccordionStates.commLinks}
+                            onChange={() => {
+                                handleAccordionClick(BotAccordionNames.COMM_LINKS);
+                            }}
+                            className="accordion-container"
+                        >
+                            <AccordionSummary
+                                expandIcon={<ExpandMoreIcon />}
+                                className="accordion-summary"
+                            >
+                                <Typography>Comm Links</Typography>
+                            </AccordionSummary>
+                            <AccordionDetails>
+                                <table>
+                                    <tbody>
+                                        {Object.entries(bot.getActiveLinkStatusAges()).length >
+                                        0 ? (
+                                            Object.entries(bot.getActiveLinkStatusAges()).map(
+                                                ([link, statusAge]) => (
+                                                    <tr
+                                                        key={link}
+                                                        className={getStatusAgeClassName(
+                                                            statusAge,
+                                                            link as Link,
+                                                        )}
+                                                    >
+                                                        <td>{formatLinkName(link)}</td>
+                                                        <td>{`${convertMicrosecondsToSeconds(statusAge).toFixed(0)} s`}</td>
+                                                    </tr>
+                                                ),
+                                            )
+                                        ) : (
+                                            <tr>
+                                                <td>No active links</td>
+                                                <td>N/A</td>
+                                            </tr>
+                                        )}
+                                    </tbody>
+                                </table>
                             </AccordionDetails>
                         </Accordion>
                     </ThemeProvider>

--- a/src/web/components/BotDetails/BotDetails.tsx
+++ b/src/web/components/BotDetails/BotDetails.tsx
@@ -38,7 +38,6 @@ import {
     formatAttitudeAngle,
     convertMicrosecondsToSeconds,
 } from "../../shared/Utilities";
-import type { Link } from "../../shared/JAIAProtobuf";
 
 // MDI and MUI
 import { ThemeProvider } from "@mui/material";
@@ -152,7 +151,7 @@ export default function BotDetails() {
                                         <tr
                                             className={getStatusAgeClassName(
                                                 bot.getStatusAge(),
-                                                bot.getLink(),
+                                                bot.isCommsDropped(),
                                             )}
                                         >
                                             <td>Status Age</td>
@@ -325,7 +324,7 @@ export default function BotDetails() {
                                                         key={link}
                                                         className={getStatusAgeClassName(
                                                             statusAge,
-                                                            link as Link,
+                                                            bot.isCommsDropped(),
                                                         )}
                                                     >
                                                         <td>{formatLinkName(link)}</td>

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -2,7 +2,6 @@
 import { MissionState } from "../../types/protobuf-types";
 import { MissionStatus } from "../../types/jaia-system-types";
 import { convertMicrosecondsToSeconds } from "../../shared/Utilities";
-import { Link } from "../../shared/JAIAProtobuf";
 
 import { missionSet } from "../../data/mission_set/mission-set";
 import Hub from "../../data/hubs/hub";

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -7,35 +7,21 @@ import { Link } from "../../shared/JAIAProtobuf";
 import { missionSet } from "../../data/mission_set/mission-set";
 import Hub from "../../data/hubs/hub";
 import GPS from "../../data/sensors/gps";
-import Mission from "../../data/mission_set/mission";
 
 import { point, rhumbDistance, Units } from "@turf/turf";
-import { IRIDIUM_NO_COMMS_STATUS_AGE, NO_COMMS_STATUS_AGE } from "../../utils/constants";
-
-/**
- * Returns the no-comms timeout in seconds based on the link type.
- * Iridium link uses a 3-minute timeout; all other links use 30 seconds.
- *
- * @param {Link} link The link type from the last BotStatus message
- * @returns {number} Timeout in seconds
- */
-export function getNoCommsTimeout(link?: Link): number {
-    return link === Link.LINK_IRIDIUM ? IRIDIUM_NO_COMMS_STATUS_AGE : NO_COMMS_STATUS_AGE;
-}
 
 /**
  * Provides a class name that corresponds to styles illustrating comms health
  *
  * @param {number} portalStatusAge Time since last communication between Bot and Hub (microseconds)
- * @param {Link} link The link type from the last BotStatus message
+ * @param {boolean} isCommsDropped Whether or not the Bot is currently experiencing dropped comms
  * @returns {string} Class name that dictates the style of the status age
  */
-export function getStatusAgeClassName(portalStatusAge: number, link?: Link) {
-    const healthFailedTimeout = getNoCommsTimeout(link);
+export function getStatusAgeClassName(portalStatusAge: number, isCommsDropped?: boolean) {
     const healthDegradedTimeout = 10;
     const statusAgeSeconds = convertMicrosecondsToSeconds(portalStatusAge);
 
-    if (statusAgeSeconds >= healthFailedTimeout) {
+    if (isCommsDropped) {
         return "health-state-failed";
     }
 
@@ -44,24 +30,6 @@ export function getStatusAgeClassName(portalStatusAge: number, link?: Link) {
     }
 
     return "";
-}
-
-/**
- * Checks whether the Bot and Hub are communcating
- *
- * @param {number} portalStatusAge Time since last communcation between Bot and Hub (microseconds)
- * @param {Link} link The link type from the last BotStatus message
- * @returns {boolean} True if the Bot has communicated with the Hub within the link-specific timeout (30s for XBEE/WIFI, 180s for Iridium)
- */
-export function isDisconnected(portalStatusAge: number, link?: Link) {
-    const healthFailedTimeout = getNoCommsTimeout(link);
-    const statusAgeSeconds = convertMicrosecondsToSeconds(portalStatusAge);
-
-    if (statusAgeSeconds >= healthFailedTimeout) {
-        return true;
-    }
-
-    return false;
 }
 
 /**

--- a/src/web/components/HubDetails/HubDetails.tsx
+++ b/src/web/components/HubDetails/HubDetails.tsx
@@ -83,11 +83,11 @@ export default function HubDetails() {
         const statusAgeSeconds = convertMicrosecondsToSeconds(portalStatusAge);
 
         if (statusAgeSeconds > healthFailedTimeout) {
-            return "healthFailed";
+            return "health-state-failed";
         }
 
         if (statusAgeSeconds > healthDegradedTimeout) {
-            return "healthDegraded";
+            return "health-state-degraded";
         }
 
         return "";

--- a/src/web/components/NodeList/NodeList.tsx
+++ b/src/web/components/NodeList/NodeList.tsx
@@ -5,8 +5,6 @@ import { JaiaContextType, JaiaAction } from "../../types/context-types";
 
 import { NodeTypes } from "../../types/jaia-system-types";
 import { HealthState } from "../../types/protobuf-types";
-import { Link } from "../../shared/JAIAProtobuf";
-import { isDisconnected } from "../BotDetails/bot-details";
 import { CLOUD_HUB_ID } from "../../utils/constants";
 import "./NodeList.less";
 
@@ -45,15 +43,14 @@ export default function NodeList() {
      * @param {NodeTypes} nodeType Indicates Bot or Hub
      * @param {number} nodeID Provides ID of Bot or Hub
      * @param {HealthState} healthState Determines color of node item
-     * @param {number} statusAge Indicates comms with the node (microsecodns)
+     * @param {boolean} isCommsDropped Indicates whether the node is currently experiencing dropped comms
      * @returns {string} Class name that sets correct style
      */
     function getClassName(
         nodeType: NodeTypes,
         nodeID: number,
         healthState: HealthState,
-        statusAge: number,
-        link?: Link,
+        isCommsDropped?: boolean,
     ) {
         const faultLevel: Map<HealthState, number> = new Map([
             [HealthState.HEALTH__OK, 0],
@@ -67,7 +64,7 @@ export default function NodeList() {
         const selectedClass =
             selectedNode.type === nodeType && selectedNode.id === nodeID ? "selected" : "";
 
-        const disconnectedClass = isDisconnected(statusAge, link) ? "disconnected" : "";
+        const disconnectedClass = isCommsDropped ? "disconnected" : "";
 
         return `node-item ${nodeTypeClass} ${faultLevelClass} ${selectedClass} ${disconnectedClass}`;
     }
@@ -86,7 +83,7 @@ export default function NodeList() {
                         NodeTypes.HUB,
                         hub.getHubID(),
                         hub.getHealthState(),
-                        hub.getStatusAge(),
+                        hub.isCommsDropped(),
                     )}
                 >
                     <div className="hub-label">
@@ -105,8 +102,7 @@ export default function NodeList() {
                         NodeTypes.BOT,
                         bot.getBotID(),
                         bot.getHealthState(),
-                        bot.getStatusAge(),
-                        bot.getLink(),
+                        bot.isCommsDropped(),
                     )}
                 >
                     {bot.getBotID()}

--- a/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
+++ b/src/web/components/__buttons__/ActivateAllButton/ActivateAllButton.tsx
@@ -10,7 +10,6 @@ import { mdiCheckboxMarkedCirclePlusOutline } from "@mdi/js";
 
 import Bot from "../../../data/bots/bot";
 
-import { isCommsDropped } from "../button-utils";
 import { MDI_BUTTON_SIZE } from "../../../utils/constants";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
 import { Command, CommandType, MissionState } from "../../../types/protobuf-types";
@@ -44,7 +43,7 @@ export default function ActivateAllButton(props: Props) {
         const updatedBotReadyStates = new Map<DisabledCodes, number[]>(initBotReadyStates());
 
         for (const [botID, bot] of props.bots.entries()) {
-            if (isCommsDropped(bot.getStatusAge())) {
+            if (bot.isCommsDropped()) {
                 updatedBotReadyStates.get(DisabledCodes.NO_COMMS).push(botID);
             } else if (
                 bot.getMissionStatus().missionState === MissionState.PRE_DEPLOYMENT__STARTING_UP

--- a/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
+++ b/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
@@ -12,7 +12,6 @@ import Bot from "../../../data/bots/bot";
 import { DialogActions } from "../../../types/context-types";
 import { Command, CommandType, MissionState } from "../../../types/protobuf-types";
 import { MDI_BUTTON_SIZE } from "../../../utils/constants";
-import { microsecondsToSeconds } from "../../../utils/conversions";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
 
 interface Props {

--- a/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
+++ b/src/web/components/__buttons__/ActivateButton/ActivateButton.tsx
@@ -11,7 +11,7 @@ import { mdiCheckboxMarkedCirclePlusOutline } from "@mdi/js";
 import Bot from "../../../data/bots/bot";
 import { DialogActions } from "../../../types/context-types";
 import { Command, CommandType, MissionState } from "../../../types/protobuf-types";
-import { MDI_BUTTON_SIZE, NO_COMMS_STATUS_AGE } from "../../../utils/constants";
+import { MDI_BUTTON_SIZE } from "../../../utils/constants";
 import { microsecondsToSeconds } from "../../../utils/conversions";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
 
@@ -48,7 +48,7 @@ export default function ActivateButton(props: Props) {
      * @returns {DisabledCodes} The applicable disabled code based on the Bot and button conditions
      */
     const getDisabledCode = () => {
-        if (microsecondsToSeconds(props.bot.getStatusAge()) > NO_COMMS_STATUS_AGE) {
+        if (props.bot.isCommsDropped()) {
             return DisabledCodes.NO_COMMS;
         }
 

--- a/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllButton.tsx
+++ b/src/web/components/__buttons__/DataOfffloadAllButton/DataOffloadAllButton.tsx
@@ -14,7 +14,6 @@ import { MDI_BUTTON_SIZE } from "../../../utils/constants";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
 import { Command, CommandType } from "../../../types/protobuf-types";
 import { DialogActions } from "../../../types/context-types";
-import { isCommsDropped } from "../button-utils";
 
 interface Props {
     bots: Map<number, Bot>;
@@ -44,7 +43,7 @@ export default function DataOffloadAllButton(props: Props) {
         const updatedBotReadyStates = new Map<DisabledCodes, number[]>(initBotReadyStates());
 
         for (const [botID, bot] of props.bots.entries()) {
-            if (isCommsDropped(bot.getStatusAge(), bot.getLink())) {
+            if (bot.isCommsDropped()) {
                 updatedBotReadyStates.get(DisabledCodes.NO_COMMS).push(botID);
             } else if (
                 !(

--- a/src/web/components/__buttons__/GoToRallyButton/GoToRallyButton.tsx
+++ b/src/web/components/__buttons__/GoToRallyButton/GoToRallyButton.tsx
@@ -24,7 +24,7 @@ import {
 import { ButtonNames, ButtonTypes } from "../../../types/context-types";
 import { MDI_BUTTON_SIZE } from "../../../utils/constants";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
-import { isCommsDropped, isCritiallyLowBattery } from "../button-utils";
+import { isCritiallyLowBattery } from "../button-utils";
 
 interface Props {
     bots: Map<number, Bot>;
@@ -57,7 +57,7 @@ export default function GoToRallyButton(props: Props) {
         const updatedBotReadyStates = new Map<DisabledCodes, number[]>(initBotReadyStates());
 
         for (const [botID, bot] of props.bots.entries()) {
-            if (isCommsDropped(bot.getStatusAge())) {
+            if (bot.isCommsDropped()) {
                 updatedBotReadyStates.get(DisabledCodes.NO_COMMS).push(botID);
             } else if (
                 !isCommandAvailable(CommandType.START_MISSION, bot.getMissionStatus().missionState)

--- a/src/web/components/__buttons__/StartAllMissionsButton/StartAllMissionsButton.tsx
+++ b/src/web/components/__buttons__/StartAllMissionsButton/StartAllMissionsButton.tsx
@@ -16,16 +16,9 @@ import Mission from "../../../data/mission_set/mission";
 import { missionsManager } from "../../../data/missions_manager/missions-manager";
 
 import { Command, CommandType } from "../../../types/protobuf-types";
-import { Link } from "../../../shared/JAIAProtobuf";
 import { ButtonNames, ButtonTypes, DialogActions } from "../../../types/context-types";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
-import { microsecondsToSeconds } from "../../../utils/conversions";
-import {
-    MDI_BUTTON_SIZE,
-    MIN_BATTERY_PERCENT,
-    UNASSIGNED_ID,
-} from "../../../utils/constants";
-import { getNoCommsTimeout } from "../../BotDetails/bot-details";
+import { MDI_BUTTON_SIZE, MIN_BATTERY_PERCENT, UNASSIGNED_ID } from "../../../utils/constants";
 
 interface Props {
     bots: Map<number, Bot>;
@@ -58,7 +51,7 @@ export default function StartAllMissionsButton(props: Props) {
         const updatedBotReadyStates = new Map<DisabledCodes, number[]>(initBotReadyStates());
 
         for (const [botID, bot] of props.bots.entries()) {
-            if (isCommsDropped(bot.getStatusAge(), bot.getLink())) {
+            if (bot.isCommsDropped()) {
                 updatedBotReadyStates.get(DisabledCodes.NO_COMMS).push(botID);
             } else if (
                 !isCommandAvailable(CommandType.START_MISSION, bot.getMissionStatus().missionState)
@@ -174,17 +167,6 @@ function initBotReadyStates() {
         [DisabledCodes.LOW_BATTERY, []],
     ];
     return botReadyStates;
-}
-
-/**
- * Checks the supplied status age against the no comms threshold
- *
- * @param {number} statusAge Bot's status age in microseconds
- * @param {Link} link The link type from the last BotStatus message
- * @returns {boolean} True if the Bot does not have comms with the Hub
- */
-function isCommsDropped(statusAge: number, link?: Link) {
-    return microsecondsToSeconds(statusAge) > getNoCommsTimeout(link);
 }
 
 /**

--- a/src/web/components/__buttons__/StartMissionButton/StartMissionButton.tsx
+++ b/src/web/components/__buttons__/StartMissionButton/StartMissionButton.tsx
@@ -18,13 +18,7 @@ import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../.
 
 import { mdiPlay } from "@mdi/js";
 import { missionsManager } from "../../../data/missions_manager/missions-manager";
-import {
-    MDI_BUTTON_SIZE,
-    MIN_BATTERY_PERCENT,
-    NO_COMMS_STATUS_AGE,
-    UNASSIGNED_ID,
-} from "../../../utils/constants";
-import { microsecondsToSeconds } from "../../../utils/conversions";
+import { MDI_BUTTON_SIZE, MIN_BATTERY_PERCENT, UNASSIGNED_ID } from "../../../utils/constants";
 
 interface Props {
     bot: Bot;
@@ -62,7 +56,7 @@ export default function StartMissionButton(props: Props) {
      * @returns {DisabledCodes} The applicable disabled code based on the Bot and button conditions
      */
     const getDisabledCode = () => {
-        if (microsecondsToSeconds(props.bot.getStatusAge()) > NO_COMMS_STATUS_AGE) {
+        if (props.bot.isCommsDropped()) {
             return DisabledCodes.NO_COMMS;
         }
 

--- a/src/web/components/__buttons__/StopAllBotsButton/StopAllBotsButton.tsx
+++ b/src/web/components/__buttons__/StopAllBotsButton/StopAllBotsButton.tsx
@@ -14,11 +14,8 @@ import Bot from "../../../data/bots/bot";
 
 import { DialogActions } from "../../../types/context-types";
 import { Command, CommandType } from "../../../types/protobuf-types";
-import { Link } from "../../../shared/JAIAProtobuf";
 import { isCommandAvailable, isControllingClient, sendBotCommand } from "../../../utils/commands";
-import { microsecondsToSeconds } from "../../../utils/conversions";
 import { MDI_BUTTON_SIZE } from "../../../utils/constants";
-import { getNoCommsTimeout } from "../../BotDetails/bot-details";
 
 interface Props {
     bots: Map<number, Bot>;
@@ -49,7 +46,7 @@ export default function StopAllBotsButton(props: Props) {
         const updatedBotReadyStates = new Map<DisabledCodes, number[]>(initBotReadyStates());
 
         for (const [botID, bot] of props.bots.entries()) {
-            if (isCommsDropped(bot.getStatusAge(), bot.getLink())) {
+            if (bot.isCommsDropped()) {
                 updatedBotReadyStates.get(DisabledCodes.NO_COMMS).push(botID);
             } else if (!isCommandAvailable(CommandType.STOP, bot.getMissionStatus().missionState)) {
                 updatedBotReadyStates.get(DisabledCodes.MISSION_STATE).push(botID);
@@ -145,15 +142,4 @@ function initBotReadyStates() {
         [DisabledCodes.MISSION_STATE, []],
     ];
     return botReadyStates;
-}
-
-/**
- * Checks the supplied status age against the no comms threshold
- *
- * @param {number} statusAge Bot's status age in microseconds
- * @param {Link} link The link type from the last BotStatus message
- * @returns {boolean} True if the Bot does not have comms with the Hub
- */
-function isCommsDropped(statusAge: number, link?: Link) {
-    return microsecondsToSeconds(statusAge) > getNoCommsTimeout(link);
 }

--- a/src/web/components/__buttons__/button-utils.ts
+++ b/src/web/components/__buttons__/button-utils.ts
@@ -1,18 +1,4 @@
-import { microsecondsToSeconds } from "../../utils/conversions";
 import { MIN_BATTERY_PERCENT } from "../../utils/constants";
-import { Link } from "../../shared/JAIAProtobuf";
-import { getNoCommsTimeout } from "../BotDetails/bot-details";
-
-/**
- * Checks the supplied status age against the no comms threshold
- *
- * @param {number} statusAge Bot's status age in microseconds
- * @param {Link} link The link type from the last BotStatus message
- * @returns {boolean} True if the Bot does not have comms with the Hub
- */
-export function isCommsDropped(statusAge: number, link?: Link) {
-    return microsecondsToSeconds(statusAge) > getNoCommsTimeout(link);
-}
 
 /**
  * Checks whether the supplied battery percent is below the min threshold

--- a/src/web/data/bots/bot.ts
+++ b/src/web/data/bots/bot.ts
@@ -7,8 +7,9 @@ import {
     GeographicCoordinate,
     HealthState,
     Warning,
+    ActiveLink,
+    Link,
 } from "../../types/protobuf-types";
-import { Link } from "../../shared/JAIAProtobuf";
 import BotSensors from "./bot-sensors";
 
 export default class Bot {
@@ -24,7 +25,7 @@ export default class Bot {
     private wifiLinkQuality: number;
     private statusAge: number;
     private link: Link;
-    private activeLinks: Link[];
+    private activeLinks: ActiveLink[];
     private activeLinkStatusAges: { [link: string]: number };
     private engineering: Engineering;
     private mode: BotModes;
@@ -87,8 +88,6 @@ export default class Bot {
         return this.botSensors;
     }
 
-    // setBotSensors does not exists because the sensor init is handled when the Bot type is received
-
     getLocation() {
         return this.location;
     }
@@ -131,15 +130,15 @@ export default class Bot {
         this.link = link;
     }
 
-    getActiveLinks() {
+    getActiveLinks(): ActiveLink[] {
         return this.activeLinks ?? [];
     }
 
-    setActiveLinks(activeLinks: Link[]) {
+    setActiveLinks(activeLinks: ActiveLink[]) {
         this.activeLinks = activeLinks;
     }
 
-    getActiveLinkStatusAges() {
+    getActiveLinkStatusAges(): { [link: string]: number } {
         return this.activeLinkStatusAges ?? {};
     }
 

--- a/src/web/data/bots/bot.ts
+++ b/src/web/data/bots/bot.ts
@@ -10,6 +10,8 @@ import {
     ActiveLink,
     Link,
 } from "../../types/protobuf-types";
+import { IRIDIUM_NO_COMMS_STATUS_AGE, NO_COMMS_STATUS_AGE } from "../../utils/constants";
+import { microsecondsToSeconds } from "../../utils/conversions";
 import BotSensors from "./bot-sensors";
 
 export default class Bot {
@@ -160,6 +162,20 @@ export default class Bot {
 
     setMode(mode: BotModes) {
         this.mode = mode;
+    }
+
+    /**
+     * Determines if the Bot has lost comms with the Hub based on the age of the portal status and link type
+     * Takes into account link type (Iridium has a longer timeout)
+     *
+     * @returns true if the bot has lost comms with the hub
+     */
+    isCommsDropped(): boolean {
+        const commsTimeout =
+            this.getLink() === Link.LINK_IRIDIUM
+                ? IRIDIUM_NO_COMMS_STATUS_AGE
+                : NO_COMMS_STATUS_AGE;
+        return microsecondsToSeconds(this.getStatusAge()) > commsTimeout;
     }
 
     private initializeSensors() {

--- a/src/web/data/bots/bots.ts
+++ b/src/web/data/bots/bots.ts
@@ -119,8 +119,8 @@ export class Bots {
             bot.setLink(botStatus.link);
         }
 
-        if (botStatus.active_link) {
-            bot.setActiveLinks(botStatus.active_link);
+        if (botStatus.active_links) {
+            bot.setActiveLinks(botStatus.active_links);
         } else {
             bot.setActiveLinks([]);
         }

--- a/src/web/data/hubs/hub.ts
+++ b/src/web/data/hubs/hub.ts
@@ -6,6 +6,8 @@ import {
     LinuxHardwareStatus,
     Warning,
 } from "../../types/protobuf-types";
+import { NO_COMMS_STATUS_AGE } from "../../utils/constants";
+import { microsecondsToSeconds } from "../../utils/conversions";
 import HubSensors from "./hub-sensors";
 
 export default class Hub {
@@ -99,5 +101,14 @@ export default class Hub {
 
     setStatusAge(statusAge: number) {
         this.statusAge = statusAge;
+    }
+
+    /**
+     * Determines if the hub has lost comms with the client
+     *
+     * @returns true if the hub has lost comms with the client
+     */
+    isCommsDropped(): boolean {
+        return microsecondsToSeconds(this.getStatusAge()) > NO_COMMS_STATUS_AGE;
     }
 }

--- a/src/web/jcc/polling.ts
+++ b/src/web/jcc/polling.ts
@@ -13,12 +13,9 @@ import { hubCommsLayer } from "../openlayers/layers/vector/hub-comms-layer";
 import { excludedTaskPacketsLayer } from "../openlayers/layers/vector/excluded-task-packets-layer";
 import { NO_COMMS_STATUS_AGE, IRIDIUM_NO_COMMS_STATUS_AGE } from "../utils/constants";
 import { Metadata, Version } from "../types/protobuf-types";
-import { Link } from "../shared/JAIAProtobuf";
 import SoundEffects from "../style/audio/sound-effects";
 
 const MAX_REQUEST_TIME = 10000; // ms;
-const XBEE_WIFI_DISCONNECT_THRESHOLD = NO_COMMS_STATUS_AGE * 1e6;
-const IRIDIUM_DISCONNECT_THRESHOLD = IRIDIUM_NO_COMMS_STATUS_AGE * 1e6;
 const VERSION_LENGTH = 3;
 
 const CONNECTION_WARNING = "connection-warning";
@@ -203,9 +200,11 @@ export async function pollInternet() {
 function updateBots(botStatuses: { [botID: string]: PortalBotStatus }) {
     const botIDs = Object.keys(botStatuses);
     for (let botID of botIDs) {
-        const prevStatusAge = bots.getBot(Number(botID))?.getStatusAge();
-        handleBotSoundEffects(prevStatusAge, botStatuses[botID].portalStatusAge, botStatuses[botID].link);
+        const numericBotID = Number(botID);
+        const wasCommsDropped = bots.getBot(numericBotID)?.isCommsDropped() ?? false;
         bots.setBot(botStatuses[botID]);
+        botStatuses[botID].isDisconnected = bots.getBot(numericBotID)?.isCommsDropped() ?? false;
+        handleBotSoundEffects(wasCommsDropped, botStatuses[botID].isDisconnected);
     }
     bots.setTick(bots.getTick() + 1);
 }
@@ -279,28 +278,20 @@ function updateWarning(id: string, isDisconnected: boolean) {
 }
 
 /**
- * Plays disconnect and reconnect sounds based on Bot's status age
+ * Plays disconnect and reconnect sounds based on Bot's comms state transitions
  *
- * @param {number} prevStatusAge Used to mark first moment of comms connect/disconnect
- * @param {number} newStatusAge Used to check for Bot connection status
- * @param {Link} link The link type from the last BotStatus message
+ * @param {boolean} wasCommsDropped Previous comms dropped state
+ * @param {boolean} isCommsDropped Current comms dropped state
  * @returns {void}
  */
-function handleBotSoundEffects(prevStatusAge: number, newStatusAge: number, link?: Link) {
-    if (!prevStatusAge) {
-        return;
-    }
-
-    const disconnectThreshold =
-        link === Link.LINK_IRIDIUM ? IRIDIUM_DISCONNECT_THRESHOLD : XBEE_WIFI_DISCONNECT_THRESHOLD;
-
-    const isBotDisconnected = newStatusAge > disconnectThreshold;
-
-    if (isBotDisconnected && prevStatusAge < disconnectThreshold) {
+function handleBotSoundEffects(wasCommsDropped: boolean, isCommsDropped: boolean) {
+    // Transition from connected to disconnected
+    if (isCommsDropped && !wasCommsDropped) {
         SoundEffects.botDisconnect.play();
     }
 
-    if (!isBotDisconnected && prevStatusAge >= disconnectThreshold) {
+    // Transition from disconnected to connected
+    if (!isCommsDropped && wasCommsDropped) {
         SoundEffects.botReconnect.play();
     }
 }

--- a/src/web/jcc/polling.ts
+++ b/src/web/jcc/polling.ts
@@ -11,7 +11,6 @@ import { driftLayer } from "../openlayers/layers/vector/drift-layer";
 import { contourLayer } from "../openlayers/layers/vector/contour-layer";
 import { hubCommsLayer } from "../openlayers/layers/vector/hub-comms-layer";
 import { excludedTaskPacketsLayer } from "../openlayers/layers/vector/excluded-task-packets-layer";
-import { NO_COMMS_STATUS_AGE, IRIDIUM_NO_COMMS_STATUS_AGE } from "../utils/constants";
 import { Metadata, Version } from "../types/protobuf-types";
 import SoundEffects from "../style/audio/sound-effects";
 

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -115,54 +115,13 @@ class Interface:
             except socket.timeout:
                 self.ping_portal()
 
-    def update_active_link_received_times(self, status: dict):
-        """Updates per-link last-received times for active links in a status dict."""
-        if 'active_link' not in status:
-            return
-
-        active_links = status.get('active_link', [])
-        if 'activeLinkLastStatusReceivedTimes' not in status:
-            status['activeLinkLastStatusReceivedTimes'] = {}
-
-        last_received = status['activeLinkLastStatusReceivedTimes']
-        now = now_utime()
-        reporting_link = status.get('link')
-
-        # Stamp only the link that delivered this status message.
-        if reporting_link is not None:
-            last_received[reporting_link] = now
-            return
-
-        # If no explicit reporting link is present but there is exactly one active link,
-        # treat it as the reporting link.
-        if len(active_links) == 1:
-            last_received[active_links[0]] = now
-
     def update_active_link_status_ages(self, status: dict):
-        """Calculates age in microseconds for each active link in a status dict."""
-        active_links = status.get('active_link', [])
-        last_received = status.get('activeLinkLastStatusReceivedTimes', {})
-        now = now_utime()
-
+        now = int(now_utime())
         status['active_link_status_age'] = {
-            link: now - last_received[link] for link in active_links if link in last_received
+            entry['link']: now - int(entry['last_received_time'])
+            for entry in status.get('active_links', [])
+            if 'last_received_time' in entry
         }
-
-    def is_stale_status(self, prior_status: dict, new_status: dict):
-        """Returns True when incoming status is older than currently stored status."""
-        if not prior_status:
-            return False
-
-        prior_time = prior_status.get('time')
-        new_time = new_status.get('time')
-
-        if prior_time is None or new_time is None:
-            return False
-
-        try:
-            return int(new_time) < int(prior_time)
-        except (TypeError, ValueError):
-            return False
 
     def process_portal_to_client_message(self, data):
         if len(data) > 0:
@@ -184,34 +143,9 @@ class Interface:
 
             if msg.HasField('bot_status'):
                 botStatus = protobufMessageToDict(msg.bot_status)
-                accepted_bot_status = False
 
                 bot_id = botStatus['bot_id']
-                prior_bot_status = self.bots.get(bot_id)
-                if self.is_stale_status(prior_bot_status, botStatus):
-                    # Do not replace core bot state with stale data, but still mark
-                    # the reporting link as recently heard-from for Comm Links age.
-                    reporting_link = botStatus.get('link')
-                    if prior_bot_status and reporting_link is not None:
-                        if 'activeLinkLastStatusReceivedTimes' not in prior_bot_status:
-                            prior_bot_status['activeLinkLastStatusReceivedTimes'] = {}
-                        prior_bot_status['activeLinkLastStatusReceivedTimes'][reporting_link] = now_utime()
-                        if 'active_link' not in prior_bot_status:
-                            prior_bot_status['active_link'] = []
-                        if reporting_link not in prior_bot_status['active_link']:
-                            prior_bot_status['active_link'].append(reporting_link)
-                    logging.warning(f'Ignoring stale bot status for bot {bot_id}: time={botStatus.get("time")} < stored={prior_bot_status.get("time")}')
-                else:
-                    # Set the time of last status to now
-                    botStatus['lastStatusReceivedTime'] = now_utime()
-
-                    if prior_bot_status and 'activeLinkLastStatusReceivedTimes' in prior_bot_status:
-                        botStatus['activeLinkLastStatusReceivedTimes'] = prior_bot_status[
-                            'activeLinkLastStatusReceivedTimes'
-                        ]
-                    self.update_active_link_received_times(botStatus)
-                    self.bots[bot_id] = botStatus
-                    accepted_bot_status = True
+                self.bots[bot_id] = botStatus
 
                 # Add position to bot_paths
                 #if msg.bot_status.HasField('location'):
@@ -226,7 +160,7 @@ class Interface:
                 #    if msg.bot_status.time - last_bot_path_point_time >= BOT_PATH_UTIME_THRESHOLD:
                 #        bot_path.append(BotPathPoint(msg.bot_status.time, bot_location.lon, bot_location.lat))
 
-                if accepted_bot_status and msg.HasField('active_mission_plan'):
+                if  msg.HasField('active_mission_plan'):
                     self.process_active_mission_plan(bot_id, msg.active_mission_plan)
 
             if msg.HasField('engineering_status'):
@@ -236,19 +170,15 @@ class Interface:
 
             if msg.HasField('hub_status'):
                 hubStatus = protobufMessageToDict(msg.hub_status)
-                hub_id = hubStatus['hub_id']
-                prior_hub_status = self.hubs.get(hub_id)
-                if self.is_stale_status(prior_hub_status, hubStatus):
-                    logging.warning(f'Ignoring stale hub status for hub {hub_id}: time={hubStatus.get("time")} < stored={prior_hub_status.get("time")}')
-                else:
-                    if 'bot_offload' in hubStatus:
-                        if hubStatus['bot_offload'].get('offload_succeeded') is True:
-                            self.task_packet_database._update()
 
-                    # Set the time of last status to now
-                    hubStatus['lastStatusReceivedTime'] = now_utime()
+                if 'bot_offload' in hubStatus:
+                    if hubStatus['bot_offload'].get('offload_succeeded') is True:
+                        self.task_packet_database._update()
 
-                    self.hubs[hub_id] = hubStatus
+                # Set the time of last status to now
+                hubStatus['lastStatusReceivedTime'] = now_utime()
+
+                self.hubs[hubStatus['hub_id']] = hubStatus
 
             if msg.HasField('task_packet'):
                 logging.info('Task packet received')
@@ -465,14 +395,21 @@ class Interface:
         return {'status': 'ok'}
 
     def get_status(self):
+        now = int(now_utime())
+
         for hub in self.hubs.values():
             # Add the time since last status
-            hub['portalStatusAge'] = now_utime() - hub['lastStatusReceivedTime']
+            hub['portalStatusAge'] = now - hub['lastStatusReceivedTime']
 
 
         for bot in self.bots.values():
-            # Add the time since last status
-            bot['portalStatusAge'] = now_utime() - bot['lastStatusReceivedTime']
+            # Derive last received time from the most recent link timestamp
+            link_times = [int(entry['last_received_time']) for entry in bot.get('active_links', [])
+                  if 'last_received_time' in entry]
+            
+            if link_times:
+                bot['portalStatusAge'] = now - max(link_times)
+
             self.update_active_link_status_ages(bot)
 
             if bot['bot_id'] in self.bots_engineering:

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -419,7 +419,7 @@ class Interface:
                   if 'last_received_time' in entry]
             
             if link_times:
-                bot['portalStatusAge'] = (now - max(link_times)) / warp_factor
+                bot['portalStatusAge'] = int((now - max(link_times)) / warp_factor)
 
             self.update_active_link_status_ages(bot, warp_factor)
 

--- a/src/web/server/jaia_portal.py
+++ b/src/web/server/jaia_portal.py
@@ -115,13 +115,23 @@ class Interface:
             except socket.timeout:
                 self.ping_portal()
 
-    def update_active_link_status_ages(self, status: dict):
-        now = int(now_utime())
+    def update_active_link_status_ages(self, status: dict, warp_factor: int = 1):
+        now = self.current_utime()
         status['active_link_status_age'] = {
-            entry['link']: now - int(entry['last_received_time'])
+            entry['link']: (now - int(entry['last_received_time'])) / warp_factor
             for entry in status.get('active_links', [])
             if 'last_received_time' in entry
         }
+    
+    def current_utime(self):
+        """Return the current time in microseconds.
+        
+        In real-time operation, equivalent to now_utime().
+        In simulation, time is warped from the reference time by the warp factor.
+        """
+        warp_factor = int(self.metadata.get('simulation_warp', 1))
+        simulation_reference_time = int(self.metadata.get('simulation_reference_time', 0))
+        return now_utime(warp_factor, simulation_reference_time)
 
     def process_portal_to_client_message(self, data):
         if len(data) > 0:
@@ -176,7 +186,7 @@ class Interface:
                         self.task_packet_database._update()
 
                 # Set the time of last status to now
-                hubStatus['lastStatusReceivedTime'] = now_utime()
+                hubStatus['lastStatusReceivedTime'] = self.current_utime()
 
                 self.hubs[hubStatus['hub_id']] = hubStatus
 
@@ -241,7 +251,7 @@ class Interface:
         command = google.protobuf.json_format.ParseDict(command_dict, Command())
 
         logging.debug(f'Sending command: {command}')
-        command.time = now_utime()
+        command.time = self.current_utime()
 
         if (
                 command.type == Command.MISSION_PLAN
@@ -263,7 +273,7 @@ class Interface:
         logging.debug(f'Sending single waypoint coordinate: {single_waypoint_mission_dict}')
 
         if 'lat' in single_waypoint_mission_dict and 'lon' in single_waypoint_mission_dict:
-            command_dict = {'bot_id': 1, 'time': now_utime(), 'type': 'MISSION_PLAN', 
+            command_dict = {'bot_id': 1, 'time': self.current_utime(), 'type': 'MISSION_PLAN', 
                             'plan': {'start': 'START_IMMEDIATELY', 'movement': 'TRANSIT', 
                             'goal': [{'location': {'lat': single_waypoint_mission_dict["lat"], 'lon': single_waypoint_mission_dict["lon"]}}], 
                             'recovery': {'recover_at_final_goal': True}, 'speeds': {'transit': 2, 'stationkeep_outer': 1.5}}}
@@ -321,7 +331,7 @@ class Interface:
     def post_command_for_hub(self, command_for_hub_dict, clientId):
         command_for_hub = google.protobuf.json_format.ParseDict(command_for_hub_dict, CommandForHub())
         logging.debug(f'Sending command for hub: {command_for_hub}')
-        command_for_hub.time = now_utime()
+        command_for_hub.time = self.current_utime()
         msg = ClientToPortalMessage()
         msg.command_for_hub.CopyFrom(command_for_hub)
         
@@ -338,7 +348,7 @@ class Interface:
         for bot in self.bots.values():
             cmd = {
                 'bot_id': bot['bot_id'],
-                'time': str(now_utime()),
+                'time': str(self.current_utime()),
                 'type': 'STOP', 
             }
             self.post_command(cmd, clientId)
@@ -353,7 +363,7 @@ class Interface:
         for bot in self.bots.values():
             cmd = {
                 'bot_id': bot['bot_id'],
-                'time': str(now_utime()),
+                'time': str(self.current_utime()),
                 'type': 'ACTIVATE' 
             }
             self.post_command(cmd, clientId)
@@ -369,7 +379,7 @@ class Interface:
         for bot in self.bots.values():
             cmd = {
                 'bot_id': bot['bot_id'],
-                'time': str(now_utime()),
+                'time': str(self.current_utime()),
                 'type': 'RECOVERED' 
             }
             self.post_command(cmd, clientId)
@@ -385,7 +395,7 @@ class Interface:
         for bot in self.bots.values():
             cmd = {
                 'bot_id': bot['bot_id'],
-                'time': str(now_utime()),
+                'time': str(self.current_utime()),
                 'type': 'NEXT_TASK'
             }
             self.post_command(cmd, clientId)
@@ -395,7 +405,8 @@ class Interface:
         return {'status': 'ok'}
 
     def get_status(self):
-        now = int(now_utime())
+        now = self.current_utime()
+        warp_factor = int(self.metadata.get('simulation_warp', 1))
 
         for hub in self.hubs.values():
             # Add the time since last status
@@ -408,9 +419,9 @@ class Interface:
                   if 'last_received_time' in entry]
             
             if link_times:
-                bot['portalStatusAge'] = now - max(link_times)
+                bot['portalStatusAge'] = (now - max(link_times)) / warp_factor
 
-            self.update_active_link_status_ages(bot)
+            self.update_active_link_status_ages(bot, warp_factor)
 
             if bot['bot_id'] in self.bots_engineering:
                 bot['engineering'] = self.bots_engineering[bot['bot_id']]
@@ -436,16 +447,18 @@ class Interface:
         Returns:
             {[hub_id: int]: HubStatus}: The status for all online hubs
         """
+        now = self.current_utime()
+
         for hub in self.hubs.values():
             # Add the time since last status
             if not 'portalStatusAge' in hub:
-                hub['portalStatusAge'] = now_utime() - hub['lastStatusReceivedTime']
+                hub['portalStatusAge'] = now - hub['lastStatusReceivedTime']
         
         return self.hubs
 
     def post_engineering_command(self, command, clientId):
         cmd = google.protobuf.json_format.ParseDict(command, Engineering())
-        cmd.time = now_utime()
+        cmd.time = self.current_utime()
         msg = ClientToPortalMessage()
         msg.engineering_command.CopyFrom(cmd)
 
@@ -461,7 +474,7 @@ class Interface:
 
     def post_ep_command(self, command, clientId):
         cmd = google.protobuf.json_format.ParseDict(command, Engineering())
-        cmd.time = now_utime()
+        cmd.time = self.current_utime()
         msg = ClientToPortalMessage()
         msg.engineering_command.CopyFrom(cmd)
 

--- a/src/web/shared/JAIAProtobuf.ts
+++ b/src/web/shared/JAIAProtobuf.ts
@@ -1008,6 +1008,11 @@ export enum Link {
     LINK_HUB2HUB = "LINK_HUB2HUB",
 }
 
+export interface ActiveLink {
+    link?: Link;
+    last_received_time?: number;
+}
+
 export interface BotStatus {
     bot_id?: number;
     time?: number;
@@ -1034,7 +1039,8 @@ export interface BotStatus {
     data_offload_percentage?: number;
     wifi_link_quality_percentage?: number;
     link?: Link;
-    active_link?: Link[];
+    active_links?: ActiveLink[];
+    active_link_status_age?: { [link: string]: number };
 }
 
 export interface EstimatedDrift {

--- a/src/web/types/protobuf-types.ts
+++ b/src/web/types/protobuf-types.ts
@@ -1002,6 +1002,19 @@ export interface Speed {
     over_water?: number;
 }
 
+export enum Link {
+    LINK_UNKNOWN = "LINK_UNKNOWN",
+    LINK_XBEE = "LINK_XBEE",
+    LINK_WIFI = "LINK_WIFI",
+    LINK_IRIDIUM = "LINK_IRIDIUM",
+    LINK_HUB2HUB = "LINK_HUB2HUB",
+}
+
+export interface ActiveLink {
+    link?: Link;
+    last_received_time?: number;
+}
+
 export interface BotStatus {
     bot_id?: number;
     time?: number;
@@ -1027,6 +1040,9 @@ export interface BotStatus {
     pdop?: number;
     data_offload_percentage?: number;
     wifi_link_quality_percentage?: number;
+    link?: Link;
+    active_links?: ActiveLink[];
+    active_link_status_age?: { [link: string]: number };
 }
 
 export interface EstimatedDrift {


### PR DESCRIPTION
This pull request introduces a set of changes to support simulation time warping on the web server, improve comms status handling, and refactor how communication link health is tracked and displayed throughout the system. The most significant updates include protocol changes to support richer link metadata, new simulation time fields, and a frontend refactor to consistently use a new comms health abstraction.

**Protocol and data structure updates:**

- Added `simulation_warp` and `simulation_reference_time` fields to the `DeviceMetadata` protobuf message to support simulation time warping.
- Updated the `BotStatus` protobuf message to replace the repeated `Link` field with a repeated `ActiveLink` message, which now includes both the link and its last-received time.
- Updated the DCCL hash for `BotStatus` in the CMake configuration to reflect the protocol changes.

**Simulation time support:**

- Modified the `now_utime` function in `utils.py` to support time warping based on a warp factor and simulation reference time, enabling accurate simulation timing.

**Frontend comms health refactor:**

- Refactored the frontend (React) code to use the new `isCommsDropped` abstraction instead of manually checking status age and link type, simplifying comms health checks and improving consistency across components such as `BotDetails`, `NodeList`, and button components. [[1]](diffhunk://#diff-115b7104ae099fcc5087d876958068dbc0e663e4247e2dee307bfafc965faf29L152-R156) [[2]](diffhunk://#diff-5920b90002d5f56f659170b6a24175d6278ed3b5e4ca396f63531427fcedd2f7L10-R24) [[3]](diffhunk://#diff-60c210718cb9869ca77aca61bc4786f9c0c1a05a43b8d4b67fcb37e565004e89L89-R86) [[4]](diffhunk://#diff-549df6cf0445c659164b9ca9763b54d767daa69280cfc13e158528eab071c65bL51-R51) [[5]](diffhunk://#diff-190dd8b957a3bbacacf5fdf6999227859d5c5c9c36d99c2b5f4ef742e280ca88L47-R46)
- Updated the comm links display in `BotDetails` to utilize the new `ActiveLink` structure, showing link status ages and using the new comms health logic for row styling. [[1]](diffhunk://#diff-115b7104ae099fcc5087d876958068dbc0e663e4247e2dee307bfafc965faf29L227-L277) [[2]](diffhunk://#diff-115b7104ae099fcc5087d876958068dbc0e663e4247e2dee307bfafc965faf29R302-R346)
- Removed obsolete or redundant comms health utility functions and constants that are no longer needed after the refactor. [[1]](diffhunk://#diff-5920b90002d5f56f659170b6a24175d6278ed3b5e4ca396f63531427fcedd2f7L49-L66) [[2]](diffhunk://#diff-190dd8b957a3bbacacf5fdf6999227859d5c5c9c36d99c2b5f4ef742e280ca88L13) [[3]](diffhunk://#diff-e86893e97e444569734dad8c71db0140537402c367b75e9eac41c7d0b4da8579L17)

**Styling and consistency improvements:**

- Standardized health state class names in `HubDetails` for consistency with the new comms health system.

**Configuration cleanup:**

- Minor cleanup in configuration templates to remove redundant comments and clarify parameter usage.