### PR TITLE
Bug/hub2hub not initialized properly failure/sw 2367

### DIFF
--- a/cmake/JaiaVersions.cmake
+++ b/cmake/JaiaVersions.cmake
@@ -81,4 +81,4 @@ set(PROJECT_SOVERSION "1")
 
 # increment when DCCL messages change. See also src/lib/messages/CMakeLists.txt
 # start at 1 as 0 would be used prior to introducing this version (goby::middleware::Group::broadcast_group == 0)
-set(PROJECT_INTERVEHICLE_API_VERSION 21)
+set(PROJECT_INTERVEHICLE_API_VERSION 22)

--- a/config/launch/simulation/generate_all_launch.sh
+++ b/config/launch/simulation/generate_all_launch.sh
@@ -45,9 +45,7 @@ if [[ "$comms_mode" == *w* && "$comms_mode" == *x* ]]; then
     jaia_comms_mode="xbee,wifi"
 fi
 
-if [[ "$n_hubs" != "1" ]]; then
-    ${script_dir}/../../../rootfs/customization/includes.chroot/etc/jaiabot/init/jaia-create-ansible-inventory.sh -b $(seq -s , 1 ${n_bots}) -h $(seq -s , 1 ${n_hubs}) -f 0 > /etc/jaiabot/inventory.yml
-fi
+${script_dir}/../../../rootfs/customization/includes.chroot/etc/jaiabot/init/jaia-create-ansible-inventory.sh -b $(seq -s , 1 ${n_bots}) -h $(seq -s , 1 ${n_hubs}) -f 0 > /etc/jaiabot/inventory.yml
 
 launchdelay=100
 

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -84,6 +84,7 @@ class HubManager : public ApplicationBase
 
   private:
     void loop() override;
+    void health(goby::middleware::protobuf::ThreadHealth& health) override;
 
     void handle_bot_nav(jaiabot::protobuf::BotStatus dccl_nav, bool from_other_hub = false);
     void handle_command(const jaiabot::protobuf::Command& input_command,
@@ -206,6 +207,9 @@ class HubManager : public ApplicationBase
     std::set<jaiabot::protobuf::Link>
         active_links_; // which links have we subscribe on at some point?
     std::map<MissionCommandTime, CommandPending> commands_pending_result_;
+
+    std::set<jaiabot::protobuf::Warning> hub_warnings_;
+    std::set<jaiabot::protobuf::Error> hub_errors_;
 };
 } // namespace apps
 } // namespace jaiabot
@@ -398,55 +402,84 @@ void jaiabot::apps::HubManager::handle_subscription_report(
     const goby::middleware::intervehicle::protobuf::SubscriptionReport& sub_report)
 {
     auto command_dccl_id = jaiabot::protobuf::Command::DCCL_ID;
-    if (sub_report.has_changed() && sub_report.changed().dccl_id() == command_dccl_id)
+    auto hub2hub_dccl_id = jaiabot::protobuf::Hub2HubData::DCCL_ID;
+    if (sub_report.has_changed())
     {
-        auto bot_modem_id = sub_report.changed().header().src();
-        auto bot_id = jaiabot::comms::bot_id_from_modem_id(bot_modem_id, cfg().subnet_mask());
-        auto link = jaiabot::comms::link_from_modem_id(bot_modem_id, cfg().subnet_mask());
-
-        std::uint32_t bot_api_version =
-            intervehicle::api_version_from_hub_command(bot_id, sub_report.changed().group());
-
-        if (bot_api_version == jaiabot::INTERVEHICLE_API_VERSION)
+        if (sub_report.changed().dccl_id() == command_dccl_id)
         {
-            switch (sub_report.changed().action())
-            {
-                case goby::middleware::intervehicle::protobuf::Subscription::SUBSCRIBE:
-                    glog.is_verbose() && glog << group("main") << "Subscribe to bot: " << bot_id
-                                              << " on link " << jaiabot::protobuf::Link_Name(link)
-                                              << std::endl;
+            auto bot_modem_id = sub_report.changed().header().src();
+            auto bot_id = jaiabot::comms::bot_id_from_modem_id(bot_modem_id, cfg().subnet_mask());
+            auto link = jaiabot::comms::link_from_modem_id(bot_modem_id, cfg().subnet_mask());
 
-                    managed_bot_ids_.insert(bot_id);
-                    intervehicle_subscribe(bot_id, {link});
-                    break;
-                case goby::middleware::intervehicle::protobuf::Subscription::UNSUBSCRIBE:
-                    // do nothing as the bot subscriptions no longer persist across restarts
-                    // this reduces edge cases problems with unsubscription messages getting through or not
-                    break;
+            std::uint32_t bot_api_version =
+                intervehicle::api_version_from_hub_command(bot_id, sub_report.changed().group());
+
+            if (bot_api_version == jaiabot::INTERVEHICLE_API_VERSION)
+            {
+                switch (sub_report.changed().action())
+                {
+                    case goby::middleware::intervehicle::protobuf::Subscription::SUBSCRIBE:
+                        glog.is_verbose() &&
+                            glog << group("main") << "Subscribe to bot: " << bot_id << " on link "
+                                 << jaiabot::protobuf::Link_Name(link) << std::endl;
+
+                        managed_bot_ids_.insert(bot_id);
+                        intervehicle_subscribe(bot_id, {link});
+                        break;
+                    case goby::middleware::intervehicle::protobuf::Subscription::UNSUBSCRIBE:
+                        // do nothing as the bot subscriptions no longer persist across restarts
+                        // this reduces edge cases problems with unsubscription messages getting through or not
+                        break;
+                }
+            }
+            else
+            {
+                glog.is_warn() && glog << group("main") << "Bot " << bot_id
+                                       << " subscribing with API version " << bot_api_version
+                                       << " but hub is using API version "
+                                       << jaiabot::INTERVEHICLE_API_VERSION << std::endl;
+
+                jaiabot::protobuf::BotStatus status;
+                status.set_bot_id(bot_id);
+                status.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
+                auto error = bot_api_version < jaiabot::INTERVEHICLE_API_VERSION
+                                 ? protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_BOT
+                                 : protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB;
+                status.add_error(error);
+                hub_errors_.insert(error);
+                status.set_health_state(goby::middleware::protobuf::HEALTH__FAILED);
+
+                if (status.has_mission_command_time())
+                {
+                    status.set_mission_name(get_mission_name_for_bot_command_time(
+                        bot_id, status.mission_command_time()));
+                }
+
+                interprocess().publish<jaiabot::groups::bot_status>(status);
             }
         }
-        else
+        else if (sub_report.changed().dccl_id() == command_dccl_id)
         {
-            glog.is_warn() && glog << group("main") << "Bot " << bot_id
-                                   << " subscribing with API version " << bot_api_version
-                                   << " but hub is using API version "
-                                   << jaiabot::INTERVEHICLE_API_VERSION << std::endl;
+            auto other_hub_modem_id = sub_report.changed().header().src();
+            auto link = jaiabot::comms::link_from_modem_id(other_hub_modem_id, cfg().subnet_mask());
+            auto other_hub_id =
+                jaiabot::comms::hub_id_from_modem_id(other_hub_modem_id, cfg().subnet_mask(), link);
+            // group id is the API version for Hub2Hub messages
+            std::uint32_t other_hub_api_version = sub_report.changed().group();
 
-            jaiabot::protobuf::BotStatus status;
-            status.set_bot_id(bot_id);
-            status.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
-            status.add_error(bot_api_version < jaiabot::INTERVEHICLE_API_VERSION
-                                 ? protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_BOT
-                                 : protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB);
-            status.set_health_state(goby::middleware::protobuf::HEALTH__FAILED);
-
-            if (status.has_mission_command_time())
+            if (other_hub_api_version != jaiabot::INTERVEHICLE_API_VERSION)
             {
-                status.set_mission_name(
-                    get_mission_name_for_bot_command_time(bot_id, status.mission_command_time()));
-            }
+                glog.is_warn() && glog << group("main") << "Hub " << other_hub_id
+                                       << " subscribing with API version " << other_hub_api_version
+                                       << " but this hub is using API version "
+                                       << jaiabot::INTERVEHICLE_API_VERSION << std::endl;
 
-            interprocess().publish<jaiabot::groups::bot_status>(status);
+                auto error =
+                    other_hub_api_version < jaiabot::INTERVEHICLE_API_VERSION
+                        ? protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_OTHER_HUB
+                        : protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB;
+                hub_errors_.insert(error);
+            }
         }
     }
 }
@@ -592,12 +625,15 @@ void jaiabot::apps::HubManager::intervehicle_subscribe(int bot_id,
 
                         // Make sure the engineering_status is not a repeat
                         // If it is, then we should not handle it and exit
-                        auto& prev_times = eng_status_id_to_prev_timestamps_[engineering_status.bot_id()];
+                        auto& prev_times =
+                            eng_status_id_to_prev_timestamps_[engineering_status.bot_id()];
 
                         if (prev_times.count(engineering_status.time()))
                         {
-                            glog.is_debug1() && glog << group("engineering_status")
-                                                    << "Repeat Engineering Status received! Ignoring..." << std::endl;
+                            glog.is_debug1() &&
+                                glog << group("engineering_status")
+                                     << "Repeat Engineering Status received! Ignoring..."
+                                     << std::endl;
                             return;
                         }
 
@@ -645,8 +681,20 @@ void jaiabot::apps::HubManager::hub2hub_subscribe(int other_hub_id)
     intervehicle().subscribe<jaiabot::groups::hub2hub_data, jaiabot::protobuf::Hub2HubData>(
         [this](const jaiabot::protobuf::Hub2HubData& data)
         {
-            handle_hub2hub_data(data);
-            interprocess().publish<jaiabot::groups::hub2hub_data>(data);
+            if (!hub_errors_.count(
+                    protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_OTHER_HUB) &&
+                !hub_errors_.count(protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB))
+            {
+                handle_hub2hub_data(data);
+                interprocess().publish<jaiabot::groups::hub2hub_data>(data);
+            }
+            else
+            {
+                glog.is_warn() &&
+                    glog << group("comms")
+                         << "Ignoring hub2hub messages as we have an intervehicle API mismatch"
+                         << std::endl;
+            }
         },
         subscriber);
 }
@@ -854,10 +902,9 @@ void jaiabot::apps::HubManager::handle_bot_nav(jaiabot::protobuf::BotStatus dccl
 
     if (prev_times.count(dccl_nav.time()))
     {
-        glog.is_debug1() && glog << group("bot_status")
-                                << "Repeat Bot Status received on link: " 
-                                << jaiabot::protobuf::Link_Name(dccl_nav.link()) 
-                                << "! Ignoring..." << std::endl;
+        glog.is_debug1() && glog << group("bot_status") << "Repeat Bot Status received on link: "
+                                 << jaiabot::protobuf::Link_Name(dccl_nav.link()) << "! Ignoring..."
+                                 << std::endl;
 
         return;
     }
@@ -875,8 +922,7 @@ void jaiabot::apps::HubManager::handle_bot_nav(jaiabot::protobuf::BotStatus dccl
     // Keep track of previous bot status times per bot to avoid duplicates
     // (typically from multiple comms links: iridium, wifi, xbee)
     // If our buffer overflows, remove the smallest (oldest) timestamp
-    while (prev_times.size() >= history_max_count_)
-        prev_times.erase(prev_times.begin());
+    while (prev_times.size() >= history_max_count_) prev_times.erase(prev_times.begin());
 
     prev_times.insert(dccl_nav.time());
 
@@ -1010,15 +1056,14 @@ void jaiabot::apps::HubManager::handle_task_packet(const jaiabot::protobuf::Task
     if (prev_times.count(task_packet.start_time()))
     {
         glog.is_debug1() && glog << group("task_packet")
-                                << "Repeat taskpacket received! Ignoring..." << std::endl;
+                                 << "Repeat taskpacket received! Ignoring..." << std::endl;
         return;
     }
 
     // Keep track of previous task packet times per bot to avoid duplicates
     // (typically from multiple comms links: iridium, wifi, xbee)
     // If our buffer overflows, remove the smallest (oldest) timestamp
-    while (prev_times.size() >= history_max_count_)
-        prev_times.erase(prev_times.begin());
+    while (prev_times.size() >= history_max_count_) prev_times.erase(prev_times.begin());
 
     prev_times.insert(task_packet.start_time());
 
@@ -1542,5 +1587,24 @@ void jaiabot::apps::HubManager::process_ack_or_expire(
                                    << " that we weren't expecting for command message: "
                                    << orig_msg.ShortDebugString() << std::endl;
         }
+    }
+}
+
+void jaiabot::apps::HubManager::health(goby::middleware::protobuf::ThreadHealth& health)
+{
+    health.ClearExtension(jaiabot::protobuf::jaiabot_thread);
+    health.set_name(this->app_name());
+    health.set_state(goby::middleware::protobuf::HEALTH__OK);
+
+    for (const auto& w : hub_warnings_)
+    {
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)->add_warning(w);
+        health.set_state(goby::middleware::protobuf::HEALTH__DEGRADED);
+    }
+
+    for (const auto& e : hub_errors_)
+    {
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)->add_error(e);
+        health.set_state(goby::middleware::protobuf::HEALTH__FAILED);
     }
 }

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -438,6 +438,7 @@ void jaiabot::apps::HubManager::handle_subscription_report(
             status.add_error(bot_api_version < jaiabot::INTERVEHICLE_API_VERSION
                                  ? protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_BOT
                                  : protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB);
+            status.set_health_state(goby::middleware::protobuf::HEALTH__FAILED);
 
             if (status.has_mission_command_time())
             {

--- a/src/bin/hub_manager/hub_manager.cpp
+++ b/src/bin/hub_manager/hub_manager.cpp
@@ -134,6 +134,13 @@ class HubManager : public ApplicationBase
     void process_ack_or_expire(const protobuf::Command& orig_msg, protobuf::Link link,
                                protobuf::CommandCommsResult::CommsResult result);
 
+    bool hub2hub_api_mismatch()
+    {
+        return (
+            hub_errors_.count(protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_OTHER_HUB) ||
+            hub_errors_.count(protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB));
+    }
+
   private:
     jaiabot::protobuf::HubStatus latest_hub_status_;
     goby::time::SteadyClock::time_point last_health_report_time_{std::chrono::seconds(0)};
@@ -458,7 +465,7 @@ void jaiabot::apps::HubManager::handle_subscription_report(
                 interprocess().publish<jaiabot::groups::bot_status>(status);
             }
         }
-        else if (sub_report.changed().dccl_id() == command_dccl_id)
+        else if (sub_report.changed().dccl_id() == hub2hub_dccl_id)
         {
             auto other_hub_modem_id = sub_report.changed().header().src();
             auto link = jaiabot::comms::link_from_modem_id(other_hub_modem_id, cfg().subnet_mask());
@@ -681,9 +688,7 @@ void jaiabot::apps::HubManager::hub2hub_subscribe(int other_hub_id)
     intervehicle().subscribe<jaiabot::groups::hub2hub_data, jaiabot::protobuf::Hub2HubData>(
         [this](const jaiabot::protobuf::Hub2HubData& data)
         {
-            if (!hub_errors_.count(
-                    protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_OTHER_HUB) &&
-                !hub_errors_.count(protobuf::ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB))
+            if (!hub2hub_api_mismatch())
             {
                 handle_hub2hub_data(data);
                 interprocess().publish<jaiabot::groups::hub2hub_data>(data);
@@ -691,7 +696,7 @@ void jaiabot::apps::HubManager::hub2hub_subscribe(int other_hub_id)
             else
             {
                 glog.is_warn() &&
-                    glog << group("comms")
+                    glog << group("hub2hub")
                          << "Ignoring hub2hub messages as we have an intervehicle API mismatch"
                          << std::endl;
             }
@@ -1500,10 +1505,20 @@ void jaiabot::apps::HubManager::start_dataoffload(int bot_id)
 
 void jaiabot::apps::HubManager::publish_hub2hub_data(jaiabot::protobuf::Hub2HubData* hub2hub_data)
 {
-    hub2hub_data->set_hub_id(cfg().hub_id());
-    hub2hub_data->set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
-    intervehicle().publish<jaiabot::groups::hub2hub_data>(
-        *hub2hub_data, intervehicle::default_publisher<jaiabot::protobuf::Hub2HubData>);
+    if (!hub2hub_api_mismatch())
+    {
+        hub2hub_data->set_hub_id(cfg().hub_id());
+        hub2hub_data->set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
+        intervehicle().publish<jaiabot::groups::hub2hub_data>(
+            *hub2hub_data, intervehicle::default_publisher<jaiabot::protobuf::Hub2HubData>);
+    }
+    else
+    {
+        glog.is_warn() &&
+            glog << group("hub2hub")
+                 << "Not publishing hub2hub messages as we have an intervehicle API mismatch"
+                 << std::endl;
+    }
 }
 
 void jaiabot::apps::HubManager::process_ack_or_expire(

--- a/src/lib/comms/comms.h
+++ b/src/lib/comms/comms.h
@@ -88,6 +88,22 @@ inline int hub_modem_id(unsigned subnet_mask, jaiabot::protobuf::Link link, int 
     }
 }
 
+inline int hub_id_from_modem_id(int modem_id, unsigned subnet_mask, jaiabot::protobuf::Link link)
+{
+    if (link == jaiabot::protobuf::LINK_HUB2HUB)
+    {
+        int base_modem_id = modem_id & (~subnet_mask & 0xFFFF);
+        int hub_id = base_modem_id - hub_base_modem_id;
+        check_hub_id_bounds(hub_id);
+        return hub_id;
+    }
+    else
+    {
+        throw(jaiabot::Exception(
+            "Hub ID cannot be inferred from modem_id for links other than LINK_HUB2HUB"));
+    }
+}
+
 inline int modem_id_from_bot_id(int bot_id, unsigned subnet_mask, jaiabot::protobuf::Link link)
 {
     check_bot_id_bounds(bot_id);

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -97,8 +97,9 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0x57fa2ff48bd9844a")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xc4f31768df8d6cbe")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xc2b6ff5101df098c")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0x14ebbe8ed8aed722")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x6694c32d91a8b1c7")
+  check_dccl_md5_hash("jaiabot.protobuf.Hub2HubData" "0x24159993f740a6f8")
 endif()

--- a/src/lib/messages/health.proto
+++ b/src/lib/messages/health.proto
@@ -88,8 +88,7 @@ enum Error
         [(jaia.ev).rest_api.presence = GUARANTEED];
     ERROR__FAILED__JAIABOT_UDP_GATEWAY = 43
         [(jaia.ev).rest_api.presence = GUARANTEED];
-    ERROR__FAILED__JAIABOT_PPK = 44
-        [(jaia.ev).rest_api.presence = GUARANTEED];
+    ERROR__FAILED__JAIABOT_PPK = 44 [(jaia.ev).rest_api.presence = GUARANTEED];
 
     // from goby_coroner
     // must be "ERROR__NOT_RESPONDING__" + uppercase(application name)
@@ -229,12 +228,17 @@ enum Error
         [(jaia.ev).rest_api.presence = GUARANTEED];
     ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB = 702 [
         (jaia.ev).rest_api.presence = GUARANTEED
-    ];  // INTERVEHICLE_API_VERSION_mismatch - hub version < bot_version
+    ];  // INTERVEHICLE_API_VERSION_mismatch - hub version < bot_version OR this
+        // hub version < other hub version
     ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_BOT = 703 [
         (jaia.ev).rest_api.presence = GUARANTEED
     ];  // INTERVEHICLE_API_VERSION_mismatch - hub_version > bot_version
     ERROR__ARDUINO_CONNECTION_FAILED = 704
         [(jaia.ev).rest_api.presence = GUARANTEED];
+    ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_OTHER_HUB = 705
+        [(jaia.ev).rest_api.presence =
+             GUARANTEED];  // INTERVEHICLE_API_VERSION_mismatch - other hub
+                           // version < this hub version
 
     // jaiabot_sensor
     ERROR__INIT_FAILED__BLUE_ROBOTICS__BAR30 = 800
@@ -360,8 +364,7 @@ enum Warning
         [(jaia.ev).rest_api.presence = GUARANTEED];
     WARNING__MISSING_DATA__AML_DATA = 808
         [(jaia.ev).rest_api.presence = GUARANTEED];
-    WARNING__INIT_FAILED__AML = 809
-        [(jaia.ev).rest_api.presence = GUARANTEED];
+    WARNING__INIT_FAILED__AML = 809 [(jaia.ev).rest_api.presence = GUARANTEED];
 }
 
 message LinuxHardwareStatus

--- a/src/lib/serial/serial_crc32.h
+++ b/src/lib/serial/serial_crc32.h
@@ -5,8 +5,9 @@
 #include <boost/asio.hpp>
 #include <string>
 
-#include "goby/middleware/io/detail/io_interface.h"     // for PubSubLayer
-#include "goby/middleware/io/detail/serial_interface.h" // for SerialThread
+#include <goby/middleware/io/detail/io_interface.h>
+#include <goby/middleware/io/detail/serial_interface.h>
+#include <goby/version.h>
 
 #include "jaiabot/crc/crc32.h"
 
@@ -83,7 +84,11 @@ template <const goby::middleware::Group& line_in_group,
               goby::middleware::io::PubSubLayer::INTERPROCESS,
           goby::middleware::io::PubSubLayer subscribe_layer =
               goby::middleware::io::PubSubLayer::INTERTHREAD,
+#if GOBY_VERSION_MAJOR == 3 && GOBY_VERSION_MINOR < 4
           template <class> class ThreadType = goby::middleware::SimpleThread,
+#else
+          template <class> class ThreadType = goby::zeromq::SimpleThread,
+#endif
           bool use_indexed_groups = false>
 class SerialThreadCRC32
     : public goby::middleware::io::detail::SerialThread<line_in_group, line_out_group,

--- a/src/lib/serial/serial_fletcher16.h
+++ b/src/lib/serial/serial_fletcher16.h
@@ -5,8 +5,10 @@
 #include <boost/asio.hpp>
 #include <string>
 
-#include "goby/middleware/io/detail/io_interface.h"     // for PubSubLayer
-#include "goby/middleware/io/detail/serial_interface.h" // for SerialThread
+#include <goby/middleware/io/detail/io_interface.h>
+#include <goby/version.h>
+#include <goby/middleware/io/detail/serial_interface.h>
+
 #include "nanopb/jaiabot/messages/feather.pb.h"
 
 #include "jaiabot/crc/fletcher16.h"
@@ -50,7 +52,11 @@ template <const goby::middleware::Group& line_in_group,
               goby::middleware::io::PubSubLayer::INTERPROCESS,
           goby::middleware::io::PubSubLayer subscribe_layer =
               goby::middleware::io::PubSubLayer::INTERTHREAD,
+#if GOBY_VERSION_MAJOR == 3 && GOBY_VERSION_MINOR < 4
           template <class> class ThreadType = goby::middleware::SimpleThread,
+#else
+          template <class> class ThreadType = goby::zeromq::SimpleThread,
+#endif
           bool use_indexed_groups = false>
 class SerialThreadFletcher16
     : public goby::middleware::io::detail::SerialThread<line_in_group, line_out_group,

--- a/src/test/comms/test.cpp
+++ b/src/test/comms/test.cpp
@@ -66,6 +66,29 @@ BOOST_AUTO_TEST_CASE(test_bot_id_bounds)
     BOOST_CHECK_THROW(check_bot_id_bounds(bot_id_max + 1), jaiabot::Exception);
 }
 
+BOOST_AUTO_TEST_CASE(test_hub_id_from_modem_id)
+{
+    {
+        int hub_id = 1;
+        BOOST_CHECK_EQUAL(
+            hub_id_from_modem_id(hub_modem_id(subnet_mask, jaiabot::protobuf::LINK_HUB2HUB, hub_id),
+                                 subnet_mask, jaiabot::protobuf::LINK_HUB2HUB),
+            hub_id);
+    }
+    {
+        int hub_id = 10;
+        BOOST_CHECK_EQUAL(
+            hub_id_from_modem_id(hub_modem_id(subnet_mask, jaiabot::protobuf::LINK_HUB2HUB, hub_id),
+                                 subnet_mask, jaiabot::protobuf::LINK_HUB2HUB),
+            hub_id);
+    }
+
+    BOOST_CHECK_THROW(hub_id_from_modem_id(10, subnet_mask, jaiabot::protobuf::LINK_XBEE),
+                      jaiabot::Exception);
+    BOOST_CHECK_THROW(hub_id_from_modem_id(10, subnet_mask, jaiabot::protobuf::LINK_WIFI),
+                      jaiabot::Exception);
+}
+
 BOOST_AUTO_TEST_CASE(test_link_from_modem_id)
 {
     BOOST_CHECK_EQUAL(link_from_modem_id(1, subnet_mask), jaiabot::protobuf::LINK_XBEE);


### PR DESCRIPTION
## Overview

Fixes bug when two hubs have a different INTERVEHICLE_API version: https://jaia-innovation.atlassian.net/browse/SW-2367

## Bug

 previously this wasn't detected for the Hub2HubData message, potentially causing crashes if the message versions were incompatible.

## Fix

This PR adds code for the hub_manager to detect the mismatch for the Hub2HubData message much like the Command message.

Upon subscription to Hub2HubData from some other hub:

1. If this hub is older then the other hub, the error is:
ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_HUB
2. If this hub is newer than the other hub, the error is: ERROR__VERSION__MISMATCH_INTERVEHICLE__UPGRADE_OTHER_HUB
3. Stop sending Hub2Hub data.
4. Stop processing Hub2Hub incoming.

## Testing

Manually switched INTERVEHICLE_API using 1 hub on v21 and 1 hub and 1 bot on v22. Then used 1 hub and 1 bot on v21 and 1 hub on v22. Checked that all bots and hubs gave expected error messages.

**Note**: HubStatus errors are not viewable in JCC. This should be updated so that they are.