### PR TITLE
bug/bot-not-entering-rc-mode/SW-1790

### DIFF
--- a/src/web/components/RemoteControlPanel/LoadingPanel/LoadingPanel.less
+++ b/src/web/components/RemoteControlPanel/LoadingPanel/LoadingPanel.less
@@ -1,0 +1,12 @@
+@import "../../../style/stylesheets/vars.less";
+
+.loading-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
+    justify-content: center;
+    align-items: center;
+
+    color: @cc-text-color-light;
+    font-size: 1.2rem;
+}

--- a/src/web/components/RemoteControlPanel/LoadingPanel/LoadingPanel.tsx
+++ b/src/web/components/RemoteControlPanel/LoadingPanel/LoadingPanel.tsx
@@ -1,0 +1,15 @@
+import CircularProgress from "@mui/material/CircularProgress";
+import "./LoadingPanel.less";
+
+/**
+ * Rendered prior to RC panel to prevent the operator from sending RC commands
+ * before the Bot enters the RC state.
+ */
+export default function LoadingPanel() {
+    return (
+        <div className="remote-control-panel loading-panel">
+            <div>Entering Remote Control Mode</div>
+            <CircularProgress size={72} sx={{ color: "#cc0505" }} />
+        </div>
+    );
+}

--- a/src/web/jcc/App.tsx
+++ b/src/web/jcc/App.tsx
@@ -3,6 +3,7 @@ import { JaiaContext, JaiaContextProvider } from "../context/JaiaContext";
 
 import { gridPlan } from "../data/survey_planner/grid-plan";
 import { ButtonNames } from "../types/context-types";
+import { MissionState } from "../types/protobuf-types";
 import { BotModes, ButtonListTypes, NodeTypes } from "../types/jaia-system-types";
 import { isControllingClient } from "../utils/commands";
 import { JCC_CONTAINER } from "../utils/constants";
@@ -33,11 +34,13 @@ import DataOffloadPanel from "../components/DataOffloadPanel/DataOffloadPanel";
 import SimulationBanner from "../components/SimulationBanner/SimulationBanner";
 import TakeControlButton from "../components/__buttons__/TakeControl/TakeControlButton/TakeControlButton";
 import RemoteControlPanel from "../components/RemoteControlPanel/RemoteControlPanel";
+import LoadingPanel from "../components/RemoteControlPanel/LoadingPanel/LoadingPanel";
 
 import "./App.less";
 
 // 400 ms is intentionally conservative to avoid flicker or partially rendered content on slower devices.
 const LOADING_SCREEN_REMOVAL_DELAY_MS = 400;
+const RC_STATE = MissionState.IN_MISSION__UNDERWAY__MOVEMENT__REMOTE_CONTROL__SURFACE_DRIFT;
 
 /**
  * The root of the JCC interface
@@ -163,10 +166,19 @@ function RemoteControl() {
     if (jaiaContext === null) {
         return;
     }
+
     if (jaiaContext.jaiaGlobal.getSelectedNode().type === NodeTypes.BOT) {
         const selectedBot = jaiaContext.bots.getBot(jaiaContext.jaiaGlobal.getSelectedNode().id);
-        if (selectedBot.getMode() === BotModes.REMOTE_CONTROL) {
+
+        if (
+            selectedBot.getMode() === BotModes.REMOTE_CONTROL &&
+            selectedBot.getMissionStatus().missionState === RC_STATE
+        ) {
             return <RemoteControlPanel botID={selectedBot.getBotID()} />;
+        }
+
+        if (selectedBot.getMode() === BotModes.REMOTE_CONTROL) {
+            return <LoadingPanel />;
         }
     }
 }


### PR DESCRIPTION
### Summary
An operator could find themselves in a state where they could send RC commands without the Bot being in RC mode. These commands would clash with the autonomous control of the vehicle causing unknown behaviors. This pull request shows a loading screen in between the time the operator clicks the enter RC button and the time the Bot enters the RC state. Note, I decided with Matt that we will not have an exit loading screen since the operator will not have or need the ability to send RC commands.

### Testing
* Click the enter RC button, watch the loading screen appear, once the state changes to the RC state, you will see the controls appear.
* Exit RC mode, the panel disappears on click

### Video Demonstration
https://github.com/user-attachments/assets/3029cab4-47a5-49d5-a512-f06bc0d3e208