### PR TITLE
task/add-back-ability-to-hide-rc-panel/SW-2432

### DIFF
--- a/src/web/components/RemoteControlPanel/RemoteControlPanel.less
+++ b/src/web/components/RemoteControlPanel/RemoteControlPanel.less
@@ -17,6 +17,27 @@
     border-top: 6px solid #fff;
 }
 
+.remote-control-panel.minimized {
+    height: 60px;
+}
+
+.view-arrow {
+    position: fixed;
+    right: 45px;
+    bottom: 180px;
+    cursor: pointer;
+}
+
+.view-arrow.minimized {
+    bottom: 12px;
+}
+
+.view-arrow svg {
+    color: #fff;
+    width: 2rem;
+    height: 2rem;
+}
+
 .remote-control-panel.dive {
     grid-template-columns: 420px 420px;
     justify-content: center;

--- a/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
+++ b/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
+import { mdiChevronDown, mdiChevronUp } from "@mdi/js";
 import { jaiaGlobal } from "../../data/jaia_global/jaia-global";
-import { IJoystickUpdateEvent } from "react-joystick-component/build/lib/Joystick";
+import Icon from "@mdi/react";
 import Gamepad from "react-gamepad";
 
 import JaiaToggle from "../JaiaToggle/JaiaToggle";
@@ -65,6 +66,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
         ...defaultParams.drift,
     });
     const [rcOverdrive, setRCOverdrive] = useState(false);
+    const [isMinimizedView, setIsMinimizedView] = useState(true);
 
     // Include useEffect dependencies to prevent interval data from going stale
     useEffect(() => {
@@ -280,8 +282,25 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
         </div>
     );
 
+    const RCMinimizedView = (
+        <div className="remote-control-panel minimized">
+            <div className="view-arrow minimized" onClick={() => setIsMinimizedView(false)}>
+                <Icon path={mdiChevronUp} />
+            </div>
+        </div>
+    );
+
+    const RCMinimizeArrow = (
+        <div className="view-arrow" onClick={() => setIsMinimizedView(true)}>
+            <Icon path={mdiChevronDown} />
+        </div>
+    );
+
     switch (controlType) {
         case ControlTypes.SINGLE:
+            if (isMinimizedView) {
+                return RCMinimizedView;
+            }
             return (
                 <>
                     {/* Gamepad component listens for Xbox controller input in background */}
@@ -298,6 +317,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
                         <div></div>
                     </Gamepad>
                     <div className="remote-control-panel">
+                        {RCMinimizeArrow}
                         <AnalogStick
                             analogStickType={AnalogStickTypes.SINGLE}
                             handleAnalogStickMove={(event) => {
@@ -317,6 +337,9 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
                 </>
             );
         case ControlTypes.DUAL:
+            if (isMinimizedView) {
+                return RCMinimizedView;
+            }
             return (
                 <>
                     {/* Gamepad component listens for Xbox controller input in background */}
@@ -333,6 +356,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
                         <div></div>
                     </Gamepad>
                     <div className="remote-control-panel">
+                        {RCMinimizeArrow}
                         <AnalogStick
                             analogStickType={AnalogStickTypes.LEFT}
                             handleAnalogStickMove={(event) =>
@@ -358,6 +382,9 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
                 </>
             );
         case ControlTypes.DIVE:
+            if (isMinimizedView) {
+                return RCMinimizedView;
+            }
             return (
                 <>
                     {/* Gamepad component listens for Xbox controller input in background */}
@@ -374,6 +401,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
                         <div></div>
                     </Gamepad>
                     <div className="remote-control-panel dive">
+                        {RCMinimizeArrow}
                         <DiveInputs
                             rcDiveParameters={rcDiveParameters}
                             onChange={handleRCDiveChange}

--- a/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
+++ b/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
@@ -66,7 +66,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
         ...defaultParams.drift,
     });
     const [rcOverdrive, setRCOverdrive] = useState(false);
-    const [isMinimizedView, setIsMinimizedView] = useState(true);
+    const [isMinimizedView, setIsMinimizedView] = useState(false);
 
     // Include useEffect dependencies to prevent interval data from going stale
     useEffect(() => {


### PR DESCRIPTION
### Summary
After the refactor, I forgot to add back the RC minimize/expand button. This pull request adds it back.

### Testing
Minimize + expand RC panel in single, dual, and dive modes

### Video Demonstration
https://github.com/user-attachments/assets/aa086904-08ff-4aa4-a360-fb80f29236d5

