### PR TITLE
Fixed health incrementing issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,9 @@ foreach(script ${scripts_to_install})
     configure_file(${project_SCRIPTS_DIR}/${script} ${project_BIN_DIR} COPYONLY)
 endforeach()
 
+install(PROGRAMS ${project_SCRIPTS_DIR}/jaia_firm_arduino_flash.sh
+        DESTINATION share/jaiabot/scripts)
+
 
 option(enable_testing "Enable building of tests using CTest (if set to ON, you can run tests with 'make test')" OFF)
 if(enable_testing)

--- a/config/templates/bot/jaiabot_health.pb.cfg.in
+++ b/config/templates/bot/jaiabot_health.pb.cfg.in
@@ -33,3 +33,10 @@ linux_hw {
 motor {
     motor_harness_type: $motor_harness_type
 }
+
+arduino_recovery {
+    enable_auto_flash: true
+    min_interval_seconds: 300
+    max_attempts: 3
+    flash_script: "/usr/share/jaiabot/scripts/jaia_firm_arduino_flash.sh"
+}

--- a/scripts/jaia_firm_arduino_flash.sh
+++ b/scripts/jaia_firm_arduino_flash.sh
@@ -23,7 +23,24 @@ if [ ! -x "${DIR}/upload.sh" ]; then
     exit 1
 fi
 
+if [ "${TYPE}" = "usb" ]; then
+    HEX_BASENAME="jaiabot_runtime.ino.hex"
+else
+    HEX_BASENAME="jaiabot_runtime.ino.with_bootloader.hex"
+fi
+UPLOADED_MARKER="${DIR}/${HEX_BASENAME}.uploaded"
+
 systemctl stop jaiabot_driver_arduino
-rm -f "${DIR}/jaiabot_runtime.ino.hex.uploaded"
-"${DIR}/upload.sh"
+rm -f "${UPLOADED_MARKER}"
+
+upload_ok=false
+if "${DIR}/upload.sh"; then
+    upload_ok=true
+fi
+
 systemctl start jaiabot_driver_arduino
+
+if [ "${upload_ok}" = false ] || [ ! -f "${UPLOADED_MARKER}" ]; then
+    echo "Arduino upload failed; uploaded marker not present: ${UPLOADED_MARKER}"
+    exit 1
+fi

--- a/scripts/jaia_firm_arduino_flash.sh
+++ b/scripts/jaia_firm_arduino_flash.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Stop the Arduino driver, force-reflash firmware, and restart the driver.
+set -euo pipefail
+
+if [ -f /etc/jaiabot/runtime.env ]; then
+    set -a
+    # shellcheck source=/etc/jaiabot/runtime.env
+    source /etc/jaiabot/runtime.env
+    set +a
+fi
+
+TYPE="${jaia_arduino_type:-usb}"
+
+if [ "${TYPE}" = "none" ]; then
+    echo "jaia_arduino_type is none; skipping Arduino flash."
+    exit 0
+fi
+
+DIR="/usr/share/jaiabot/arduino/jaiabot_runtime/${TYPE}"
+
+if [ ! -x "${DIR}/upload.sh" ]; then
+    echo "Arduino upload script not found: ${DIR}/upload.sh"
+    exit 1
+fi
+
+systemctl stop jaiabot_driver_arduino
+rm -f "${DIR}/jaiabot_runtime.ino.hex.uploaded"
+"${DIR}/upload.sh"
+systemctl start jaiabot_driver_arduino

--- a/src/arduino/upload.sh.in
+++ b/src/arduino/upload.sh.in
@@ -23,6 +23,7 @@ if [[ ! -f ${uploaded_path} || ${hex_mtime} -gt `stat -c %Y ${uploaded_path}` ]]
         touch ${uploaded_path}
     else
         echo "UPLOAD FAILED!"
+        exit 1
     fi
 else
     echo "SKIPPING ARDUINO UPLOAD: ${hex_path} is older than ${uploaded_path}"

--- a/src/bin/drivers/arduino/app.cpp
+++ b/src/bin/drivers/arduino/app.cpp
@@ -65,6 +65,7 @@ class ArduinoDriver : public zeromq::MultiThreadApplication<config::ArduinoDrive
     void health(goby::middleware::protobuf::ThreadHealth& health) override;
     void check_last_report(goby::middleware::protobuf::ThreadHealth& health,
                            goby::middleware::protobuf::HealthState& health_state);
+    void maybe_request_arduino_flash();
     void setBounds(const jaiabot::protobuf::Bounds& bounds);
     void publish_arduino_commands();
     void handle_control_surfaces(const ControlSurfaces& control_surfaces);
@@ -113,6 +114,11 @@ class ArduinoDriver : public zeromq::MultiThreadApplication<config::ArduinoDrive
     goby::time::SteadyClock::time_point last_arduino_report_time_{std::chrono::seconds(0)};
     // Used to check the time the arduino restarted
     goby::time::SteadyClock::time_point last_arduino_restart_time_{std::chrono::seconds(0)};
+
+    static constexpr int k_arduino_flash_request_delay_seconds_{30};
+    bool flash_arduino_requested_{false};
+    bool arduino_failure_timer_active_{false};
+    goby::time::SteadyClock::time_point arduino_failure_time_{};
 };
 
 } // namespace apps
@@ -564,6 +570,7 @@ void jaiabot::apps::ArduinoDriver::health(goby::middleware::protobuf::ThreadHeal
     auto health_state = goby::middleware::protobuf::HEALTH__OK;
 
     check_last_report(health, health_state);
+    maybe_request_arduino_flash();
 
     health.set_state(health_state);
 }
@@ -605,4 +612,42 @@ void jaiabot::apps::ArduinoDriver::check_last_report(
         health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
             ->add_error(protobuf::ERROR__MISSING_DATA__ARDUINO_REPORT);
     }
+}
+
+void jaiabot::apps::ArduinoDriver::maybe_request_arduino_flash()
+{
+    const bool needs_flash = !is_driver_connected_ || !is_driver_compatible_;
+    const bool recovered = is_driver_connected_ && is_driver_compatible_;
+
+    if (recovered)
+    {
+        flash_arduino_requested_ = false;
+        arduino_failure_timer_active_ = false;
+        return;
+    }
+
+    if (!needs_flash)
+        return;
+
+    const auto now = goby::time::SteadyClock::now();
+    if (!arduino_failure_timer_active_)
+    {
+        arduino_failure_time_ = now;
+        arduino_failure_timer_active_ = true;
+    }
+
+    if (flash_arduino_requested_)
+        return;
+
+    if (now < arduino_failure_time_ + std::chrono::seconds(k_arduino_flash_request_delay_seconds_))
+        return;
+
+    jaiabot::protobuf::ArduinoIssue issue;
+    issue.set_solution(jaiabot::protobuf::ArduinoIssue::FLASH_ARDUINO);
+    interprocess().publish<groups::arduino_issue>(issue);
+    flash_arduino_requested_ = true;
+
+    glog.is_warn() && glog << group("main")
+                           << "Published ArduinoIssue FLASH_ARDUINO for health recovery"
+                           << std::endl;
 }

--- a/src/bin/health/app.cpp
+++ b/src/bin/health/app.cpp
@@ -27,6 +27,7 @@
 
 #include "config.pb.h"
 #include "jaiabot/groups.h"
+#include "jaiabot/messages/arduino.pb.h"
 #include "jaiabot/messages/engineering.pb.h"
 #include "jaiabot/messages/jaia_dccl.pb.h"
 #include "system_thread.h"
@@ -77,6 +78,7 @@ class Health : public ApplicationBase
     void reboot_bno085_imu() { system("systemctl start jaia_firm_bno085_reset_gpio_pin_py"); }
     void reboot_echo() { system("systemctl start jaia_firm_echo_reset_gpio_pin_py"); }
     void process_coroner_report(const goby::middleware::protobuf::VehicleHealth& vehicle_health);
+    void attempt_flash_arduino();
 
   private:
     goby::time::SteadyClock::time_point next_check_time_;
@@ -84,6 +86,10 @@ class Health : public ApplicationBase
     const std::map<std::string, jaiabot::protobuf::Error> process_to_not_responding_error_;
     std::set<jaiabot::protobuf::Error> failed_services_;
     jaiabot::protobuf::LinuxHardwareStatus sim_hardware_status_;
+    goby::time::SteadyClock::time_point last_arduino_flash_time_{};
+    bool last_arduino_flash_time_set_{false};
+    int arduino_flash_attempts_{0};
+    bool arduino_flash_in_progress_{false};
 };
 } // namespace apps
 } // namespace jaiabot
@@ -271,6 +277,48 @@ jaiabot::apps::Health::Health()
             }
         });
 
+    interprocess().subscribe<jaiabot::groups::arduino_issue>(
+        [this](const jaiabot::protobuf::ArduinoIssue& issue) {
+            if (issue.solution() != protobuf::ArduinoIssue::FLASH_ARDUINO)
+                return;
+
+            if (cfg().is_in_sim() && !cfg().test_hardware_in_sim())
+            {
+                glog.is_debug2() && glog << "Arduino FLASH_ARDUINO ignored in simulation"
+                                         << std::endl;
+                return;
+            }
+
+            const auto& recovery = cfg().arduino_recovery();
+            if (!recovery.enable_auto_flash())
+                return;
+
+            if (arduino_flash_in_progress_)
+                return;
+
+            if (arduino_flash_attempts_ >= recovery.max_attempts())
+            {
+                glog.is_warn() && glog << "Arduino auto-flash max attempts ("
+                                       << recovery.max_attempts() << ") reached; skipping"
+                                       << std::endl;
+                return;
+            }
+
+            const auto now = goby::time::SteadyClock::now();
+            if (last_arduino_flash_time_set_ &&
+                now < last_arduino_flash_time_ +
+                            std::chrono::seconds(recovery.min_interval_seconds()))
+            {
+                glog.is_debug2() && glog << "Arduino auto-flash rate limited; skipping"
+                                         << std::endl;
+                return;
+            }
+
+            glog.is_warn() && glog << "Received ArduinoIssue FLASH_ARDUINO; starting recovery"
+                                   << std::endl;
+            attempt_flash_arduino();
+        });
+
     interprocess().subscribe<goby::middleware::groups::health_report>(
         [this](const goby::middleware::protobuf::VehicleHealth& vehicle_health) {
             process_coroner_report(vehicle_health);
@@ -383,6 +431,38 @@ void jaiabot::apps::Health::loop()
         wifi.set_signal_level(33);
         wifi.set_noise_level(0);
         interprocess().publish<jaiabot::groups::linux_hardware_status>(sim_hardware_status_);
+    }
+}
+
+void jaiabot::apps::Health::attempt_flash_arduino()
+{
+    const auto& recovery = cfg().arduino_recovery();
+    if (recovery.flash_script().empty())
+    {
+        glog.is_warn() && glog << "Arduino auto-flash enabled but flash_script is empty"
+                               << std::endl;
+        return;
+    }
+
+    arduino_flash_in_progress_ = true;
+    glog.is_warn() && glog << "Running Arduino auto-flash: " << recovery.flash_script()
+                           << std::endl;
+
+    const int status = std::system(recovery.flash_script().c_str());
+    arduino_flash_in_progress_ = false;
+    last_arduino_flash_time_ = goby::time::SteadyClock::now();
+    last_arduino_flash_time_set_ = true;
+    ++arduino_flash_attempts_;
+
+    if (status != 0)
+    {
+        glog.is_warn() && glog << "Arduino auto-flash script exited with status " << status
+                               << std::endl;
+    }
+    else
+    {
+        glog.is_verbose() && glog << "Arduino auto-flash script completed successfully"
+                                  << std::endl;
     }
 }
 

--- a/src/bin/health/config.proto
+++ b/src/bin/health/config.proto
@@ -83,6 +83,20 @@ message MotorStatusConfig
     optional jaiabot.protobuf.MotorHarnessType motor_harness_type = 12 [default = NONE];
 }
 
+message ArduinoRecoveryConfig
+{
+    option (dccl.msg) = {
+        unit_system: "si"
+    };
+
+    optional bool enable_auto_flash = 1 [default = false];
+    optional int32 min_interval_seconds = 2
+        [default = 300, (dccl.field).units = { base_dimensions: "T" }];
+    optional int32 max_attempts = 3 [default = 3];
+    optional string flash_script = 10
+        [default = "/usr/share/jaiabot/scripts/jaia_firm_arduino_flash.sh"];
+}
+
 message Health
 {
     option (dccl.msg) = {
@@ -108,4 +122,5 @@ message Health
     optional NTPStatusConfig ntp = 40;
     optional HelmIVPStatusConfig helm = 41;
     optional MotorStatusConfig motor = 42;
+    optional ArduinoRecoveryConfig arduino_recovery = 43;
 }

--- a/src/lib/groups.h
+++ b/src/lib/groups.h
@@ -118,6 +118,7 @@ constexpr goby::middleware::Group hub_command_result{
 constexpr goby::middleware::Group arduino_from_pi{"jaiabot::arduino_from_pi"};
 constexpr goby::middleware::Group arduino_to_pi{"jaiabot::arduino_to_pi"};
 constexpr goby::middleware::Group arduino_debug{"jaiabot::arduino_debug"};
+constexpr goby::middleware::Group arduino_issue{"jaiabot::arduino_issue"};
 
 // Metadata
 constexpr goby::middleware::Group metadata{"jaiabot::metadata"};

--- a/src/lib/messages/arduino.proto
+++ b/src/lib/messages/arduino.proto
@@ -60,3 +60,13 @@ message ArduinoDebug
     optional bool arduino_restarted = 1 [default = false];
     optional bool arduino_not_responding = 2 [default = false];
 }
+
+message ArduinoIssue
+{
+    enum SolutionType
+    {
+        FLASH_ARDUINO = 0;
+    }
+
+    required SolutionType solution = 1 [default = FLASH_ARDUINO];
+}


### PR DESCRIPTION
Fixed health always incrementing arduino_flash_attempts_ and starting the 300s cooldown either way. Resolved misleading success logging and no non-zero exit for monitoring/retries. 