### PR TITLE
Add tooltip to rally point button

### DIFF
--- a/src/web/components/__buttons__/RallyButton/RallyButton.tsx
+++ b/src/web/components/__buttons__/RallyButton/RallyButton.tsx
@@ -44,6 +44,7 @@ export default function RallyButton() {
             <Button
                 className={getClassName()}
                 aria-label={"add-rally-point"}
+                title="Create Rally Point"
                 onClick={() => handleRallyButtonClick()}
             >
                 <img src={rallyIcon} />


### PR DESCRIPTION
 Adds a "Create Rally Point" tooltip to the rally point button in the map toolbar.