### PR TITLE
bug/task-packet-icon-selection-prevents-waypoint-selection/SW-2292

### DIFF
--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -333,20 +333,14 @@ export default function Map() {
      */
     const handleWaypointClick = (feature: Feature<Geometry>) => {
         if (feature.get("isBypass")) return;
-        const selectedWaypoint = jaiaGlobal.getSelectedWaypoint();
-        if (
-            feature.get("missionID") !== selectedWaypoint.missionID ||
-            feature.get("waypointNum") !== selectedWaypoint.waypointNum
-        ) {
-            jaiaDispatch({
-                type: JaiaActions.CLICKED_WAYPOINT,
-                clickedWaypoint: {
-                    waypointNum: feature.get("waypointNum"),
-                    missionID: feature.get("missionID"),
-                    isMoveable: false,
-                },
-            });
-        }
+        jaiaDispatch({
+            type: JaiaActions.CLICKED_WAYPOINT,
+            clickedWaypoint: {
+                waypointNum: feature.get("waypointNum"),
+                missionID: feature.get("missionID"),
+                isMoveable: false,
+            },
+        });
     };
 
     /**

--- a/src/web/context/handlers/selection-handlers.ts
+++ b/src/web/context/handlers/selection-handlers.ts
@@ -134,6 +134,7 @@ function handleClickedFeature() {
     missionLayer.updateFeatures();
     diveLayer.updateFeatures();
     driftLayer.updateFeatures();
+    excludedTaskPacketsLayer.updateFeatures();
 }
 
 /**

--- a/src/web/context/handlers/selection-handlers.ts
+++ b/src/web/context/handlers/selection-handlers.ts
@@ -124,6 +124,19 @@ export function handleClickedButton(mutableState: JaiaContextType, action: JaiaA
 }
 
 /**
+ * Carries out resets and updates that need to occur on map feature clicks
+ *
+ * @returns {void}
+ */
+function handleClickedFeature() {
+    jaiaGlobal.resetSelectedWaypoint();
+    jaiaGlobal.resetSelectedTaskPacket();
+    missionLayer.updateFeatures();
+    diveLayer.updateFeatures();
+    driftLayer.updateFeatures();
+}
+
+/**
  * Opens panel for the selected waypoint
  *
  * @param {JaiaContextType} mutableState State object ref for making modifications
@@ -131,16 +144,9 @@ export function handleClickedButton(mutableState: JaiaContextType, action: JaiaA
  * @returns {JaiaContextType} Updated mutable state object
  */
 export function handleClickedWaypoint(mutableState: JaiaContextType, action: JaiaAction) {
-    if (!missionSet.getMission(action.clickedWaypoint.missionID)) {
-        jaiaGlobal.resetSelectedWaypoint();
-        if (mutableState.visiblePanel === ButtonNames.WAYPOINT_PANEL) {
-            mutableState.visiblePanel = ButtonNames.NONE;
-        }
-    } else {
-        jaiaGlobal.setSelectedWaypoint(action.clickedWaypoint);
-        mutableState.visiblePanel = ButtonNames.WAYPOINT_PANEL;
-    }
-    missionLayer.updateFeatures();
+    handleClickedFeature();
+    jaiaGlobal.setSelectedWaypoint(action.clickedWaypoint);
+    mutableState.visiblePanel = ButtonNames.WAYPOINT_PANEL;
     return mutableState;
 }
 
@@ -172,6 +178,7 @@ export function handleClickedEditMission(mutableState: JaiaContextType, action: 
  * @returns {JaiaContextType} Updated mutable state object
  */
 export function handleClickedRallyPoint(mutableState: JaiaContextType, action: JaiaAction) {
+    handleClickedFeature();
     rallyPoints.setSelectedRallyPointID(action.rallyID);
     mutableState.visiblePanel = ButtonNames.RALLY_PANEL;
     return mutableState;
@@ -184,6 +191,7 @@ export function handleClickedRallyPoint(mutableState: JaiaContextType, action: J
  * @returns {JaiaContextType} Updated mutable state object
  */
 export function handleClickedTaskPacket(mutableState: JaiaContextType, action: JaiaAction) {
+    handleClickedFeature();
     const selectedTaskPacket = jaiaGlobal.getSelectedTaskPacket();
 
     if (

--- a/src/web/data/tasks/task.ts
+++ b/src/web/data/tasks/task.ts
@@ -135,8 +135,13 @@ export default class Task {
     }
 
     private updateDefaultTaskParameters() {
+        let diveParams = { ...this.diveParameters };
+        // Do not update default dive parameters if we have a bottom dive
+        if (diveParams.max_depth === TASK_MAX_DEPTH_CONSTRAINT) {
+            diveParams = jaiaGlobal.getDefaultTaskParameters().dive;
+        }
         jaiaGlobal.setDefaultTaskParameters({
-            dive: this.diveParameters,
+            dive: diveParams,
             drift: this.driftParameters,
             constantHeading: this.constantHeadingParameters,
             stationKeep: this.stationKeepParameters,


### PR DESCRIPTION
### Summary
There was a bug with the cleanup from selecting different map features. For example, if I selected a waypoint, then a task packet, I could not open the waypoint panel (until clicking another button) because the reset of selected waypoint was not being applied between feature clicks. This pull request creates a general function `handleFeatureClick` to apply those resets and updates prior to handling the specifics of the feature click.

### Testing
Tested in simulation by switching between the various map features (waypoints, dive packets, drift packets, rally points) and seeing the correct updates take place.

### Bonus
When planning survey missions that included bottom dives and a surface drift, the defaults for dive parameters would be set to the maximums which is not the desired behavior because it involves more editing for the operator. This pull request fixes that problem by detecting the max and using the previous defaults.