### PR TITLE
task/jcc-add-warning-popup-entering-overdrive-rc

### DIFF
--- a/src/web/components/RemoteControlPanel/OverdriveWarning/OverdriveWarningDialog.tsx
+++ b/src/web/components/RemoteControlPanel/OverdriveWarning/OverdriveWarningDialog.tsx
@@ -1,4 +1,4 @@
-import { DialogActions } from "../../types/context-types";
+import { DialogActions } from "../../../types/context-types";
 
 interface DialogProps {
     isVisible: boolean;
@@ -18,10 +18,7 @@ export function OverdriveWarningDialog(props: DialogProps) {
             <div className="blocking-overlay" onClick={() => {}}>
                 <div className="jaia-dialog alert">
                     <h1>Warning</h1>
-                    <p className="dialog-warn">
-                        Enabling Overdrive may introduce risk to the bot. Manual control will be
-                        harder.
-                    </p>
+                    <p>Overdrive offers more speed, but it can make control more difficult.</p>
                     <div className="dialog-button-row">
                         <button
                             className="dialog-button"

--- a/src/web/components/RemoteControlPanel/OverdriveWarningDialog.tsx
+++ b/src/web/components/RemoteControlPanel/OverdriveWarningDialog.tsx
@@ -1,0 +1,43 @@
+import { DialogActions } from "../../types/context-types";
+
+interface DialogProps {
+    isVisible: boolean;
+    onClose: (dialogAction: DialogActions) => void;
+}
+
+/**
+ * Produces the warning dialog that appears when enabling Overdrive in remote control mode.
+ */
+export function OverdriveWarningDialog(props: DialogProps) {
+    if (!props.isVisible) {
+        return <div></div>;
+    }
+
+    return (
+        <div className="jaia-dialog-container">
+            <div className="blocking-overlay" onClick={() => {}}>
+                <div className="jaia-dialog alert">
+                    <h1>Warning</h1>
+                    <p className="dialog-warn">
+                        Enabling Overdrive may introduce risk to the bot. Manual control will be
+                        harder.
+                    </p>
+                    <div className="dialog-button-row">
+                        <button
+                            className="dialog-button"
+                            onClick={() => props.onClose(DialogActions.NONE)}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            className="dialog-button"
+                            onClick={() => props.onClose(DialogActions.CONFIRMED)}
+                        >
+                            Enable Overdrive
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
+++ b/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
@@ -9,6 +9,7 @@ import { AnalogStick, AnalogStickTypes } from "./AnalogStick/AnalogStick";
 import { SelectMenu, ControlTypes } from "./SelectMenu/SelectMenu";
 import { Dashboard } from "./Dashboard/Dashboard";
 import { DiveCommand, DiveInputs, RCDiveParameters } from "./DiveControls/DiveControls";
+import { OverdriveWarningDialog } from "./OverdriveWarningDialog";
 
 import {
     CommandType,
@@ -19,6 +20,7 @@ import {
 } from "../../types/protobuf-types";
 import { sendBotCommand, sendEngineeringCommand } from "../../utils/commands";
 import { error, success } from "../../utils/notifications";
+import { DialogActions } from "../../types/context-types";
 import { SelectChangeEvent } from "@mui/material";
 
 import "./RemoteControlPanel.less";
@@ -66,6 +68,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
         ...defaultParams.drift,
     });
     const [rcOverdrive, setRCOverdrive] = useState(false);
+    const [isOverdriveDialogVisible, setIsOverdriveDialogVisible] = useState(false);
     const [isMinimizedView, setIsMinimizedView] = useState(false);
 
     // Include useEffect dependencies to prevent interval data from going stale
@@ -159,7 +162,24 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
      * @returns {void}
      */
     const handleOverdriveToggleClick = () => {
-        setRCOverdrive(!rcOverdrive);
+        if (rcOverdrive) {
+            setRCOverdrive(false);
+        } else {
+            setIsOverdriveDialogVisible(true);
+        }
+    };
+
+    /**
+     * Closes the overdrive warning dialog and enables overdrive if confirmed
+     *
+     * @param {DialogActions} dialogAction Indicates which button was clicked
+     * @returns {void}
+     */
+    const onOverdriveDialogClose = (dialogAction: DialogActions) => {
+        setIsOverdriveDialogVisible(false);
+        if (dialogAction === DialogActions.CONFIRMED) {
+            setRCOverdrive(true);
+        }
     };
 
     /**
@@ -282,6 +302,13 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
         </div>
     );
 
+    const overdriveWarningDialog = (
+        <OverdriveWarningDialog
+            isVisible={isOverdriveDialogVisible}
+            onClose={onOverdriveDialogClose}
+        />
+    );
+
     const RCMinimizedView = (
         <div className="remote-control-panel minimized">
             <div className="view-arrow minimized" onClick={() => setIsMinimizedView(false)}>
@@ -303,6 +330,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
             }
             return (
                 <>
+                    {overdriveWarningDialog}
                     {/* Gamepad component listens for Xbox controller input in background */}
                     <Gamepad
                         onAxisChange={(axisName, value) => {
@@ -342,6 +370,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
             }
             return (
                 <>
+                    {overdriveWarningDialog}
                     {/* Gamepad component listens for Xbox controller input in background */}
                     <Gamepad
                         onAxisChange={(axisName, value) => {
@@ -387,6 +416,7 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
             }
             return (
                 <>
+                    {overdriveWarningDialog}
                     {/* Gamepad component listens for Xbox controller input in background */}
                     <Gamepad
                         onAxisChange={(axisName, value) => {

--- a/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
+++ b/src/web/components/RemoteControlPanel/RemoteControlPanel.tsx
@@ -9,7 +9,7 @@ import { AnalogStick, AnalogStickTypes } from "./AnalogStick/AnalogStick";
 import { SelectMenu, ControlTypes } from "./SelectMenu/SelectMenu";
 import { Dashboard } from "./Dashboard/Dashboard";
 import { DiveCommand, DiveInputs, RCDiveParameters } from "./DiveControls/DiveControls";
-import { OverdriveWarningDialog } from "./OverdriveWarningDialog";
+import { OverdriveWarningDialog } from "./OverdriveWarning/OverdriveWarningDialog";
 
 import {
     CommandType,
@@ -416,7 +416,6 @@ export default function RemoteControlPanel(props: RemoteControlPanelProps) {
             }
             return (
                 <>
-                    {overdriveWarningDialog}
                     {/* Gamepad component listens for Xbox controller input in background */}
                     <Gamepad
                         onAxisChange={(axisName, value) => {

--- a/src/web/components/RemoteControlPanel/__tests__/OverdriveWarningDialog.test.tsx
+++ b/src/web/components/RemoteControlPanel/__tests__/OverdriveWarningDialog.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+import { OverdriveWarningDialog } from "../OverdriveWarningDialog";
+import { DialogActions } from "../../../types/context-types";
+
+test("Overdrive warning dialog is hidden when not visible", () => {
+    render(<OverdriveWarningDialog isVisible={false} onClose={jest.fn()} />);
+
+    expect(screen.queryByText("Warning")).not.toBeInTheDocument();
+});
+
+test("Overdrive warning dialog shows warning text and buttons when visible", () => {
+    render(<OverdriveWarningDialog isVisible={true} onClose={jest.fn()} />);
+
+    expect(screen.getByText("Warning")).toBeInTheDocument();
+    expect(
+        screen.getByText(
+            "Enabling Overdrive may introduce risk to the bot. Manual control will be harder.",
+        ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Enable Overdrive" })).toBeInTheDocument();
+});
+
+test("Overdrive warning dialog calls onClose with correct action", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    render(<OverdriveWarningDialog isVisible={true} onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledWith(DialogActions.NONE);
+
+    await user.click(screen.getByRole("button", { name: "Enable Overdrive" }));
+    expect(onClose).toHaveBeenCalledWith(DialogActions.CONFIRMED);
+});

--- a/src/web/components/RemoteControlPanel/__tests__/OverdriveWarningDialog.test.tsx
+++ b/src/web/components/RemoteControlPanel/__tests__/OverdriveWarningDialog.test.tsx
@@ -15,9 +15,7 @@ test("Overdrive warning dialog shows warning text and buttons when visible", () 
 
     expect(screen.getByText("Warning")).toBeInTheDocument();
     expect(
-        screen.getByText(
-            "Enabling Overdrive may introduce risk to the bot. Manual control will be harder.",
-        ),
+        screen.getByText("Overdrive offers more speed, but it can make control more difficult."),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Enable Overdrive" })).toBeInTheDocument();

--- a/src/web/components/RemoteControlPanel/__tests__/OverdriveWarningDialog.test.tsx
+++ b/src/web/components/RemoteControlPanel/__tests__/OverdriveWarningDialog.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 
-import { OverdriveWarningDialog } from "../OverdriveWarningDialog";
+import { OverdriveWarningDialog } from "../OverdriveWarning/OverdriveWarningDialog";
 import { DialogActions } from "../../../types/context-types";
 
 test("Overdrive warning dialog is hidden when not visible", () => {


### PR DESCRIPTION
## Summary
When users are navigating the remote control panel, it’s currently too easy to accidentally toggle into Overdrive mode. To prevent accidental speed boosts or hardware strain, this PR introduces a quick confirmation step. Now, clicking the Overdrive toggle drops down a clear warning dialog outlining the risks, requiring an explicit confirmation before the mode actually switches on.

## Changes
### UI & State Management

- `OverdriveWarningDialog.tsx`: Built a clean, reusable modal dialog that spells out the operational risks of enabling Overdrive, featuring straightforward "Cancel" and "Enable Overdrive" actions.
- `RemoteControlPanel.tsx`:
  - Added an `isOverdriveDialogVisible` state hook to track whether the warning modal is open.
  - Interrupted `handleOverdriveToggleClick()` so it no longer triggers the mode immediately; it now surfaces the warning dialog first.
  - Implemented `onOverdriveDialogClose()` to catch the user's decision, safely activating Overdrive only if they explicitly confirm it.

## Testing & Validation

- `OverdriveWarningDialog.test.tsx`: Added comprehensive unit tests ensuring that:
  - The dialog stays hidden until it's supposed to show up.
  - The copy and action buttons render exactly as expected.
  - Clicking "Cancel" or "Enable" fires off the correct lifecycle callbacks.
- Manual Verification: Verified inside the simulator that the workflow feels smooth across all control panel view modes, ensuring that clicking "Cancel" completely aborts the state change and clicking "Enable" seamlessly kicks the system into Overdrive.