### PR TITLE
task/change-exclusion-zone-buffer-to-10-meters

### DIFF
--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -494,7 +494,11 @@ export default function Map() {
             // lat/lon values match those produced by detectMissionReroutes,
             // which also uses the first clean waypoint as origin.
             const firstCleanLoc = waypoints.filter((wp) => !wp.getIsBypass())[0]?.getLocation();
-            const result = routeAroundExclusionZones(miniPlan, 5, firstCleanLoc ?? fromLocation);
+            const result = routeAroundExclusionZones(
+                miniPlan,
+                undefined,
+                firstCleanLoc ?? fromLocation,
+            );
             const locations = result.plan.goal.slice(1).map((g) => g.location!);
 
             // Let the normal waypoint-add handler reject impossible or over-limit

--- a/src/web/components/Map/Map.tsx
+++ b/src/web/components/Map/Map.tsx
@@ -32,6 +32,7 @@ import { gridPlan, GridPlanningStates } from "../../data/survey_planner/grid-pla
 import {
     routeAroundExclusionZones,
     isLocationBlockedByZone,
+    DEFAULT_SAFETY_MARGIN_METERS,
 } from "../../data/exclusion_zones/exclusion-zone-router";
 
 import ZoneCrossingDialog from "../ZoneCrossingDialog/ZoneCrossingDialog";
@@ -496,7 +497,7 @@ export default function Map() {
             const firstCleanLoc = waypoints.filter((wp) => !wp.getIsBypass())[0]?.getLocation();
             const result = routeAroundExclusionZones(
                 miniPlan,
-                undefined,
+                DEFAULT_SAFETY_MARGIN_METERS,
                 firstCleanLoc ?? fromLocation,
             );
             const locations = result.plan.goal.slice(1).map((g) => g.location!);

--- a/src/web/data/exclusion_zones/exclusion-zone-router.ts
+++ b/src/web/data/exclusion_zones/exclusion-zone-router.ts
@@ -220,7 +220,8 @@ interface ZoneGeom {
 // ── A* grid pathfinding ────────────────────────────────────────────────────────
 
 const GRID_CELL_SIZE = 5; // metres per grid cell
-const DEFAULT_SAFETY_MARGIN_METERS = 5;
+/** Matches hibernation_radius in config/templates/bot/bot.bhv.in */
+export const DEFAULT_SAFETY_MARGIN_METERS = 10;
 const MIN_BYPASS_SPACING = GRID_CELL_SIZE * 1.5;
 const BACKTRACK_TOLERANCE = GRID_CELL_SIZE * 1.5;
 


### PR DESCRIPTION
This pull request updates the default safety margin for exclusion zone routing from 5 meters to 10 meters. The goal is to ensure that the safety margin used in pathfinding matches the value defined in the bot configuration. 

**Exclusion zone routing improvements:**

* Increased the `DEFAULT_SAFETY_MARGIN_METERS` from 5 to 10 in `exclusion-zone-router.ts` to match the `hibernation_radius` setting in the bot configuration.

**Code consistency and usage:**

* Updated the call to `routeAroundExclusionZones` in `Map.tsx` to use `undefined` for the safety margin argument so that the new default value is applied.

**Testing:**
* Verified in the simulator. 