### PR TITLE
feature/hub-details-add-health-information/SW-2462

### DIFF
--- a/src/web/components/HubDetails/HubDetails.tsx
+++ b/src/web/components/HubDetails/HubDetails.tsx
@@ -4,6 +4,7 @@ import { JaiaActions } from "../../context/jaia-actions";
 import { JaiaContext, JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaAction } from "../../types/context-types";
 import SystemButton from "../../components/__buttons__/SystemButton/SystemButton";
+import HealthRow from "../BotDetails/HealthRow/HealthRow";
 
 // Utilities
 import {
@@ -248,6 +249,26 @@ export default function HubDetails() {
                             <SystemButton node={hub} type={SystemButtonTypes.SHUTDOWN} />
                             <SystemButton node={hub} type={SystemButtonTypes.REBOOT} />
                             <SystemButton node={hub} type={SystemButtonTypes.RESTART_SERVICES} />
+                        </AccordionDetails>
+                    </Accordion>
+                </ThemeProvider>
+
+                <ThemeProvider theme={accordionTheme}>
+                    <Accordion
+                        expanded={jaiaContext.hubAccordionStates.health}
+                        onChange={() => {
+                            handleAccordionClick(HubAccordionNames.HEALTH);
+                        }}
+                        className="accordion-container"
+                    >
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            className="accordion-summary"
+                        >
+                            <Typography>Health</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <HealthRow />
                         </AccordionDetails>
                     </Accordion>
                 </ThemeProvider>

--- a/src/web/context/handlers/data-model-handers.ts
+++ b/src/web/context/handlers/data-model-handers.ts
@@ -22,6 +22,7 @@ import { syncOpenLayers } from "./handler-utils";
 const defaultHubAccordionStates: HubAccordionStates = {
     quickLook: false,
     commands: false,
+    health: false,
     links: false,
 };
 

--- a/src/web/types/context-types.ts
+++ b/src/web/types/context-types.ts
@@ -124,12 +124,14 @@ export interface JaiaAction {
 export const enum HubAccordionNames {
     QUICKLOOK = "quickLook",
     COMMANDS = "commands",
+    HEALTH = "health",
     LINKS = "links",
 }
 
 export interface HubAccordionStates {
     quickLook: boolean;
     commands: boolean;
+    health: boolean;
     links: boolean;
 }
 


### PR DESCRIPTION
### Summary
This pull request adds the health accordion to the Hub details panel. It re-uses the code from the Bot details panel.

### Testing
1. No health errors or warnings
<img width="767" height="576" alt="image" src="https://github.com/user-attachments/assets/fe1d543c-351e-4442-9e5f-b9a0d823b0be" />

2. Health failed due to version mismatch
<img width="770" height="576" alt="image" src="https://github.com/user-attachments/assets/1ae1ce2b-4562-44ad-a78e-c3559316b67c" />
