### PR TITLE
task/use-vin-instead-of-bot-and-fleet-number-for-bot-db/SW-2467

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -16,6 +16,7 @@ jaia_imu_type='bno055'
 jaia_arduino_type='spi'
 jaia_pam_connection_type='none'
 jaia_tail_serial_number = os.environ.get('jaia_tail_serial_number', default='unknown_serial_number')
+jaia_bot_vin = os.environ.get('jaia_bot_vin', default='unknown_vin')
 
 if "jaia_electronics_stack" in os.environ:
     jaia_electronics_stack=os.environ['jaia_electronics_stack']
@@ -284,7 +285,8 @@ elif common.app == 'jaiabot_health':
                                      ignore_powerstate_changes=ignore_powerstate_changes,
                                      is_in_sim=is_simulation(),
                                      motor_harness_type=jaia_motor_harness_type,
-                                     jaia_tail_serial_number=jaia_tail_serial_number))
+                                     jaia_tail_serial_number=jaia_tail_serial_number,
+                                     jaia_bot_vin=jaia_bot_vin))
 elif common.app == 'goby_logger':    
     print(config.template_substitute(templates_dir+'/goby_logger.pb.cfg.in',
                                      app_block=app_common,

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -59,7 +59,7 @@ parser.add_argument('--imu_install_type', choices=['embedded', 'retrofit', 'none
 parser.add_argument('--arduino_type', choices=['spi', 'usb', 'none'], help='If set, configure services for arduino type')
 parser.add_argument('--pam_connection_type', choices=['uart', 'usb', 'none'], help='If set, configure services for PAM connection type')
 parser.add_argument('--bot_type', choices=['hydro', 'echo', 'bio', 'none'], help='If set, configure services for bot type')
-parser.add_argument('--bot_vin', default='', help='If set, configure services for bot vin')
+parser.add_argument('--bot_vin', default='unknown_vin', help='If set, configure services for bot vin (defaults to "unknown_vin")')
 parser.add_argument('--data_offload_ignore_type', choices=['goby', 'taskpacket', 'none'], help='If set, configure services for arduino type')
 parser.add_argument('--motor_harness_type', choices=['rpm_and_thermistor', 'none'], help='If set, configure services for motor harness type')
 parser.add_argument('--temperature_sensor_type', choices=['bar02', 'bar30', 'tsys01', 'none'], help='If set, configure services for temperature sensor')

--- a/config/templates/bot/jaiabot_health.pb.cfg.in
+++ b/config/templates/bot/jaiabot_health.pb.cfg.in
@@ -32,7 +32,7 @@ linux_hw {
 
 motor {
     motor_harness_type: $motor_harness_type
-    vehicle_db_path: "/var/log/jaiabot/db/vehicle_bot${bot_id}_fleet${fleet_id}.db"
+    vehicle_db_path: "/var/log/jaiabot/db/bot_vin_${jaia_bot_vin}.db"
     tail_serial_number: "${jaia_tail_serial_number}"
 }
 

--- a/debian/jaiabot-embedded.templates
+++ b/debian/jaiabot-embedded.templates
@@ -5,7 +5,7 @@ Description: Choose a common option to edit
 
 Template: jaiabot-embedded/debconf_state_bot
 Type: select
-Choices: BACK, bot_id, bot_vin, arduino_type, pam_connection_type, imu_type, bot_type, data_offload_ignore_type, imu_install_type, temperature_sensor_type, pressure_sensor_type, motor_harness_type, camera_positions, additional_sensors, EXIT
+Choices: BACK, bot_id, bot_vin, arduino_type, tail_serial_number, pam_connection_type, imu_type, bot_type, data_offload_ignore_type, imu_install_type, temperature_sensor_type, pressure_sensor_type, motor_harness_type, camera_positions, additional_sensors, EXIT
 Description: Choose a bot option to edit
 
 Template: jaiabot-embedded/debconf_state_hub

--- a/src/bin/health/config.proto
+++ b/src/bin/health/config.proto
@@ -84,6 +84,7 @@ message MotorStatusConfig
 
     optional string vehicle_db_path = 50 [default = "/var/log/jaiabot/db/vehicle.db"];
     optional string tail_serial_number = 51 [default = "unknown_serial_number"];
+    optional string bot_vin = 52 [default = "unknown_vin"];
 }
 
 message ArduinoRecoveryConfig

--- a/src/bin/health/motor_thread.cpp
+++ b/src/bin/health/motor_thread.cpp
@@ -323,6 +323,7 @@ void jaiabot::apps::MotorStatusThread::update_total_motor_usage()
     next_motor_usage_report_time_ = goby::time::SteadyClock::now() + MOTOR_USAGE_REPORT_INTERVAL;
 
     jaiabot::protobuf::MotorUsageReport usage_report;
+    usage_report.set_bot_vin(cfg().bot_vin());
     usage_report.set_tail_serial_number(cfg().tail_serial_number());
     double total_running_time_seconds = 0;
     for (const auto& bin : motor_usage_cache_)

--- a/src/lib/messages/motor.proto
+++ b/src/lib/messages/motor.proto
@@ -34,7 +34,8 @@ message Motor
 
 message MotorUsageReport
 {
-    optional string tail_serial_number = 1;
-    optional double total_running_time_seconds = 2; 
-    repeated MotorUsageBin motor_usage_bins = 3;
+    optional string bot_vin = 1;
+    optional string tail_serial_number = 2;
+    optional double total_running_time_seconds = 3; 
+    repeated MotorUsageBin motor_usage_bins = 4;
 }


### PR DESCRIPTION
## Description

Added bot vin to the motor usage output and we are now using it to name the sql db file.

## Test

* Start simulation (1 bot (unknown vin is the default))
* Review liaison and ensure in the motor usage report group the vin number is present (unknown vin)
* Check /var/log/jaiabot/db for bot_vin_unknown_vin.db

Needs testing on actual bot.