### PR TITLE
bug/move-tail-serial-number-config-to-bot-only-block

### DIFF
--- a/debian/jaiabot-embedded.postinst
+++ b/debian/jaiabot-embedded.postinst
@@ -15,6 +15,8 @@ if [ "$JAIA_TYPE" = "bot" ]; then
     BOT_OR_HUB_FINAL_OCTET=$((BOT_OR_HUB_INDEX + 100))
     db_get jaiabot-embedded/bot_vin
     JAIA_BOT_VIN=$RET
+    db_get jaiabot-embedded/tail_serial_number
+    JAIA_TAIL_SERIAL_NUMBER=$RET
     if [ "$JAIA_BOT_TYPE" = "none" ]; then
         JAIA_BOT_TYPE="hydro"
         db_set jaiabot-embedded/bot_type "hydro"
@@ -142,9 +144,6 @@ JAIA_DCCL_ENCRYPTION_PASSWORD=$RET
 
 db_get jaiabot-embedded/additional_sensors
 JAIA_ADDITIONAL_SENSORS="$(echo $RET | sed 's/,/ /g')"
-
-db_get jaiabot-embedded/tail_serial_number
-JAIA_TAIL_SERIAL_NUMBER=$RET
 
 /usr/share/jaiabot/config/gen/systemd.py ${JAIA_TYPE} \
                                          --enable \


### PR DESCRIPTION
### Problem
This is the error message we received while installing the last continuous code on a Hub.

<img width="2842" height="1513" alt="image" src="https://github.com/user-attachments/assets/0aedafc9-67fc-4f81-8e7a-02f8d9f4b0a5" />

### Solution
The get call is only made on a Bot (which has a tail serial number). When making the get call on the Hub without establishing a tail serial number it appears to provide an array of sorts since systemd.py thinks it is receiving multiple arguments for `--tail_serial_number`
