### PR TITLE
bug/deb-config-hub-accordion

### DIFF
--- a/debian/jaiabot-embedded.postinst
+++ b/debian/jaiabot-embedded.postinst
@@ -175,7 +175,7 @@ JAIA_ADDITIONAL_SENSORS="$(echo $RET | sed 's/,/ /g')"
                                          --camera_positions ${JAIA_CAMERA_POSITIONS} \
                                          --dccl_encryption_password=${JAIA_DCCL_ENCRYPTION_PASSWORD} \
                                          --additional_sensors ${JAIA_ADDITIONAL_SENSORS} \
-                                         --tail_serial_number ${JAIA_TAIL_SERIAL_NUMBER}
+                                         --tail_serial_number=${JAIA_TAIL_SERIAL_NUMBER}
 
 echo "<<<<< Installing and enabling systemd services complete!"
 

--- a/src/web/context/handlers/accordion-handlers.ts
+++ b/src/web/context/handlers/accordion-handlers.ts
@@ -24,6 +24,9 @@ export function handleClickedHubAccordion(mutableState: JaiaContextType, action:
         case HubAccordionNames.COMMANDS:
             hubAccordionStates.commands = !hubAccordionStates.commands;
             break;
+        case HubAccordionNames.HEALTH:
+            hubAccordionStates.health = !hubAccordionStates.health;
+            break;
         case HubAccordionNames.LINKS:
             hubAccordionStates.links = !hubAccordionStates.links;
             break;


### PR DESCRIPTION
### Bug Fixes
1. Add `=` when passing single argument to a `systemd.py` parameter
2. Hub health accordion was missing the trigger to open/close

### Testing
1. Tested on system after initial failure
2. Tested in simulation