### PR TITLE
feature/hub-add-system-time/SW-2454

### DIFF
--- a/src/web/components/HubDetails/HubDetails.tsx
+++ b/src/web/components/HubDetails/HubDetails.tsx
@@ -184,6 +184,10 @@ export default function HubDetails() {
                             <table>
                                 <tbody>
                                     <tr>
+                                        <td>System Time (UTC)</td>
+                                        <td>{hub.getSystemTime()}</td>
+                                    </tr>
+                                    <tr>
                                         <td>Latitude</td>
                                         <td>
                                             {formatLatitude(hub.getHubSensors().getGPS()?.getLat())}

--- a/src/web/data/hubs/hub.ts
+++ b/src/web/data/hubs/hub.ts
@@ -103,6 +103,20 @@ export default class Hub {
         this.statusAge = statusAge;
     }
 
+    getSystemTime() {
+        const date = new Date();
+
+        const options = {
+            timeZone: "UTC",
+            hour12: true,
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+        };
+
+        return date.toLocaleTimeString("en-US", options);
+    }
+
     /**
      * Determines if the hub has lost comms with the client
      *

--- a/src/web/data/hubs/hub.ts
+++ b/src/web/data/hubs/hub.ts
@@ -21,6 +21,7 @@ export default class Hub {
     private linuxHardwareStatus: LinuxHardwareStatus;
     private botOffload: BotOffloadData;
     private statusAge: number;
+    private systemTime: string;
 
     constructor() {
         // Init base sensors
@@ -104,14 +105,22 @@ export default class Hub {
     }
 
     getSystemTime() {
-        const date = new Date();
+        return this.systemTime;
+    }
+
+    setSystemTime(systemTime: number) {
+        this.systemTime = new Date(systemTime / 1000).toUTCString();
+        console.log("toUTCString(): " + this.systemTime);
+
+        const date = new Date(systemTime / 1000);
 
         const options = {
             timeZone: "UTC",
-            hour12: true,
+            hour12: false,
         };
 
-        return date.toLocaleTimeString("en-US", options);
+        this.systemTime = date.toLocaleTimeString("en-US", options);
+        console.log("toLocaleTimeString(): " + this.systemTime);
     }
 
     /**

--- a/src/web/data/hubs/hub.ts
+++ b/src/web/data/hubs/hub.ts
@@ -8,6 +8,7 @@ import {
 } from "../../types/protobuf-types";
 import { NO_COMMS_STATUS_AGE } from "../../utils/constants";
 import { microsecondsToSeconds } from "../../utils/conversions";
+import { timestampToLocaleTimeString } from "../../utils/conversions";
 import HubSensors from "./hub-sensors";
 
 export default class Hub {
@@ -109,14 +110,7 @@ export default class Hub {
     }
 
     setSystemTime(systemTime: number) {
-        const date = new Date(systemTime / 1000);
-
-        const options = {
-            timeZone: "UTC",
-            hour12: false,
-        };
-
-        this.systemTime = date.toLocaleTimeString("en-US", options);
+        this.systemTime = timestampToLocaleTimeString(systemTime);
     }
 
     /**

--- a/src/web/data/hubs/hub.ts
+++ b/src/web/data/hubs/hub.ts
@@ -109,9 +109,6 @@ export default class Hub {
     }
 
     setSystemTime(systemTime: number) {
-        this.systemTime = new Date(systemTime / 1000).toUTCString();
-        console.log("toUTCString(): " + this.systemTime);
-
         const date = new Date(systemTime / 1000);
 
         const options = {
@@ -120,7 +117,6 @@ export default class Hub {
         };
 
         this.systemTime = date.toLocaleTimeString("en-US", options);
-        console.log("toLocaleTimeString(): " + this.systemTime);
     }
 
     /**

--- a/src/web/data/hubs/hub.ts
+++ b/src/web/data/hubs/hub.ts
@@ -109,9 +109,6 @@ export default class Hub {
         const options = {
             timeZone: "UTC",
             hour12: true,
-            hour: "numeric",
-            minute: "2-digit",
-            second: "2-digit",
         };
 
         return date.toLocaleTimeString("en-US", options);

--- a/src/web/data/hubs/hubs.ts
+++ b/src/web/data/hubs/hubs.ts
@@ -105,6 +105,10 @@ export class Hubs {
             hub.setBotOffload({ bot_id: UNASSIGNED_ID });
         }
 
+        if (hubStatus.time) {
+            hub.setSystemTime(hubStatus.time);
+        }
+
         // HubSensors
         // GPS
         if (hubStatus.location?.lat) {

--- a/src/web/utils/conversions.ts
+++ b/src/web/utils/conversions.ts
@@ -36,6 +36,24 @@ export function timestampToISOString(tMicroseconds: number) {
 }
 
 /**
+ * Converts a Unix timestamp (microseconds) to an locale time string
+ *
+ * @param {number} tMicroseconds Unix timestamp in microseconds since Unix epoch
+ * @returns {string} Time string in UTC time format
+ */
+export function timestampToLocaleTimeString(tMicroseconds: number) {
+    if (!tMicroseconds) {
+        return "";
+    }
+    const options = {
+        timeZone: "UTC",
+        hour12: false,
+    };
+
+    return new Date(tMicroseconds / 1000).toLocaleTimeString("en-US", options);
+}
+
+/**
  * Return a human-readable data size value (i.e. "10.2 GB" or "356.2 MB")
  *
  * @param {number} bytes Number of bytes.


### PR DESCRIPTION
Added system time (UTC) to hub quick look data using HubStatus time.

Testing:
(On the JCC)
1. Open the Hub interface by selecting the _Hub 1_ button
2. Select _Quick Look_
3. Verify "System Time (UTC)" is present and contains the current time in UTC