### PR TITLE
feature/python-lib-zeromq-connection

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -279,8 +279,6 @@ elif common.app == 'jaiabot_health':
                                      fleet_id=fleet_index,
                                      app_block=app_common,
                                      interprocess_block = interprocess_common,
-                                     bind_port=common.udp.motor_cpp_udp_port(),
-                                     remote_port=common.udp.motor_py_udp_port(bot_index),
                                      # do not power off or restart the simulator computer unless we're a VirtualFleet
                                      ignore_powerstate_changes=ignore_powerstate_changes,
                                      is_in_sim=is_simulation(),
@@ -455,5 +453,4 @@ else:
                                      udp_gateway_port=udp_gateway_port,
                                      imu_type=imu_type,
                                      pressure_sensor_type=pressure_sensor_type,
-                                     log_file_dir=log_file_dir,
-                                     motor_py_udp_port=common.udp.motor_py_udp_port(bot_index)))
+                                     log_file_dir=log_file_dir))

--- a/config/gen/common/udp.py
+++ b/config/gen/common/udp.py
@@ -32,14 +32,6 @@ def udp_gateway_port(node_id):
 def contact_gpsd_port(contact_id):
     return 33000 + contact_id
 
-def motor_cpp_udp_port():
-    return 0
-
-def motor_py_udp_port(bot_id):
-    if is_simulation():
-        return 20005 + bot_id
-    return 20005 
-
 def web_portal_udp_port(hub_id):
     if is_simulation() and common.jaia_sim_type == common.SimType.SINGLE_HOST:
         return 40001 - hub_id

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -652,7 +652,7 @@ if jaia_motor_harness_type.value == 'RPM_AND_THERMISTOR':
         'user': 'root', # must run as root to allow interaction with GPIO pin
         'group': 'root',
         'subdir': 'motor',
-        'args': '',
+        'args': f'--bot_index {args.bot_index} --fleet_index {args.fleet_index}',
         'error_on_fail': 'ERROR__FAILED__PYTHON_JAIABOT_MOTOR_LISTENER',
         'runs_on': [Type.BOT],
         'runs_when': Mode.RUNTIME,

--- a/config/launch/simulation/bot.launch
+++ b/config/launch/simulation/bot.launch
@@ -57,4 +57,4 @@ jaiabot_driver_arduino <(../../gen/bot.py jaiabot_driver_arduino)
 
 # Run rpm.py in simulator mode if we're in the simulator
 # Disabled for now: depends on build/web_dev/python/venv, which requires src/web/run.sh
-[kill=SIGTERM] ../../../build/web_dev/python/venv/bin/python3 ../../../src/python/motor/rpm.py --simulator `../../gen/bot.py rpm.py`
+# [kill=SIGTERM] ../../../build/web_dev/python/venv/bin/python3 ../../../src/python/motor/rpm.py --simulator `../../gen/bot.py rpm.py`

--- a/config/launch/simulation/bot.launch
+++ b/config/launch/simulation/bot.launch
@@ -57,4 +57,4 @@ jaiabot_driver_arduino <(../../gen/bot.py jaiabot_driver_arduino)
 
 # Run rpm.py in simulator mode if we're in the simulator
 # Disabled for now: depends on build/web_dev/python/venv, which requires src/web/run.sh
-# [kill=SIGTERM] ../../../build/web_dev/python/venv/bin/python3 ../../../src/python/motor/rpm.py --simulator `../../gen/bot.py rpm.py`
+[kill=SIGTERM] ../../../build/web_dev/python/venv/bin/python3 ../../../src/python/motor/rpm.py --simulator `../../gen/bot.py rpm.py`

--- a/config/templates/bot/jaiabot_health.pb.cfg.in
+++ b/config/templates/bot/jaiabot_health.pb.cfg.in
@@ -1,12 +1,6 @@
 $app_block
 $interprocess_block
 
-udp_config { 
-    bind_port: $bind_port
-    remote_address: "127.0.0.1"
-    remote_port: $remote_port
-}
-
 auto_restart: false
 auto_restart_timeout: 20
 auto_restart_init_grace_period: 60

--- a/config/templates/bot/rpm.py.pb.cfg.in
+++ b/config/templates/bot/rpm.py.pb.cfg.in
@@ -1,1 +1,1 @@
--p ${motor_py_udp_port}
+--bot_index ${bot_id} --fleet_index ${fleet_id}

--- a/src/bin/health/app.cpp
+++ b/src/bin/health/app.cpp
@@ -336,11 +336,11 @@ jaiabot::apps::Health::Health()
     {
         launch_thread<LinuxHardwareThread>(cfg().linux_hw());
         launch_thread<NTPStatusThread>(cfg().ntp());
-    }
 
-    if (cfg().motor().motor_harness_type() != jaiabot::protobuf::MotorHarnessType::NONE)
-    {
-        launch_thread<MotorStatusThread>(cfg().motor());
+        if (cfg().motor().motor_harness_type() != jaiabot::protobuf::MotorHarnessType::NONE)
+        {
+            launch_thread<MotorStatusThread>(cfg().motor());
+        }
     }
 
     // Only run these on the bot

--- a/src/bin/health/app.cpp
+++ b/src/bin/health/app.cpp
@@ -21,8 +21,6 @@
 // along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <goby/middleware/marshalling/protobuf.h>
-// this space intentionally left blank
-#include <goby/middleware/io/udp_point_to_point.h>
 #include <goby/zeromq/application/multi_thread.h>
 
 #include "config.pb.h"
@@ -105,10 +103,6 @@ jaiabot::apps::Health::Health()
                            cfg().auto_restart_init_grace_period_with_units())),
       process_to_not_responding_error_(create_process_to_not_responding_error_map())
 {
-    using MotorRPMUDPThread =
-        goby::middleware::io::UDPPointToPointThread<jaiabot::groups::motor_udp_in,
-                                                    jaiabot::groups::motor_udp_out>;
-
     glog.is_debug1() && glog << "Health thread started. " << std::endl;
     glog.is_debug1() && glog << cfg().DebugString() << std::endl;
 
@@ -342,12 +336,11 @@ jaiabot::apps::Health::Health()
     {
         launch_thread<LinuxHardwareThread>(cfg().linux_hw());
         launch_thread<NTPStatusThread>(cfg().ntp());
+    }
 
-        if (cfg().motor().motor_harness_type() != jaiabot::protobuf::MotorHarnessType::NONE)
-        {
-            launch_thread<MotorRPMUDPThread>(cfg().udp_config());
-            launch_thread<MotorStatusThread>(cfg().motor());
-        }
+    if (cfg().motor().motor_harness_type() != jaiabot::protobuf::MotorHarnessType::NONE)
+    {
+        launch_thread<MotorStatusThread>(cfg().motor());
     }
 
     // Only run these on the bot

--- a/src/bin/health/config.proto
+++ b/src/bin/health/config.proto
@@ -24,7 +24,6 @@ syntax = "proto2";
 
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "goby/middleware/protobuf/udp_config.proto";
 import "dccl/option_extensions.proto";
 import "jaiabot/messages/motor.proto";
 
@@ -106,7 +105,6 @@ message Health
 
     optional goby.middleware.protobuf.AppConfig app = 1;
     optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
-    optional goby.middleware.protobuf.UDPPointToPointConfig udp_config = 3;
 
     optional bool auto_restart = 10 [default = true];
     optional int32 auto_restart_timeout = 11

--- a/src/bin/health/motor_thread.cpp
+++ b/src/bin/health/motor_thread.cpp
@@ -22,7 +22,6 @@
 
 #include "goby/util/sci.h" // for linear_interpolate
 #include <boost/units/io.hpp>
-#include <goby/middleware/io/udp_point_to_point.h>
 
 #include "jaiabot/messages/arduino.pb.h"
 #include "jaiabot/messages/motor.pb.h"
@@ -50,16 +49,9 @@ jaiabot::apps::MotorStatusThread::MotorStatusThread(const jaiabot::config::Motor
 
     status_.set_motor_harness_type(cfg.motor_harness_type());
 
-    interthread().subscribe<jaiabot::groups::motor_udp_in>(
-        [this](const goby::middleware::protobuf::IOData& data) {
-            jaiabot::protobuf::Motor motor;
-            if (!motor.ParseFromString(data.data()))
-            {
-                glog.is_warn() && glog << "Couldn't deserialize Motor message from UDP packet"
-                                       << std::endl;
-                return;
-            }
-            glog.is_debug2() && glog << "Publishing Motor message: " << motor.ShortDebugString()
+    interprocess().subscribe<jaiabot::groups::motor_rpm>(
+        [this](const jaiabot::protobuf::Motor& motor) {
+            glog.is_debug2() && glog << "Received Motor message: " << motor.ShortDebugString()
                                      << std::endl;
 
             rpm_value_ = motor.rpm();
@@ -109,20 +101,10 @@ jaiabot::apps::MotorStatusThread::MotorStatusThread(const jaiabot::config::Motor
 
 void jaiabot::apps::MotorStatusThread::issue_status_summary()
 {
-    send_rpm_query();
     update_total_motor_usage();
     glog.is_debug2() && glog << group(thread_name()) << "Status: " << status_.DebugString()
                              << std::endl;
     interprocess().publish<jaiabot::groups::motor_status>(status_);
-}
-
-void jaiabot::apps::MotorStatusThread::send_rpm_query()
-{
-    glog.is_debug2() && glog << group(thread_name()) << "Sending RPM Query: " << std::endl;
-    // send an empty packet to provide the python driver with a return address
-    auto io_data = std::make_shared<goby::middleware::protobuf::IOData>();
-    io_data->set_data("hello\n");
-    interthread().publish<jaiabot::groups::motor_udp_out>(io_data);
 }
 
 void jaiabot::apps::MotorStatusThread::health(goby::middleware::protobuf::ThreadHealth& health)

--- a/src/bin/health/system_thread.h
+++ b/src/bin/health/system_thread.h
@@ -126,7 +126,6 @@ class MotorStatusThread : public HealthMonitorThread<jaiabot::config::MotorStatu
   private:
     void issue_status_summary() override;
     void health(goby::middleware::protobuf::ThreadHealth& health) override;
-    void send_rpm_query();
 
   private:
     jaiabot::protobuf::Motor status_;

--- a/src/lib/groups.h
+++ b/src/lib/groups.h
@@ -86,8 +86,7 @@ constexpr goby::middleware::Group linux_hardware_status{"jaiabot::linux_hardware
 constexpr goby::middleware::Group time_status{"jaiabot::time_status"};
 constexpr goby::middleware::Group systemd_report{"jaiabot::systemd_report"};
 constexpr goby::middleware::Group systemd_report_ack{"jaiabot::systemd_report_ack"};
-constexpr goby::middleware::Group motor_udp_in{"motor_udp_in"};
-constexpr goby::middleware::Group motor_udp_out{"motor_udp_out"};
+constexpr goby::middleware::Group motor_rpm{"jaiabot::motor_rpm"};
 constexpr goby::middleware::Group motor_status{"jaiabot::motor_status"};
 constexpr goby::middleware::Group motor_usage_report{"jaiabot::motor_usage_report"};
 

--- a/src/python/motor/rpm.py
+++ b/src/python/motor/rpm.py
@@ -54,9 +54,9 @@ def calculate_rpm():
     start_interval = time.time()
 
     while True:
-        now = time.time()
         # blocks here until falling_event.set() is called
         falling_event.wait()
+        now = time.time()
         # reset the flag for the next event
         falling_event.clear()
 

--- a/src/python/motor/rpm.py
+++ b/src/python/motor/rpm.py
@@ -2,38 +2,40 @@
 
 import argparse
 import math
-import socket
-from threading import Thread
+import time
+from threading import Event, Thread
+
 from jaiabot.messages.motor_pb2 import Motor
+from pyjaia.pygoby import InterProcessClient
+
+MOTOR_RPM_GROUP = 'jaiabot::motor_rpm'
+PUBLISH_INTERVAL_SECONDS = 0.2
 
 
 class Args:
     simulator: bool
-    port: int
+    bot_index: int
+    fleet_index: int
 
 
-parser = argparse.ArgumentParser(description='Read RPM from motor and publish it over UDP')
+parser = argparse.ArgumentParser(description='Read RPM from motor and publish it to gobyd')
 parser.add_argument('-s', '--simulator', dest='simulator', action='store_true', help='Run in simulator mode (no GPIO access)')
-parser.add_argument('-p', '--port', dest='port', type=int, default=20005, help='Port to access motor readings')
+parser.add_argument('--bot_index', dest='bot_index', type=int, default=1, help='Bot index (matches jaia_bot_index)')
+parser.add_argument('--fleet_index', dest='fleet_index', type=int, default=0, help='Fleet index (matches jaia_fleet_index)')
 args: Args = parser.parse_args()
+
+platform = f'bot{args.bot_index}_fleet{args.fleet_index}'
 
 
 if not args.simulator:
     from gpiozero import Button
 
 
-import time
-from threading import Event
-
 # RPM Calculation Overview:
 # 2 falling edges = 1 full revolution.
 # RPM is calculated every 0.2 seconds based on edge count.
 RPM_PIN = 27
 REVOLUTION_CONSTANT = 2.0
-
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-sock.bind(('', args.port))
-buffer_size = 1024
 
 rpm = 0
 
@@ -60,8 +62,8 @@ def calculate_rpm():
 
         state_change_count += 1
 
-        if (now - start_interval >= 0.2):
-            rps = (state_change_count / REVOLUTION_CONSTANT) / 0.2
+        if (now - start_interval >= PUBLISH_INTERVAL_SECONDS):
+            rps = (state_change_count / REVOLUTION_CONSTANT) / PUBLISH_INTERVAL_SECONDS
             rpm = rps * 60
             start_interval = now
             state_change_count = 0
@@ -71,29 +73,31 @@ def simulate_rpm():
     global rpm
     while True:
         rpm = 3.14159 + math.sin(time.time())  # Just simulate some changing RPM value for testing purposes
-        time.sleep(0.2)
+        time.sleep(PUBLISH_INTERVAL_SECONDS)
 
 
-def query_rpm():
+def publish_rpm(client: InterProcessClient):
+    # Publish on a steady timer (rather than only when rpm changes) so a
+    # stalled/stopped motor still reports in and doesn't trip jaiabot_health's
+    # RPM listener timeout.
     while True:
-
         motor_data = Motor()
         motor_data.rpm = rpm
-        try:
-            data, addr = sock.recvfrom(buffer_size)
-            sock.sendto(motor_data.SerializeToString(), addr)
-        except Exception as e:
-            print(e)
+        client.publish(MOTOR_RPM_GROUP, motor_data)
+        time.sleep(PUBLISH_INTERVAL_SECONDS)
+
 
 def main():
-    port_thread = Thread(target=query_rpm, name="port_thread", daemon=True)
-    port_thread.start()
+    client = InterProcessClient(platform=platform, client_name='rpm.py')
+
+    publish_thread = Thread(target=publish_rpm, args=(client,), name="publish_thread", daemon=True)
+    publish_thread.start()
 
     if args.simulator:
         simulate_rpm()
     else:
         calculate_rpm()
 
-    port_thread.join()
+    publish_thread.join()
 
 main()

--- a/src/python/pyjaia/examples/pygoby_example.py
+++ b/src/python/pyjaia/examples/pygoby_example.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Example: structuring a pygoby app the same way a real goby C++ app is
+structured (compare to jaiabot_mission_manager.cpp) -- several interprocess
+subscriptions serviced together, plus a loop() running at its own frequency
+that does periodic work and publishes when it has something to say. The goal
+is that switching between C++ goby development and Python pygoby development
+feels familiar.
+
+pygoby itself does not spawn any threads -- publish()/subscribe()/spin() are
+plain method calls, and it's up to the application to decide how (or whether)
+to run them concurrently. Here:
+
+  - One thread owns the SUB socket and services *all* subscriptions from a
+    single spin() loop -- the Python analogue of how one goby C++ thread
+    class services every interprocess().subscribe() it registers from its
+    own poller loop. jaiabot_mission_manager.cpp feeds pressure_adjusted and
+    salinity into its state machine; here we just cache the latest of each
+    (mirroring jaiabot_fusion.cpp's own last_pressure_adjusted_data_-style
+    caching) and publish a quick echo of each one back out.
+  - The main thread is loop() -- ticking at a fixed, developer-set frequency,
+    doing whatever periodic work is needed (here: reporting the latest cached
+    values), and publishing on that same cadence rather than on an always-on
+    separate timer.
+
+ZMQ sockets aren't thread-safe to share: the SUB socket is only ever touched
+from the subscribe thread. The PUB socket, however, is used from *both* the
+subscribe thread's callbacks (to echo what they received) and loop() in the
+main thread -- so instead of calling client.publish() directly, everything
+here goes through the module-level publish() wrapper below, which holds
+publish_lock for the duration of the call. This locking is deliberately kept
+in the example, not pushed into pygoby.py itself: the library exposes plain,
+non-thread-safe sockets, and it's up to the application to add its own
+synchronization if it chooses to share one across threads.
+
+Run against a live bot's gobyd, e.g.:
+
+    python3 pygoby_example.py --platform bot1_fleet0
+"""
+import argparse
+import logging
+import threading
+import time
+
+from threading import Thread
+from typing import Optional
+
+from google.protobuf.message import Message
+
+from jaiabot.messages.motor_pb2 import Motor
+from jaiabot.messages.sensor.pressure_temperature_pb2 import PressureAdjustedData
+from jaiabot.messages.sensor.salinity_pb2 import SalinityData
+from pyjaia.pygoby import InterProcessClient
+
+PRESSURE_ADJUSTED_GROUP = 'jaiabot::pressure_adjusted'
+SALINITY_GROUP = 'jaiabot::salinity'
+EXAMPLE_GROUP = 'pyjaia::example'
+EXAMPLE_GROUP_2 = 'pyjaia::example_2'
+LOOP_FREQUENCY_HZ = 0.5  # developer-set, same idea as ApplicationBase(loop_frequency) in C++
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('-p', '--platform', default='bot1_fleet0',
+                     help='gobyd platform name to connect to (default: bot1_fleet0)')
+args = parser.parse_args()
+
+logging.basicConfig(format='%(asctime)s %(levelname)10s %(message)s', level=logging.INFO)
+log = logging.getLogger('pygoby_example')
+
+# publish() is called from both the subscribe thread's callbacks and loop()
+# in the main thread, so every call goes through this wrapper, which holds
+# the lock for the duration of the underlying client.publish() call.
+publish_lock = threading.Lock()
+
+
+def publish(group: str, message: Message):
+    with publish_lock:
+        client.publish(group, message)
+
+# Written by the subscribe thread's callbacks, read by loop() in the main
+# thread. Safe without a lock: each write rebinds the name to a brand-new
+# message object rather than mutating one in place, so loop() always sees
+# either the previous complete object or the new one, never a half-written one.
+latest_pressure_adjusted_data: Optional[PressureAdjustedData] = None
+latest_salinity_data: Optional[SalinityData] = None
+
+
+def on_pressure_adjusted(pa: PressureAdjustedData):
+    # jaiabot_mission_manager.cpp instead feeds this into its state machine
+    # (EvMeasurement.sensor_depth); here we cache it for loop() to report and
+    # echo it straight back out as a demonstration of publishing from a
+    # subscribe callback.
+    global latest_pressure_adjusted_data
+    latest_pressure_adjusted_data = pa
+
+    publish(EXAMPLE_GROUP, pa)
+
+
+def on_salinity(sal: SalinityData):
+    # jaiabot_mission_manager.cpp instead feeds this into its state machine
+    # (EvMeasurement.salinity/conductivity); here we cache it for loop() to
+    # report and echo it back out on its own example group.
+    if sal.HasField('salinity'):
+        global latest_salinity_data
+        latest_salinity_data = sal
+
+        publish(EXAMPLE_GROUP_2, sal)
+
+
+def subscribe_thread(client: InterProcessClient):
+    client.subscribe(PRESSURE_ADJUSTED_GROUP, PressureAdjustedData, on_pressure_adjusted)
+    client.subscribe(SALINITY_GROUP, SalinityData, on_salinity)
+    while True:
+        # No other work happens on this thread, so there's nothing for a
+        # bounded timeout to unblock -- spin() reacts to a message just as
+        # fast with the default timeout as with any other value.
+        client.spin()
+
+
+def loop(client: InterProcessClient):
+    """The main thread's periodic action -- the Python analogue of a goby C++
+    thread class's loop() override. Runs at LOOP_FREQUENCY_HZ, does whatever
+    work is needed, and publishes only when it actually has something to say."""
+    sequence = 0
+    period_seconds = 1.0 / LOOP_FREQUENCY_HZ
+    while True:
+        sequence += 1
+        log.info('loop() tick %d', sequence)
+
+        if latest_pressure_adjusted_data is not None:
+            log.info('  latest pressure_adjusted: sensor_depth=%.2f',
+                     latest_pressure_adjusted_data.sensor_depth)
+        if latest_salinity_data is not None:
+            log.info('  latest salinity: salinity=%.2f conductivity=%.2f',
+                     latest_salinity_data.salinity, latest_salinity_data.conductivity)
+
+        message = Motor()
+        message.rpm = sequence
+        publish(EXAMPLE_GROUP, message)
+
+        time.sleep(period_seconds)
+
+
+client = InterProcessClient(platform=args.platform, client_name='pygoby_example')
+
+Thread(target=subscribe_thread, args=(client,), daemon=True).start()
+
+loop(client)

--- a/src/python/pyjaia/examples/pygoby_example.py
+++ b/src/python/pyjaia/examples/pygoby_example.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Example: structuring a pygoby app the same way a real goby C++ app is
-structured (compare to jaiabot_mission_manager.cpp) -- several interprocess
-subscriptions serviced together, plus a loop() running at its own frequency
-that does periodic work and publishes when it has something to say. The goal
-is that switching between C++ goby development and Python pygoby development
-feels familiar.
+structured -- several interprocess subscriptions serviced together,
+plus a loop() running at its own frequency that does periodic work and 
+publishes when it has something to say. The goal is that switching between 
+C++ goby development and Python pygoby development feels familiar.
 
 pygoby itself does not spawn any threads -- publish()/subscribe()/spin() are
 plain method calls, and it's up to the application to decide how (or whether)
@@ -15,8 +14,7 @@ to run them concurrently. Here:
     class services every interprocess().subscribe() it registers from its
     own poller loop. jaiabot_mission_manager.cpp feeds pressure_adjusted and
     salinity into its state machine; here we just cache the latest of each
-    (mirroring jaiabot_fusion.cpp's own last_pressure_adjusted_data_-style
-    caching) and publish a quick echo of each one back out.
+    and publish a quick echo of each one back out.
   - The main thread is loop() -- ticking at a fixed, developer-set frequency,
     doing whatever periodic work is needed (here: reporting the latest cached
     values), and publishing on that same cadence rather than on an always-on

--- a/src/python/pyjaia/pyproject.toml
+++ b/src/python/pyjaia/pyproject.toml
@@ -12,10 +12,11 @@ authors = [
 ]
 keywords = ["jaia"]
 dependencies = [
-    'wheel', 
-    'protobuf==3.20.0', 
-    'scipy', 
-    'numpy', 
+    'wheel',
+    'protobuf==3.20.0',
+    'pyzmq',
+    'scipy',
+    'numpy',
     'cmocean',
     'turfpy',
     'h5py',

--- a/src/python/pyjaia/src/pyjaia/pygoby.py
+++ b/src/python/pyjaia/src/pyjaia/pygoby.py
@@ -45,7 +45,7 @@ class InterProcessClient:
         self.platform = platform
         self.client_name = client_name
         self._context = zmq.Context.instance()
-        self._subscriptions: Dict[str, Tuple[Type[Message], Callable[[Message], None]]] = {}
+        self._subscriptions: Dict[bytes, Tuple[Type[Message], Callable[[Message], None]]] = {}
 
         manager = self._connect_manager_socket()
 
@@ -53,9 +53,11 @@ class InterProcessClient:
             manager, manager_timeout)
 
         self._pub = self._context.socket(zmq.PUB)
+        self._pub.setsockopt(zmq.LINGER, 0)
         self._connect(self._pub, publish_socket_cfg)
 
         self._sub = self._context.socket(zmq.SUB)
+        self._sub.setsockopt(zmq.LINGER, 0)
         self._connect(self._sub, subscribe_socket_cfg)
 
         self._wait_for_hold_release(manager, manager_timeout, hold_timeout)
@@ -147,6 +149,10 @@ class InterProcessClient:
 
     def _dispatch(self, data: bytes):
         null_pos = data.find(b'\0')
+        if null_pos == -1:
+            log.warning('Malformed message (missing null separator); dropping frame of %d bytes',
+                        len(data))
+            return
         identifier, payload = data[:null_pos + 1], data[null_pos + 1:]
         for prefix, (message_type, callback) in self._subscriptions.items():
             if identifier.startswith(prefix):

--- a/src/python/pyjaia/src/pyjaia/pygoby.py
+++ b/src/python/pyjaia/src/pyjaia/pygoby.py
@@ -1,0 +1,133 @@
+"""Minimal native Python client for the goby3 ZeroMQ interprocess transport
+(goby::zeromq::InterProcessPortal).
+
+This talks the documented wire protocol directly
+(goby3/src/doc/markdown/doc500_zeromq.md):
+
+  1. A ZMQ_REQ/REP handshake with gobyd's Manager to discover the XPUB/XSUB
+     router sockets (goby.zeromq.protobuf.ManagerRequest/ManagerResponse).
+  2. Plain ZMQ_PUB/ZMQ_SUB sockets connected to that router, where each
+     message is a single-part frame:
+
+         /{group}/{scheme}/{type}/{pid}/{thread}/\\0{serialized protobuf}
+
+     Subscriptions are ZMQ prefix filters on "/{group}/{scheme}/{type}/".
+
+This is a prototype: it skips the "hold" startup-sync handshake that real
+goby apps use (see gobyd's `hold { required_client: ... }` config), so a
+publisher started at the same instant as gobyd may lose its first message
+or two to ZMQ's "slow joiner" behavior. Fine for a continuous stream of
+sensor-style data; not a substitute for the real InterProcessPortal where
+that guarantee matters.
+"""
+import logging
+import os
+import threading
+import time
+from typing import Callable, Dict, Tuple, Type
+
+import zmq
+from google.protobuf.message import Message
+from goby.zeromq.protobuf import interprocess_zeromq_pb2 as manager_pb2
+
+log = logging.getLogger('pygoby')
+
+# goby::middleware::MarshallingScheme::e2s maps scheme 1 to the literal
+# string "PROTOBUF" (not "1") in the wire identifier.
+SCHEME_PROTOBUF = 'PROTOBUF'
+
+
+class InterProcessClient:
+    """Publishes/subscribes Protobuf messages on a gobyd interprocess bus."""
+
+    def __init__(self, platform: str, client_name: str, manager_timeout: float = 5.0):
+        self.platform = platform
+        self.client_name = client_name
+        self._context = zmq.Context.instance()
+        self._subscriptions: Dict[str, Tuple[Type[Message], Callable[[Message], None]]] = {}
+
+        publish_socket_cfg, subscribe_socket_cfg = self._query_manager(manager_timeout)
+
+        self._pub = self._context.socket(zmq.PUB)
+        self._connect(self._pub, publish_socket_cfg)
+
+        self._sub = self._context.socket(zmq.SUB)
+        self._connect(self._sub, subscribe_socket_cfg)
+
+        # Avoid ZMQ's "slow joiner" problem: give the sockets a moment to
+        # finish connecting before we start publishing/expect subscriptions
+        # to be live.
+        time.sleep(0.2)
+
+        log.info('Connected to gobyd on platform "%s" as "%s"', platform, client_name)
+
+    def _query_manager(self, timeout: float):
+        manager_addr = f'ipc:///tmp/goby_{self.platform}.manager'
+        req = self._context.socket(zmq.REQ)
+        req.setsockopt(zmq.LINGER, 0)
+        req.connect(manager_addr)
+
+        request = manager_pb2.ManagerRequest()
+        request.request = manager_pb2.PROVIDE_PUB_SUB_SOCKETS
+        request.client_name = self.client_name
+        request.client_pid = os.getpid()
+        req.send(request.SerializeToString())
+
+        if not req.poll(int(timeout * 1000)):
+            raise TimeoutError(f'No response from gobyd Manager at {manager_addr} '
+                                f'(is gobyd running with platform="{self.platform}"?)')
+
+        response = manager_pb2.ManagerResponse()
+        response.ParseFromString(req.recv())
+        req.close()
+
+        return response.publish_socket, response.subscribe_socket
+
+    @staticmethod
+    def _connect(sock: 'zmq.Socket', cfg: manager_pb2.Socket):
+        if cfg.transport == manager_pb2.Socket.IPC:
+            sock.connect(f'ipc://{cfg.socket_name}')
+        elif cfg.transport == manager_pb2.Socket.TCP:
+            sock.connect(f'tcp://{cfg.ethernet_address}:{cfg.ethernet_port}')
+        else:
+            raise ValueError(f'Unsupported transport in ManagerResponse: {cfg.transport}')
+
+    def publish(self, group: str, message: Message):
+        identifier = self._make_publish_identifier(group, message.DESCRIPTOR.full_name)
+        self._pub.send(identifier + message.SerializeToString())
+
+    def subscribe(self, group: str, message_type: Type[Message],
+                  callback: Callable[[Message], None]):
+        prefix = self._make_subscribe_prefix(group, message_type.DESCRIPTOR.full_name)
+        self._subscriptions[prefix] = (message_type, callback)
+        self._sub.setsockopt(zmq.SUBSCRIBE, prefix)
+        log.debug('Subscribed to %s', prefix)
+
+    def spin(self, timeout_ms: int = 100) -> int:
+        """Handle any currently-pending subscribed messages; returns the count handled."""
+        handled = 0
+        while self._sub.poll(timeout_ms if handled == 0 else 0):
+            self._dispatch(self._sub.recv())
+            handled += 1
+        return handled
+
+    def _dispatch(self, data: bytes):
+        null_pos = data.find(b'\0')
+        identifier, payload = data[:null_pos + 1], data[null_pos + 1:]
+        for prefix, (message_type, callback) in self._subscriptions.items():
+            if identifier.startswith(prefix):
+                message = message_type()
+                message.ParseFromString(payload)
+                callback(message)
+                return
+        log.debug('No subscriber matched identifier: %s', identifier)
+
+    @staticmethod
+    def _make_publish_identifier(group: str, type_name: str) -> bytes:
+        pid = os.getpid()
+        thread = format(threading.get_ident() & 0xFFFFFFFFFFFFFFFF, 'x')
+        return f'/{group}/{SCHEME_PROTOBUF}/{type_name}/{pid}/{thread}/\0'.encode()
+
+    @staticmethod
+    def _make_subscribe_prefix(group: str, type_name: str) -> bytes:
+        return f'/{group}/{SCHEME_PROTOBUF}/{type_name}/'.encode()

--- a/src/python/pyjaia/src/pyjaia/pygoby.py
+++ b/src/python/pyjaia/src/pyjaia/pygoby.py
@@ -13,12 +13,12 @@ This talks the documented wire protocol directly
 
      Subscriptions are ZMQ prefix filters on "/{group}/{scheme}/{type}/".
 
-This is a prototype: it skips the "hold" startup-sync handshake that real
-goby apps use (see gobyd's `hold { required_client: ... }` config), so a
-publisher started at the same instant as gobyd may lose its first message
-or two to ZMQ's "slow joiner" behavior. Fine for a continuous stream of
-sensor-style data; not a substitute for the real InterProcessPortal where
-that guarantee matters.
+Before returning, the constructor also waits out gobyd's startup "hold": if
+the platform's gobyd config lists `hold { required_client: ... }` apps, a
+new client blocks, polling the Manager, until all of them have reported
+ready. This is the same guarantee goby's own InterProcessPortal gives C++
+apps, and it's what actually avoids losing early publish()es to ZMQ's "slow
+joiner" behavior (rather than a fixed sleep-and-hope).
 """
 import logging
 import os
@@ -40,13 +40,17 @@ SCHEME_PROTOBUF = 'PROTOBUF'
 class InterProcessClient:
     """Publishes/subscribes Protobuf messages on a gobyd interprocess bus."""
 
-    def __init__(self, platform: str, client_name: str, manager_timeout: float = 5.0):
+    def __init__(self, platform: str, client_name: str, manager_timeout: float = 5.0,
+                 hold_timeout: float = 30.0):
         self.platform = platform
         self.client_name = client_name
         self._context = zmq.Context.instance()
         self._subscriptions: Dict[str, Tuple[Type[Message], Callable[[Message], None]]] = {}
 
-        publish_socket_cfg, subscribe_socket_cfg = self._query_manager(manager_timeout)
+        manager = self._connect_manager_socket()
+
+        publish_socket_cfg, subscribe_socket_cfg = self._request_pub_sub_sockets(
+            manager, manager_timeout)
 
         self._pub = self._context.socket(zmq.PUB)
         self._connect(self._pub, publish_socket_cfg)
@@ -54,34 +58,64 @@ class InterProcessClient:
         self._sub = self._context.socket(zmq.SUB)
         self._connect(self._sub, subscribe_socket_cfg)
 
-        # Avoid ZMQ's "slow joiner" problem: give the sockets a moment to
-        # finish connecting before we start publishing/expect subscriptions
-        # to be live.
-        time.sleep(0.2)
+        self._wait_for_hold_release(manager, manager_timeout, hold_timeout)
+        manager.close()
 
         log.info('Connected to gobyd on platform "%s" as "%s"', platform, client_name)
 
-    def _query_manager(self, timeout: float):
+    def _connect_manager_socket(self) -> 'zmq.Socket':
         manager_addr = f'ipc:///tmp/goby_{self.platform}.manager'
-        req = self._context.socket(zmq.REQ)
-        req.setsockopt(zmq.LINGER, 0)
-        req.connect(manager_addr)
+        manager = self._context.socket(zmq.REQ)
+        manager.setsockopt(zmq.LINGER, 0)
+        manager.connect(manager_addr)
+        return manager
 
+    def _request_pub_sub_sockets(self, manager: 'zmq.Socket', timeout: float):
         request = manager_pb2.ManagerRequest()
         request.request = manager_pb2.PROVIDE_PUB_SUB_SOCKETS
         request.client_name = self.client_name
         request.client_pid = os.getpid()
-        req.send(request.SerializeToString())
+        manager.send(request.SerializeToString())
 
-        if not req.poll(int(timeout * 1000)):
-            raise TimeoutError(f'No response from gobyd Manager at {manager_addr} '
-                                f'(is gobyd running with platform="{self.platform}"?)')
+        if not manager.poll(int(timeout * 1000)):
+            raise TimeoutError(f'No response from gobyd Manager for platform="{self.platform}" '
+                                f'(is gobyd running?)')
 
         response = manager_pb2.ManagerResponse()
-        response.ParseFromString(req.recv())
-        req.close()
+        response.ParseFromString(manager.recv())
 
         return response.publish_socket, response.subscribe_socket
+
+    def _wait_for_hold_release(self, manager: 'zmq.Socket', request_timeout: float,
+                               hold_timeout: float, poll_interval: float = 0.1):
+        """Block until gobyd reports that its `hold { required_client: ... }` apps are
+        all ready, matching goby's own InterProcessPortalReadThread::run() (100ms poll
+        period). If gobyd has no hold config for this platform, the first poll already
+        returns hold=false and this returns immediately."""
+        deadline = time.monotonic() + hold_timeout
+        while True:
+            request = manager_pb2.ManagerRequest()
+            request.request = manager_pb2.PROVIDE_HOLD_STATE
+            request.client_name = self.client_name
+            request.client_pid = os.getpid()
+            request.ready = True
+            manager.send(request.SerializeToString())
+
+            if not manager.poll(int(request_timeout * 1000)):
+                raise TimeoutError(f'No response from gobyd Manager for platform='
+                                    f'"{self.platform}" while waiting for hold state')
+
+            response = manager_pb2.ManagerResponse()
+            response.ParseFromString(manager.recv())
+            if not response.hold:
+                return
+
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f'gobyd for platform="{self.platform}" did not release its startup '
+                    f'hold within {hold_timeout}s; a required_client app may be down')
+
+            time.sleep(poll_interval)
 
     @staticmethod
     def _connect(sock: 'zmq.Socket', cfg: manager_pb2.Socket):

--- a/src/python/pyjaia/tests/test_pygoby.py
+++ b/src/python/pyjaia/tests/test_pygoby.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Tests for pyjaia.pygoby.
+
+Two tiers:
+
+  - Pure logic tests (identifier/prefix construction, _dispatch() routing,
+    _connect() socket setup): no sockets or external processes, always run.
+  - Integration tests: spin up a real, throwaway `gobyd` subprocess on a
+    unique platform name and talk to it over real IPC sockets, the same way
+    a live sim run would. These are skipped if `gobyd` isn't on PATH.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+import zmq
+
+from goby.zeromq.protobuf import interprocess_zeromq_pb2 as manager_pb2
+from jaiabot.messages.motor_pb2 import Motor
+from pyjaia.pygoby import InterProcessClient
+
+GOBYD_AVAILABLE = shutil.which('gobyd') is not None
+skip_without_gobyd = pytest.mark.skipif(not GOBYD_AVAILABLE, reason='gobyd is not installed')
+
+
+# --- Pure logic tests -------------------------------------------------------
+
+def test_make_publish_identifier_format():
+    identifier = InterProcessClient._make_publish_identifier(
+        'jaiabot::motor_rpm', 'jaiabot.protobuf.Motor')
+
+    assert identifier.startswith(b'/jaiabot::motor_rpm/PROTOBUF/jaiabot.protobuf.Motor/')
+    assert identifier.endswith(b'/\0')
+    assert f'/{os.getpid()}/'.encode() in identifier
+
+
+def test_make_subscribe_prefix_format():
+    prefix = InterProcessClient._make_subscribe_prefix(
+        'jaiabot::motor_rpm', 'jaiabot.protobuf.Motor')
+
+    assert prefix == b'/jaiabot::motor_rpm/PROTOBUF/jaiabot.protobuf.Motor/'
+
+
+def test_publish_identifier_matches_subscribe_prefix():
+    """The core wire-format invariant: a real publish() identifier must always
+    be matched by the corresponding subscribe() prefix -- that's exactly how
+    both ZMQ's own SUBSCRIBE filtering and _dispatch()'s routing depend on it
+    working."""
+    group, type_name = 'jaiabot::mission_report', 'jaiabot.protobuf.MissionReport'
+
+    identifier = InterProcessClient._make_publish_identifier(group, type_name)
+    prefix = InterProcessClient._make_subscribe_prefix(group, type_name)
+
+    assert identifier.startswith(prefix)
+
+
+def _bare_client() -> InterProcessClient:
+    """An InterProcessClient with no sockets, for testing methods that only
+    touch self._subscriptions (bypasses __init__'s real gobyd handshake)."""
+    return object.__new__(InterProcessClient)
+
+
+def test_dispatch_routes_to_matching_subscription():
+    client = _bare_client()
+    received = []
+    client._subscriptions = {
+        InterProcessClient._make_subscribe_prefix('grp', 'jaiabot.protobuf.Motor'):
+            (Motor, received.append),
+    }
+
+    message = Motor()
+    message.rpm = 42
+    data = (InterProcessClient._make_publish_identifier('grp', 'jaiabot.protobuf.Motor')
+            + message.SerializeToString())
+
+    client._dispatch(data)
+
+    assert len(received) == 1
+    assert received[0].rpm == 42
+
+
+def test_dispatch_picks_correct_subscription_among_several():
+    client = _bare_client()
+    received_a, received_b = [], []
+    client._subscriptions = {
+        InterProcessClient._make_subscribe_prefix('grp_a', 'jaiabot.protobuf.Motor'):
+            (Motor, received_a.append),
+        InterProcessClient._make_subscribe_prefix('grp_b', 'jaiabot.protobuf.Motor'):
+            (Motor, received_b.append),
+    }
+
+    message = Motor()
+    message.rpm = 7
+    data = (InterProcessClient._make_publish_identifier('grp_b', 'jaiabot.protobuf.Motor')
+            + message.SerializeToString())
+
+    client._dispatch(data)
+
+    assert received_a == []
+    assert len(received_b) == 1
+    assert received_b[0].rpm == 7
+
+
+def test_dispatch_ignores_unmatched_identifier():
+    client = _bare_client()
+    received = []
+    client._subscriptions = {
+        InterProcessClient._make_subscribe_prefix('grp', 'jaiabot.protobuf.Motor'):
+            (Motor, received.append),
+    }
+
+    data = (InterProcessClient._make_publish_identifier('other_group', 'jaiabot.protobuf.Motor')
+            + Motor().SerializeToString())
+
+    client._dispatch(data)  # should not raise, should not call the callback
+
+    assert received == []
+
+
+def test_dispatch_drops_malformed_frame_missing_null_separator(caplog):
+    client = _bare_client()
+    received = []
+    client._subscriptions = {
+        InterProcessClient._make_subscribe_prefix('grp', 'jaiabot.protobuf.Motor'):
+            (Motor, received.append),
+    }
+
+    client._dispatch(b'this frame has no null separator at all')
+
+    assert received == []
+    assert any('Malformed message' in record.message for record in caplog.records)
+
+
+def test_connect_ipc_socket():
+    cfg = manager_pb2.Socket()
+    cfg.transport = manager_pb2.Socket.IPC
+    cfg.socket_name = '/tmp/goby_test.xsub'
+    mock_socket = mock.Mock()
+
+    InterProcessClient._connect(mock_socket, cfg)
+
+    mock_socket.connect.assert_called_once_with('ipc:///tmp/goby_test.xsub')
+
+
+def test_connect_tcp_socket():
+    cfg = manager_pb2.Socket()
+    cfg.transport = manager_pb2.Socket.TCP
+    cfg.ethernet_address = '127.0.0.1'
+    cfg.ethernet_port = 12345
+    mock_socket = mock.Mock()
+
+    InterProcessClient._connect(mock_socket, cfg)
+
+    mock_socket.connect.assert_called_once_with('tcp://127.0.0.1:12345')
+
+
+def test_connect_raises_on_unsupported_transport():
+    cfg = manager_pb2.Socket()  # transport left unset -> proto default (EPGM)
+    mock_socket = mock.Mock()
+
+    with pytest.raises(ValueError):
+        InterProcessClient._connect(mock_socket, cfg)
+
+
+def test_manager_timeout_when_gobyd_not_running():
+    with pytest.raises(TimeoutError):
+        InterProcessClient(platform=f'no_such_platform_{uuid.uuid4().hex[:8]}',
+                            client_name='test_client', manager_timeout=0.5)
+
+
+# --- Integration tests: real, throwaway gobyd -------------------------------
+
+@contextmanager
+def running_gobyd(hold_config: str = ''):
+    """Launches a throwaway gobyd on a unique platform, optionally with a
+    `hold { ... }` block, and tears it down (process + socket files) on exit."""
+    platform = f'pygoby_test_{uuid.uuid4().hex[:8]}'
+    config_text = f'interprocess {{ platform: "{platform}" }}\n{hold_config}\n'
+
+    with tempfile.NamedTemporaryFile('w', suffix='.pb.cfg', delete=False) as f:
+        f.write(config_text)
+        config_path = f.name
+
+    process = subprocess.Popen(['gobyd', config_path],
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    manager_socket_path = f'/tmp/goby_{platform}.manager'
+    try:
+        deadline = time.monotonic() + 5.0
+        while not os.path.exists(manager_socket_path):
+            if process.poll() is not None:
+                raise RuntimeError('gobyd exited immediately on startup; check its config')
+            if time.monotonic() > deadline:
+                raise TimeoutError('gobyd did not start up in time')
+            time.sleep(0.05)
+        yield platform
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+        os.unlink(config_path)
+        for suffix in ('.manager', '.xpub', '.xsub'):
+            try:
+                os.unlink(f'/tmp/goby_{platform}{suffix}')
+            except FileNotFoundError:
+                pass
+
+
+@pytest.fixture
+def gobyd_platform():
+    with running_gobyd() as platform:
+        yield platform
+
+
+@skip_without_gobyd
+def test_publish_subscribe_roundtrip(gobyd_platform):
+    publisher = InterProcessClient(platform=gobyd_platform, client_name='test_publisher')
+    subscriber = InterProcessClient(platform=gobyd_platform, client_name='test_subscriber')
+
+    received = []
+    subscriber.subscribe('pyjaia::test', Motor, received.append)
+
+    # Publish repeatedly rather than once: with no hold{} relationship between
+    # these two specific clients, a single publish can still be lost to ZMQ's
+    # "slow joiner" subscription-propagation delay, exactly as it could be for
+    # any real, unrelated publisher/subscriber pair. Every real publisher in
+    # this codebase (rpm.py, pygoby_example.py's loop()) publishes on a timer
+    # for the same reason -- this test does too, rather than asserting on a
+    # single one-shot send.
+    message = Motor()
+    message.rpm = 123
+    deadline = time.monotonic() + 5.0
+    while not received and time.monotonic() < deadline:
+        publisher.publish('pyjaia::test', message)
+        subscriber.spin(timeout_ms=100)
+
+    assert len(received) == 1
+    assert received[0].rpm == 123
+
+
+@skip_without_gobyd
+def test_hold_blocks_until_required_client_reports_ready():
+    with running_gobyd(hold_config='hold { required_client: "the_app_we_wait_for" }') as platform:
+        # nobody ever reports "the_app_we_wait_for" ready, so the hold never clears
+        with pytest.raises(TimeoutError):
+            InterProcessClient(platform=platform, client_name='impatient_client',
+                                hold_timeout=1.0)
+
+
+@skip_without_gobyd
+def test_hold_releases_once_required_client_reports_ready():
+    with running_gobyd(hold_config='hold { required_client: "the_app_we_wait_for" }') as platform:
+
+        def report_ready_after_delay():
+            time.sleep(0.5)
+            req = zmq.Context.instance().socket(zmq.REQ)
+            req.connect(f'ipc:///tmp/goby_{platform}.manager')
+            request = manager_pb2.ManagerRequest()
+            request.request = manager_pb2.PROVIDE_HOLD_STATE
+            request.client_name = 'the_app_we_wait_for'
+            request.client_pid = os.getpid()
+            request.ready = True
+            req.send(request.SerializeToString())
+            req.recv()
+            req.close()
+
+        threading.Thread(target=report_ready_after_delay, daemon=True).start()
+
+        start = time.monotonic()
+        InterProcessClient(platform=platform, client_name='patient_client', hold_timeout=10.0)
+        elapsed = time.monotonic() - start
+
+        # released promptly once reported, nowhere near the full hold_timeout
+        assert elapsed < 5.0


### PR DESCRIPTION
## Description

Using connection to zeromq instead of using udp connection for rpm data by using a minimal native Python client for the goby3 ZeroMQ interprocess transport (goby::zeromq::InterProcessPortal).

## Test

Tested in sim. Used liaison to confirm rpm information is being published.