### PR TITLE
feature/jcc-sliders-instead-of-input-only/SW-2323

### DIFF
--- a/src/web/components/JaiaNumberInput/JaiaNumberInput.less
+++ b/src/web/components/JaiaNumberInput/JaiaNumberInput.less
@@ -1,0 +1,41 @@
+.jaia-number-input {
+    position: relative;
+    display: flex;
+}
+
+.jaia-number-input > input {
+    width: 100%;
+}
+
+.jaia-stepper {
+    display: flex;
+    flex-direction: column;
+    width: 16px;
+}
+
+.jaia-number-input .jaia-stepper {
+    position: absolute;
+    top: 0;
+    right: 2px;
+    bottom: 0;
+}
+
+.jaia-stepper-button {
+    all: unset;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: inherit;
+}
+
+.jaia-stepper-button:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.jaia-stepper-button svg {
+    width: 14px;
+    height: 14px;
+}

--- a/src/web/components/JaiaNumberInput/JaiaNumberInput.less
+++ b/src/web/components/JaiaNumberInput/JaiaNumberInput.less
@@ -17,13 +17,13 @@
 .jaia-stepper {
     display: flex;
     flex-direction: column;
-    width: 16px;
+    width: 15px;
 }
 
 .jaia-number-input .jaia-stepper {
     position: absolute;
     top: 0;
-    right: 2px;
+    right: 3px;
     bottom: 0;
 }
 
@@ -43,6 +43,6 @@
 }
 
 .jaia-stepper-button svg {
-    width: 14px;
-    height: 14px;
+    width: 15px;
+    height: 15px;
 }

--- a/src/web/components/JaiaNumberInput/JaiaNumberInput.less
+++ b/src/web/components/JaiaNumberInput/JaiaNumberInput.less
@@ -7,6 +7,13 @@
     width: 100%;
 }
 
+.jaia-number-input input[type="number"]::-webkit-inner-spin-button,
+.jaia-number-input input[type="number"]::-webkit-outer-spin-button {
+    appearance: none;
+    -webkit-appearance: none;
+    margin: 0;
+}
+
 .jaia-stepper {
     display: flex;
     flex-direction: column;

--- a/src/web/components/JaiaNumberInput/JaiaNumberInput.tsx
+++ b/src/web/components/JaiaNumberInput/JaiaNumberInput.tsx
@@ -1,0 +1,97 @@
+import { ChangeEvent } from "react";
+
+import Icon from "@mdi/react";
+import { mdiMenuUp, mdiMenuDown } from "@mdi/js";
+
+import "./JaiaNumberInput.less";
+
+interface StepperButtonsProps {
+    onStep: (direction: number) => void;
+    disabled?: boolean;
+}
+
+/**
+ * Renders up/down buttons for a number field
+ */
+export function StepperButtons(props: StepperButtonsProps) {
+    return (
+        <div className="jaia-stepper">
+            <button
+                type="button"
+                className="jaia-stepper-button"
+                tabIndex={-1}
+                disabled={props.disabled}
+                aria-label="increment"
+                onClick={() => props.onStep(1)}
+            >
+                <Icon path={mdiMenuUp} />
+            </button>
+            <button
+                type="button"
+                className="jaia-stepper-button"
+                tabIndex={-1}
+                disabled={props.disabled}
+                aria-label="decrement"
+                onClick={() => props.onStep(-1)}
+            >
+                <Icon path={mdiMenuDown} />
+            </button>
+        </div>
+    );
+}
+
+interface Props {
+    value: string | number;
+    onChange: (evt: ChangeEvent<HTMLInputElement>) => void;
+    name?: string;
+    min?: number;
+    max?: number;
+    step?: number;
+    disabled?: boolean;
+    className?: string;
+}
+
+/**
+ * Renders a number input with integrated increment/decrement buttons
+ */
+export default function JaiaNumberInput(props: Props) {
+    const step = props.step ?? 1;
+
+    /**
+     * Applies a change to the current value and reports it via onChange
+     *
+     * @param {number} direction 1 to increment, -1 to decrement
+     * @returns {void}
+     */
+    const handleStep = (direction: number) => {
+        const current = Number(props.value);
+        let next = (isNaN(current) ? 0 : current) + direction * step;
+        if (props.min !== undefined && next < props.min) {
+            next = props.min;
+        }
+        if (props.max !== undefined && next > props.max) {
+            next = props.max;
+        }
+        props.onChange({
+            target: { name: props.name ?? "", value: next.toString() },
+        } as unknown as ChangeEvent<HTMLInputElement>);
+    };
+
+    return (
+        <div className="jaia-number-input">
+            <input
+                name={props.name}
+                type="number"
+                value={props.value}
+                min={props.min}
+                max={props.max}
+                step={step}
+                disabled={props.disabled}
+                autoComplete="off"
+                className={props.className}
+                onChange={props.onChange}
+            />
+            <StepperButtons onStep={handleStep} disabled={props.disabled} />
+        </div>
+    );
+}

--- a/src/web/components/JaiaNumberInput/JaiaNumberInput.tsx
+++ b/src/web/components/JaiaNumberInput/JaiaNumberInput.tsx
@@ -17,7 +17,6 @@ export function StepperButtons(props: StepperButtonsProps) {
     return (
         <div className="jaia-stepper">
             <button
-                type="button"
                 className="jaia-stepper-button"
                 tabIndex={-1}
                 disabled={props.disabled}
@@ -27,7 +26,6 @@ export function StepperButtons(props: StepperButtonsProps) {
                 <Icon path={mdiMenuUp} />
             </button>
             <button
-                type="button"
                 className="jaia-stepper-button"
                 tabIndex={-1}
                 disabled={props.disabled}
@@ -41,12 +39,10 @@ export function StepperButtons(props: StepperButtonsProps) {
 }
 
 interface Props {
-    value: string | number;
+    value: string;
     onChange: (evt: ChangeEvent<HTMLInputElement>) => void;
     name?: string;
     min?: number;
-    max?: number;
-    step?: number;
     disabled?: boolean;
     className?: string;
 }
@@ -55,8 +51,6 @@ interface Props {
  * Renders a number input with integrated increment/decrement buttons
  */
 export default function JaiaNumberInput(props: Props) {
-    const step = props.step ?? 1;
-
     /**
      * Applies a change to the current value and reports it via onChange
      *
@@ -65,12 +59,9 @@ export default function JaiaNumberInput(props: Props) {
      */
     const handleStep = (direction: number) => {
         const current = Number(props.value);
-        let next = (isNaN(current) ? 0 : current) + direction * step;
+        let next = (isNaN(current) ? 0 : current) + direction;
         if (props.min !== undefined && next < props.min) {
             next = props.min;
-        }
-        if (props.max !== undefined && next > props.max) {
-            next = props.max;
         }
         props.onChange({
             target: { name: props.name ?? "", value: next.toString() },
@@ -84,8 +75,6 @@ export default function JaiaNumberInput(props: Props) {
                 type="number"
                 value={props.value}
                 min={props.min}
-                max={props.max}
-                step={step}
                 disabled={props.disabled}
                 autoComplete="off"
                 className={props.className}

--- a/src/web/components/MissionsPanel/MissionsList/MissionsList.less
+++ b/src/web/components/MissionsPanel/MissionsList/MissionsList.less
@@ -43,3 +43,14 @@
 .mission-repeats input {
     text-align: right;
 }
+
+.mission-repeats input[type="number"]::-webkit-inner-spin-button,
+.mission-repeats input[type="number"]::-webkit-outer-spin-button {
+    appearance: none;
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.mission-repeats input[type="number"] {
+    -moz-appearance: textfield;
+}

--- a/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
+++ b/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
@@ -11,6 +11,7 @@ import { missionsManager } from "../../../data/missions_manager/missions-manager
 import { MDI_BUTTON_SIZE, UNASSIGNED_ID } from "../../../utils/constants";
 import { accordionTheme, addDropdownListener, scrollMissionsList } from "../../../utils/style";
 import JaiaToggle from "../../../components/JaiaToggle/JaiaToggle";
+import { StepperButtons } from "../../../components/JaiaNumberInput/JaiaNumberInput";
 
 // MUI | MDI
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -141,7 +142,24 @@ export default function MissionsList() {
                                         label="Repeats"
                                         size="small"
                                         type="number"
-                                        slotProps={{ htmlInput: { min: 1 } }}
+                                        slotProps={{
+                                            htmlInput: { min: 1 },
+                                            input: {
+                                                endAdornment: (
+                                                    <StepperButtons
+                                                        onStep={(direction) =>
+                                                            handleRepeatsChange(
+                                                                String(
+                                                                    Number(mission.getRepeats()) +
+                                                                        direction,
+                                                                ),
+                                                                mission.getMissionID(),
+                                                            )
+                                                        }
+                                                    />
+                                                ),
+                                            },
+                                        }}
                                         className="mission-repeats"
                                         autoComplete="off"
                                         value={mission.getRepeats()}

--- a/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
+++ b/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
@@ -75,9 +75,8 @@ export default function MissionsList() {
      * @returns {void}
      */
     const handleRepeatsChange = (repeats: string, missionID: number) => {
-        const parsed = Number(repeats);
-        let numOfRepeats = parsed;
-        if (repeats === "" || isNaN(parsed) || parsed < 1) {
+        let numOfRepeats = Number(repeats);
+        if (repeats === "" || isNaN(numOfRepeats) || numOfRepeats < 1) {
             numOfRepeats = 1;
         }
         jaiaDispatch({

--- a/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
+++ b/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
@@ -140,6 +140,8 @@ export default function MissionsList() {
                                     <TextField
                                         label="Repeats"
                                         size="small"
+                                        type="number"
+                                        slotProps={{ htmlInput: { min: 1 } }}
                                         className="mission-repeats"
                                         autoComplete="off"
                                         value={mission.getRepeats()}

--- a/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
+++ b/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
@@ -76,7 +76,10 @@ export default function MissionsList() {
      */
     const handleRepeatsChange = (repeats: string, missionID: number) => {
         const parsed = Number(repeats);
-        const numOfRepeats = repeats === "" || isNaN(parsed) ? 1 : Math.max(1, parsed);
+        let numOfRepeats = parsed;
+        if (repeats === "" || isNaN(parsed) || parsed < 1) {
+            numOfRepeats = 1;
+        }
         jaiaDispatch({
             type: JaiaActions.CHANGE_MISSION_REPEATS,
             missionRepeats: numOfRepeats,

--- a/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
+++ b/src/web/components/MissionsPanel/MissionsList/MissionsList.tsx
@@ -75,10 +75,8 @@ export default function MissionsList() {
      * @returns {void}
      */
     const handleRepeatsChange = (repeats: string, missionID: number) => {
-        let numOfRepeats = Number(repeats);
-        if (isNaN(numOfRepeats)) {
-            numOfRepeats = 1;
-        }
+        const parsed = Number(repeats);
+        const numOfRepeats = repeats === "" || isNaN(parsed) ? 1 : Math.max(1, parsed);
         jaiaDispatch({
             type: JaiaActions.CHANGE_MISSION_REPEATS,
             missionRepeats: numOfRepeats,

--- a/src/web/components/SurveyPlanner/SurveyPlanner.less
+++ b/src/web/components/SurveyPlanner/SurveyPlanner.less
@@ -35,6 +35,11 @@
     border-radius: 3px;
 }
 
+.survey .input-grid input[type="number"] {
+    appearance: auto;
+    -webkit-appearance: auto;
+}
+
 .survey .input-grid .input-group {
     display: flex;
     gap: 5px;

--- a/src/web/components/SurveyPlanner/SurveyPlanner.less
+++ b/src/web/components/SurveyPlanner/SurveyPlanner.less
@@ -36,7 +36,7 @@
 }
 
 .survey .input-grid input[type="number"] {
-    padding-right: 20px;
+    padding-right: 21px;
 }
 
 .survey .input-grid .input-group {

--- a/src/web/components/SurveyPlanner/SurveyPlanner.less
+++ b/src/web/components/SurveyPlanner/SurveyPlanner.less
@@ -36,8 +36,7 @@
 }
 
 .survey .input-grid input[type="number"] {
-    appearance: auto;
-    -webkit-appearance: auto;
+    padding-right: 20px;
 }
 
 .survey .input-grid .input-group {

--- a/src/web/components/SurveyPlanner/SurveyPlanner.tsx
+++ b/src/web/components/SurveyPlanner/SurveyPlanner.tsx
@@ -8,6 +8,7 @@ import { JaiaContext, JaiaDispatchContext } from "../../context/JaiaContext";
 import { JaiaActions } from "../../context/jaia-actions";
 
 import TaskParameters from "../WaypointPanel/TaskParameters/TaskParameters";
+import JaiaNumberInput from "../JaiaNumberInput/JaiaNumberInput";
 
 import { gridLayer } from "../../openlayers/layers/vector/grid-layer";
 import Task from "../../data/tasks/task";
@@ -268,26 +269,26 @@ function GridConfigs(props: Props) {
             <div className="survey-text-row">Drag to create the grid</div>
             <div className="input-grid">
                 <div>Number of Lanes:</div>
-                <input
-                    type="number"
+                <JaiaNumberInput
                     value={formatNumericalInput(numOfLanes)}
+                    min={0}
                     onChange={(evt: ChangeEvent<HTMLInputElement>) =>
                         handleInputChange(evt.target.value, GridInputs.NUM_OF_LANES)
                     }
                 />
                 <div>Number of Bots:</div>
-                <input
-                    type="number"
+                <JaiaNumberInput
                     value={formatNumericalInput(numOfBots)}
+                    min={0}
                     onChange={(evt: ChangeEvent<HTMLInputElement>) =>
                         handleInputChange(evt.target.value, GridInputs.NUM_OF_BOTS)
                     }
                 />
                 <div>Lane Spacing:</div>
                 <div className="input-group">
-                    <input
-                        type="number"
+                    <JaiaNumberInput
                         value={formatNumericalInput(laneSpacing)}
+                        min={0}
                         onChange={(evt: ChangeEvent<HTMLInputElement>) =>
                             handleInputChange(evt.target.value, GridInputs.LANE_SPACING)
                         }
@@ -297,9 +298,9 @@ function GridConfigs(props: Props) {
 
                 <div>Point Spacing:</div>
                 <div className="input-group">
-                    <input
-                        type="number"
+                    <JaiaNumberInput
                         value={formatNumericalInput(pointSpacing)}
+                        min={0}
                         onChange={(evt: ChangeEvent<HTMLInputElement>) =>
                             handleInputChange(evt.target.value, GridInputs.POINT_SPACING)
                         }

--- a/src/web/components/WaypointPanel/TaskParameters/TaskParameters.less
+++ b/src/web/components/WaypointPanel/TaskParameters/TaskParameters.less
@@ -6,7 +6,7 @@
 }
 
 .task-parameters input[type="number"] {
-    padding-right: 20px;
+    padding-right: 21px;
 }
 
 .task-parameters .distance-calc {

--- a/src/web/components/WaypointPanel/TaskParameters/TaskParameters.less
+++ b/src/web/components/WaypointPanel/TaskParameters/TaskParameters.less
@@ -5,6 +5,11 @@
     gap: 9px;
 }
 
+.task-parameters input[type="number"] {
+    appearance: auto;
+    -webkit-appearance: auto;
+}
+
 .task-parameters .distance-calc {
     padding: 6px;
     text-align: right;

--- a/src/web/components/WaypointPanel/TaskParameters/TaskParameters.less
+++ b/src/web/components/WaypointPanel/TaskParameters/TaskParameters.less
@@ -6,8 +6,7 @@
 }
 
 .task-parameters input[type="number"] {
-    appearance: auto;
-    -webkit-appearance: auto;
+    padding-right: 20px;
 }
 
 .task-parameters .distance-calc {

--- a/src/web/components/WaypointPanel/TaskParameters/TaskParameters.tsx
+++ b/src/web/components/WaypointPanel/TaskParameters/TaskParameters.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 
 import JaiaToggle from "../../JaiaToggle/JaiaToggle";
+import JaiaNumberInput from "../../JaiaNumberInput/JaiaNumberInput";
 import { JaiaContext, JaiaDispatchContext } from "../../../context/JaiaContext";
 import { JaiaActions } from "../../../context/jaia-actions";
 
@@ -168,12 +169,10 @@ function DiveParameters(props: Props) {
                 />
                 <div className="task-parameters">
                     <div>Drift Time</div>
-                    <input
+                    <JaiaNumberInput
                         name={TaskParameterKeys.DRIFT_TIME}
-                        type="number"
                         value={formatNumericalInput(props.task.getDriftParameters().drift_time)}
                         className="jaia-input"
-                        autoComplete="off"
                         disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
@@ -197,48 +196,40 @@ function DiveParameters(props: Props) {
 
                 <div className="task-parameters">
                     <div>Max Depth</div>
-                    <input
+                    <JaiaNumberInput
                         name={TaskParameterKeys.MAX_DEPTH}
-                        type="number"
                         value={formatNumericalInput(diveParameters.max_depth)}
                         className="jaia-input"
-                        autoComplete="off"
                         disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
                     <div className="units">m</div>
 
                     <div>Depth Interval</div>
-                    <input
+                    <JaiaNumberInput
                         name={TaskParameterKeys.DEPTH_INTERVAL}
-                        type="number"
                         value={formatNumericalInput(diveParameters.depth_interval)}
                         className="jaia-input"
-                        autoComplete="off"
                         disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
                     <div className="units">m</div>
 
                     <div>Hold Time</div>
-                    <input
+                    <JaiaNumberInput
                         name={TaskParameterKeys.HOLD_TIME}
-                        type="number"
                         value={formatNumericalInput(diveParameters.hold_time)}
                         className="jaia-input"
-                        autoComplete="off"
                         disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
                     <div className="units">s</div>
 
                     <div>Drift Time</div>
-                    <input
+                    <JaiaNumberInput
                         name={TaskParameterKeys.DRIFT_TIME}
-                        type="number"
                         value={formatNumericalInput(props.task.getDriftParameters().drift_time)}
                         className="jaia-input"
-                        autoComplete="off"
                         disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
@@ -262,14 +253,12 @@ function DriftParameters(props: Props) {
             />
             <div className="task-parameters">
                 <div>Drift Time</div>
-                <input
+                <JaiaNumberInput
                     name={TaskParameterKeys.DRIFT_TIME}
-                    type="number"
                     value={formatNumericalInput(props.task.getDriftParameters().drift_time)}
                     className="jaia-input"
-                    autoComplete="off"
                     disabled={props.isDisabled}
-                    onChange={(evt) => props.onChange(evt)}
+                    onChange={props.onChange}
                 />
                 <div className="units">s</div>
             </div>
@@ -315,12 +304,10 @@ function ConstantHeading(props: Props) {
                 return <div>Safety Depth</div>;
             case TaskParameterElements.INPUT:
                 return (
-                    <input
+                    <JaiaNumberInput
                         name={TaskParameterKeys.SAFETY_DEPTH}
-                        type="number"
                         value={formatNumericalInput(props.task.getSafetyDepth())}
                         className="jaia-input srp"
-                        autoComplete="off"
                         disabled={props.isDisabled}
                         onChange={(evt) => props.onChange(evt)}
                     />
@@ -346,36 +333,30 @@ function ConstantHeading(props: Props) {
             </div>
 
             <div>Heading</div>
-            <input
+            <JaiaNumberInput
                 name={TaskParameterKeys.HEADING}
-                type="number"
                 value={formatNumericalInput(constantHeadingParameters.constant_heading)}
                 className="jaia-input"
-                autoComplete="off"
                 disabled={props.isDisabled}
                 onChange={(evt) => props.onChange(evt)}
             />
             <div className="units">deg</div>
 
             <div>Time</div>
-            <input
+            <JaiaNumberInput
                 name={TaskParameterKeys.CONSTANT_HEADING_TIME}
-                type="number"
                 value={formatNumericalInput(constantHeadingParameters.constant_heading_time)}
                 className="jaia-input"
-                autoComplete="off"
                 disabled={props.isDisabled}
                 onChange={(evt) => props.onChange(evt)}
             />
             <div className="units">s</div>
 
             <div>Speed</div>
-            <input
+            <JaiaNumberInput
                 name={TaskParameterKeys.SPEED}
-                type="number"
                 value={formatNumericalInput(constantHeadingParameters.constant_heading_speed)}
                 className="jaia-input"
-                autoComplete="off"
                 disabled={props.isDisabled}
                 onChange={(evt) => props.onChange(evt)}
             />
@@ -406,14 +387,12 @@ function StationKeepParameters(props: Props) {
             />
             <div className="task-parameters">
                 <div>Time</div>
-                <input
+                <JaiaNumberInput
                     name={TaskParameterKeys.STATION_KEEP_TIME}
-                    type="number"
                     value={formatNumericalInput(
                         props.task.getStationKeepParameters().station_keep_time,
                     )}
                     className="jaia-input"
-                    autoComplete="off"
                     disabled={props.isDisabled}
                     onChange={(evt) => props.onChange(evt)}
                 />


### PR DESCRIPTION
## Summary
The Mission Repeats field was a normal text field and the number fields in the Survey Planner and Waypoint task panels had no increment/decrement controls on a tablet. Initially I tried to restore the browser's standard `type="number"` arrow buttons, but those are mouse exclusive and aren't rendered on a tablet. 

The current version of the PR instead uses a `JaiaNumberInput` component with its own up/down buttons that work the same on laptop and tablet. These buttons are applied to the three fields mentioned above. 

## Changes Made

`src/web/components/JaiaNumberInput/` (new files)
New component `JaiaNumberInput` renders a `type="number"` input with a up/down button pair aligned to the right side of the field. It also exports `StepperButtons` on its own so the buttons can be reused elsewhere. The `.less` formats the buttons and lets them keep the surrounding panel's text color.

`src/web/components/MissionsPanel/MissionsList/MissionsList.tsx`
Mission Repeats is now `type="number"` with a minimum value of 1. 

`src/web/components/MissionsPanel/MissionsList/MissionsList.less`
Hides the browser's standard arrows on the Repeats field so desktop doesn't show the browser arrows and the custom buttons.

`src/web/components/SurveyPlanner/SurveyPlanner.tsx` / `.less`
The four inputs (lanes, bots, lane spacing, point spacing) now use `JaiaNumberInput` so the arrows are displayed. Also altered formatting so the values remain next to the buttons.

`src/web/components/WaypointPanel/TaskParameters/TaskParameters.tsx` / `.less`
All task related number inputs (depths, times, heading, speed, etc.) now use `JaiaNumberInput`.

## Testing
Verified in sim on both desktop and the tablet mode found in the device toolbar.
