### PR TITLE
3D Map now fills entire window

### DIFF
--- a/src/web/components/DepthMap3D/DepthMap3D.less
+++ b/src/web/components/DepthMap3D/DepthMap3D.less
@@ -3,6 +3,7 @@
     flex-direction: column;
     background-color: #fff;
     padding: 12px;
+    box-sizing: border-box;
 
     position: absolute;
 }
@@ -38,4 +39,10 @@
 .depth-menu button {
     all: unset;
     width: 30px;
+}
+
+.depth-map-3D-plot {
+    flex: 1;
+    min-height: 0;
+    width: 100%;
 }

--- a/src/web/components/DepthMap3D/DepthMap3D.tsx
+++ b/src/web/components/DepthMap3D/DepthMap3D.tsx
@@ -40,7 +40,7 @@ export default function DepthMap3D() {
                 setWindowPosition={setWindowPosition}
                 onClose={onClose}
             />
-            <div id={DEPTH_MAP_3D_NAME}></div>
+            <div id={DEPTH_MAP_3D_NAME} className="depth-map-3D-plot"></div>
         </div>
     );
 }


### PR DESCRIPTION
## Description:

Modified the JCC's 3D Depth Map to fill its entire window

## Tests:
(On the JCC)

1. Create a mission that generates a depth map
2. Double-Click on the depth map
3. Verify that the 3D Depth Map fills the entire window that is displayed rather than a small portion