### PR TITLE
task/limit-bandwidth-of-major-upgrade

### DIFF
--- a/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
+++ b/config/ansible/major_upgrade/tasks/get-new-filesystems.yml
@@ -4,27 +4,41 @@
     upgrade_boot_url: 'http://{{ hub_ip }}/updates/major_upgrade/{{ major_upgrade_rootfs_version }}.boot.tar.gz'    
 
 - name: Download the upgrade image boot fs
-  get_url:
-    url: "{{ upgrade_boot_url }}"
-    dest: "{{ upgrade_dir }}"
-    checksum: "{{ major_upgrade_bootfs_checksum }}"
-    force: true
-  environment:
-    TMPDIR: "{{ upgrade_tmp_dir }}"
+  shell: |
+    set -e -o pipefail
+    dest="{{ upgrade_dir }}/{{ major_upgrade_rootfs_version }}.boot.tar.gz"
+    checksum="{{ major_upgrade_bootfs_checksum | regex_replace('^sha256:', '') }}"
+    # skip a matching, already-downloaded file, letting an interrupted
+    # upgrade resume without re-copying the image.
+    if [ -f "$dest" ] && echo "$checksum  $dest" | sha256sum -c - --status; then
+      exit 0
+    fi
+    tmp="${dest}.part"
+    curl -f -sS --limit-rate 1500K -o "$tmp" "{{ upgrade_boot_url }}"
+    echo "$checksum  $tmp" | sha256sum -c - --status
+    mv "$tmp" "$dest"
+  args:
+    executable: /bin/bash
   throttle: 1
   register: download_result
   until: download_result is success
   retries: 3
   delay: 10
-    
+
 - name: Download the upgrade image rootfs
-  get_url:
-    url: "{{ upgrade_rootfs_url }}"
-    dest: "{{ upgrade_dir }}"
-    checksum: "{{ major_upgrade_rootfs_checksum }}"
-    force: true
-  environment:
-    TMPDIR: "{{ upgrade_tmp_dir }}"
+  shell: |
+    set -e -o pipefail
+    dest="{{ upgrade_dir }}/{{ major_upgrade_rootfs_version }}.rootfs.tar.gz"
+    checksum="{{ major_upgrade_rootfs_checksum | regex_replace('^sha256:', '') }}"
+    if [ -f "$dest" ] && echo "$checksum  $dest" | sha256sum -c - --status; then
+      exit 0
+    fi
+    tmp="${dest}.part"
+    curl -f -sS --limit-rate 1500K -o "$tmp" "{{ upgrade_rootfs_url }}"
+    echo "$checksum  $tmp" | sha256sum -c - --status
+    mv "$tmp" "$dest"
+  args:
+    executable: /bin/bash
   throttle: 1
   register: download_result
   until: download_result is success


### PR DESCRIPTION
## Description

This pull request updates the way upgrade image files are downloaded in the `get-new-filesystems.yml` Ansible task. Instead of using the built-in `get_url` module, it now uses a shell script with `curl` for downloading, which adds logic to skip already-downloaded and verified files, supports resumable downloads, and ensures checksum validation before moving files into place.

**Download process improvements:**

* Replaces the `get_url` Ansible module with a shell script using `curl` for both boot and rootfs image downloads, allowing for more granular control over the download process.
* Adds logic to skip downloads if the target file already exists and passes checksum validation, improving idempotency and supporting interrupted upgrade resumption.
* Downloads to a temporary `.part` file, verifies the checksum, and only then moves the file into its final location to prevent incomplete or corrupted files from being used.
* Explicitly strips the `sha256:` prefix from checksums to ensure compatibility with `sha256sum` validation.
* Sets a download rate limit with `curl` for more predictable network usage during upgrades.get_url's dest was a bare directory combined with force: true, so it always re-downloaded the full image from scratch on every retry. Switch to a curl-based download with an explicit temp file + checksum gate so a matching, already-downloaded image is skipped, and cap throughput (1500K/s) to avoid saturating the hub's shared radio link while pushing images to bots.