### PR TITLE
feature/jcu-automate-software-checkout

### DIFF
--- a/config/ansible/software-checkout.yml
+++ b/config/ansible/software-checkout.yml
@@ -16,7 +16,7 @@
       shell: "rm -rf /var/log/jaiabot/bot_offload/*"
 
 - name: Software Checkout - Test VPN connectivity
-  hosts: hubs
+  hosts: all
   gather_facts: no
   become: yes
   any_errors_fatal: true
@@ -49,7 +49,7 @@
   become: yes
   tasks:
     - name: Update apt cache
-      # in some case the "apt" module was not doing an update
+      # in some cases the apt module was not doing an update
       shell: "apt-get update"
 
     - include_tasks: tasks/get-version.yml

--- a/config/ansible/software-checkout.yml
+++ b/config/ansible/software-checkout.yml
@@ -1,0 +1,73 @@
+---
+- name: Software Checkout - Clear bot log data
+  hosts: bots
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Remove bot log data
+      shell: "rm -rf /var/log/jaiabot/bot/*"
+
+- name: Software Checkout - Clear hub bot offload data
+  hosts: hubs
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Remove hub bot offload data
+      shell: "rm -rf /var/log/jaiabot/bot_offload/*"
+
+- name: Software Checkout - Test VPN connectivity
+  hosts: hubs
+  gather_facts: no
+  become: yes
+  any_errors_fatal: true
+  tasks:
+    - name: Ping fleet VPN address
+      shell: "ping -c 3 172.23.{{ fleet_index }}.1"
+      register: vpn_ping_result
+      failed_when: false
+
+    - name: Set fact for VPN ping result
+      set_fact:
+        jaiabot_vpn_ping_result: "{{ 'reachable' if vpn_ping_result.rc == 0 else 'unreachable' }}"
+
+    - name: Abort checkout if VPN is unreachable
+      ansible.builtin.fail:
+        msg: "VPN connectivity test failed: unable to ping 172.23.{{ fleet_index }}.1"
+      when: vpn_ping_result.rc != 0
+
+- name: Software Checkout - Disable VPN
+  hosts: all
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Disable wg_jaia VPN
+      shell: "systemctl disable wg-quick@wg_jaia"
+
+- name: Software Checkout - Verify latest software version
+  hosts: all
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Update apt cache
+      # in some case the "apt" module was not doing an update
+      shell: "apt-get update"
+
+    - include_tasks: tasks/get-version.yml
+
+    - name: Set fact if upgrade available
+      set_fact:
+        jaiabot_upgrade_available: "{{ jaiabot_current_version != jaiabot_available_version }}"
+
+- name: Software Checkout - Switch JCU user profile from advanced to user
+  hosts: hubs
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: Set JCU role to user in runtime environment
+      ansible.builtin.lineinfile:
+        path: /etc/jaiabot/runtime.env
+        regexp: "^jaia_user_role="
+        line: "jaia_user_role=user"
+
+    - name: Restart JCU to apply new role
+      shell: "nohup /bin/bash -c 'sleep 5 && systemctl restart jaiabot_goby_liaison_standalone' > /dev/null &"

--- a/config/ansible/software-checkout.yml
+++ b/config/ansible/software-checkout.yml
@@ -20,6 +20,13 @@
   gather_facts: no
   become: yes
   any_errors_fatal: true
+  pre_tasks:
+    - name: Check that fleet_index is a valid integer
+      ansible.builtin.assert:
+        that:
+          - fleet_index is defined
+          - fleet_index | string is match("^[0-9]+$")
+        fail_msg: "Invalid fleet_index. Must be a non-negative integer."
   tasks:
     - name: Ping fleet VPN address
       shell: "ping -c 3 172.23.{{ fleet_index }}.1"
@@ -68,6 +75,8 @@
         path: /etc/jaiabot/runtime.env
         regexp: "^jaia_user_role="
         line: "jaia_user_role=user"
+      register: jcu_role_result
 
     - name: Restart JCU to apply new role
       shell: "nohup /bin/bash -c 'sleep 5 && systemctl restart jaiabot_goby_liaison_standalone' > /dev/null &"
+      when: jcu_role_result is changed

--- a/config/gen/hub.py
+++ b/config/gen/hub.py
@@ -248,6 +248,7 @@ elif common.app == 'goby_liaison_prelaunch':
                                      inventory=inventory,
                                      vfleet_playbooks=vfleet_playbooks,
                                      this_hub_index=hub_index,
+                                     fleet_index=fleet_index,
                                      limit=limit,
                                      ansible_log_dir=common.jaia_log_dir + '/ansible'))
 elif common.app == 'goby_gps':

--- a/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
+++ b/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
@@ -136,7 +136,6 @@ upper_right_logo_link: "https://www.jaia.tech/"
         $limit
     }
 
-    
     ansible_playbook {
         file: "software-checkout.yml"
         name: "Software Checkout"

--- a/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
+++ b/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
@@ -138,7 +138,39 @@ upper_right_logo_link: "https://www.jaia.tech/"
 
     
     ansible_playbook {
-        file: "check-vpn-status.yml" 
+        file: "software-checkout.yml"
+        name: "Software Checkout"
+        section: "Checkout"
+        role: ADVANCED
+        confirmation_required: true
+
+        input_var {
+            name: "fleet_index"
+            display_name: "Fleet Index"
+            static_value: "$fleet_index"
+        }
+
+        output_var {
+            name: "jaiabot_vpn_ping_result"
+            display_name: "VPN Connectivity"
+        }
+        output_var {
+            name: "jaiabot_current_version"
+            display_name: "Current JaiaBot Version"
+        }
+        output_var {
+            name: "jaiabot_available_version"
+            display_name: "New Available JaiaBot Version"
+        }
+        output_var {
+            name: "jaiabot_upgrade_available"
+            display_name: "Minor Upgrade available?"
+        }
+        $limit
+    }
+
+    ansible_playbook {
+        file: "check-vpn-status.yml"
         name: "Check for VPN Status"
         section: "Security"
         role: USER


### PR DESCRIPTION
## Summary
Automates the software checkout process with a new Ansible playbook for the JCU.

## Changes Included

- `config/ansible/software-checkout.yml`: Added a new playbook to automate key checkout tasks:

  - Clears bot logs (`/var/log/jaiabot/bot/\*`) and hub offload logs (`/var/log/jaiabot/bot_offload/\*`).

  - Tests VPN by pinging the fleet VPN address and aborts if unreachable.

  - Disables the `wg_jaia` WireGuard VPN.

  - Verifies updated JaiaBot software version.

  - Switches the JCU user profile role from advanced to user in `/etc/jaiabot/runtime.env` and restarts the liaison service.

- `config/templates/hub/goby_liaison_prelaunch.pb.cfg.in`: Added the Software Checkout playbook entry for advanced users along with input/output variables.

- `config/gen/hub.py`: Updated config to pass `fleet_index` through to the hub config.

## Testing (in progress)

- [ ] Checked Ansible playbook execution across hubs and bots. 

- [ ] Confirmed VPN checks pass/fail as expected.

- [ ] Verified JCU user role reverts from advanced to user and restarts the service.