### PR TITLE
task/map-layers-persist-through-refresh

### DIFF
--- a/src/web/openlayers/layers/offline/offline-layer-manager.ts
+++ b/src/web/openlayers/layers/offline/offline-layer-manager.ts
@@ -1,7 +1,7 @@
 import TileLayer from "ol/layer/Tile";
 import { XYZ, TileImage } from "ol/source";
 import { Collection, View } from "ol";
-import { map } from "../../maps/map";
+import { map, mapSettings, saveSettings } from "../../maps/map";
 import { view } from "../../views/view";
 import { jaiaAPI } from "../../../utils/jaia-api";
 
@@ -185,10 +185,17 @@ class OfflineLayerManager {
                         title: tileSet.name,
                         size: tileSet.size,
                     },
-                    visible: false,
+                    visible: mapSettings.visibleOfflineLayers?.includes(tileSet.name) ?? false,
                     source: new XYZ({
                         url: `/maps/${tileSet.name}/{z}/{x}/{y}`,
                     }),
+                });
+                layer.on("change:visible", () => {
+                    mapSettings.visibleOfflineLayers = this.layers
+                        .getArray()
+                        .filter((l) => l.getVisible())
+                        .map((l) => l.get("title"));
+                    saveSettings();
                 });
                 this.layers.push(layer);
                 map.addLayer(layer);

--- a/src/web/openlayers/maps/map.ts
+++ b/src/web/openlayers/maps/map.ts
@@ -18,6 +18,7 @@ import { OSM_MAX_ZOOM } from "../../utils/constants";
 
 interface MapSettings {
     visibleLayers: LayerTitles[];
+    visibleOfflineLayers: string[];
     center: Coordinate;
     zoomLevel: number;
     rotation: number;
@@ -27,7 +28,7 @@ const WRITE_DELAY = 500; // ms
 
 // Load map settings (if any) from localStorage
 const saved = localStorage.getItem("mapSettings");
-const mapSettings: MapSettings = saved ? JSON.parse(saved) : {};
+export const mapSettings: MapSettings = saved ? JSON.parse(saved) : {};
 
 // Apply saved map settings
 if (mapSettings.center) {
@@ -38,6 +39,11 @@ if (mapSettings.zoomLevel) {
 }
 if (mapSettings.rotation) {
     view.setRotation(mapSettings.rotation);
+}
+if (mapSettings.visibleLayers) {
+    for (const [layerTitle, layer] of layers.getLayers()) {
+        layer.setVisible(mapSettings.visibleLayers.includes(layerTitle));
+    }
 }
 
 export const map = new Map({
@@ -148,7 +154,7 @@ function debounce(fn: () => void, delay: number) {
  *
  * @returns {void}
  */
-const saveSettings = debounce(() => {
+export const saveSettings = debounce(() => {
     localStorage.setItem("mapSettings", JSON.stringify(mapSettings));
 }, WRITE_DELAY);
 
@@ -169,6 +175,16 @@ map.getView().on("change:rotation", () => {
     mapSettings.rotation = map.getView().getRotation();
     saveSettings();
 });
+
+// Persist visible layers
+for (const layer of layers.getLayers().values()) {
+    layer.on("change:visible", () => {
+        mapSettings.visibleLayers = Array.from(layers.getLayers())
+            .filter(([, l]) => l.getVisible())
+            .map(([layerTitle]) => layerTitle);
+        saveSettings();
+    });
+}
 
 // Track touch events for drag conditions
 const viewport = map.getViewport();


### PR DESCRIPTION
## Summary

Map layers now persist through JCC page refreshes by saving to local storage. 

## Changes

- `src/web/openlayers/maps/map.ts`:
  - Now exports `mapSettings` and `saveSettings()`
  - Added `visibleOfflineLayers` to `MapSettings`
  - Saved layers get applied on map initialization
  - Listen for `change:visible` on map layers to automatically update `visibleLayers` and call `saveSettings()`
- `src/web/openlayers/layers/offline/offline-layer-manager.ts`:
  - Use `visibleOfflineLayers` to set initial offline layer visibility
  - Listen for `change:visible` to sync `visibleOfflineLayers`

## Testing

- [ ] Test on flat fleet
  - [ ] Toggle a layer off and confirm it stays off through refresh
  - [ ] Toggle an offline map layer on and confirm it stays on through refresh