### PR TITLE
feature/transfer-logs-to-external-drive

### DIFF
--- a/rootfs/customization/package-lists/tools.list.chroot
+++ b/rootfs/customization/package-lists/tools.list.chroot
@@ -15,6 +15,10 @@ gpsd-clients
 ntp
 rsync
 xz-utils
+## USB drive filesystems
+dosfstools
+exfatprogs
+ntfs-3g
 ## for stress testing
 stress
 memtester

--- a/rootfs/customization/package-lists/tools.list.chroot
+++ b/rootfs/customization/package-lists/tools.list.chroot
@@ -15,10 +15,6 @@ gpsd-clients
 ntp
 rsync
 xz-utils
-## USB drive filesystems
-dosfstools
-exfatprogs
-ntfs-3g
 ## for stress testing
 stress
 memtester

--- a/src/web/jdv/client/src/model/LogApi.ts
+++ b/src/web/jdv/client/src/model/LogApi.ts
@@ -24,9 +24,11 @@ export interface ConvertStatus {
  */
 export interface UsbOffloadStatus {
     isCopying: boolean;
-    logsRemaining: number;
+    logsCopied: number;
     logsTotal: number;
-    error?: string;
+    percentComplete: number;
+    errorMessage?: string;
+    isDriveAvailable: boolean;
 }
 
 /**

--- a/src/web/jdv/client/src/model/LogApi.ts
+++ b/src/web/jdv/client/src/model/LogApi.ts
@@ -17,6 +17,19 @@ export interface ConvertStatus {
 }
 
 /**
+ * Progress of the current (or most recent) copy of logs to a USB drive plugged into the hub
+ *
+ * @interface UsbOffloadStatus
+ * @typedef {UsbOffloadStatus}
+ */
+export interface UsbOffloadStatus {
+    isCopying: boolean;
+    logsRemaining: number;
+    logsTotal: number;
+    error?: string;
+}
+
+/**
  * Initiates a browser download of the given URL, with filename and mimeType
  *
  * @param {string} url URL of the target
@@ -315,6 +328,25 @@ export class LogApi {
      */
     static async postConvertIfNeeded(logs: string[]) {
         return (await this.post("/jdv/convert-if-needed", logs)) as ConvertStatus;
+    }
+
+    /**
+     * Starts copying a set of logs to the USB drive plugged into the hub
+     *
+     * @param {string[]} logs Array of log names
+     * @returns {Promise<UsbOffloadStatus>} The status of the copy operation
+     */
+    static async postCopyToUSB(logs: string[]) {
+        return (await this.post("/jdv/copy-to-usb", logs)) as UsbOffloadStatus;
+    }
+
+    /**
+     * Gets the progress of the current (or most recent) copy of logs to a USB drive
+     *
+     * @returns {Promise<UsbOffloadStatus>} The status of the copy operation
+     */
+    static async getCopyToUSBStatus() {
+        return (await this.getJSON("/jdv/copy-to-usb")) as UsbOffloadStatus;
     }
 
     static async getAllSeriesDescriptors(logs: string[]) {

--- a/src/web/jdv/client/src/model/LogApi.ts
+++ b/src/web/jdv/client/src/model/LogApi.ts
@@ -18,9 +18,6 @@ export interface ConvertStatus {
 
 /**
  * Progress of the current (or most recent) copy of logs to a USB drive plugged into the hub
- *
- * @interface UsbOffloadStatus
- * @typedef {UsbOffloadStatus}
  */
 export interface UsbOffloadStatus {
     isCopying: boolean;

--- a/src/web/jdv/client/src/styles/styles.css
+++ b/src/web/jdv/client/src/styles/styles.css
@@ -427,7 +427,6 @@ div.spacer {
     flex-grow: 1;
 }
 
-/* Highlights on mount, which LogSelector uses to draw the eye whenever the copy changes state */
 .copyStatus {
     align-self: center;
     border-radius: 4pt;

--- a/src/web/jdv/client/src/styles/styles.css
+++ b/src/web/jdv/client/src/styles/styles.css
@@ -427,6 +427,26 @@ div.spacer {
     flex-grow: 1;
 }
 
+/* Highlights on mount, which LogSelector uses to draw the eye whenever the copy changes state */
+.copyStatus {
+    align-self: center;
+    border-radius: 4pt;
+    animation: copyStatusChanged 1.5s ease-out;
+}
+
+@keyframes copyStatusChanged {
+    from {
+        background-color: khaki;
+    }
+    to {
+        background-color: transparent;
+    }
+}
+
+.success {
+    color: green;
+}
+
 .danger {
     color: red;
 }

--- a/src/web/jdv/client/src/ui/LogSelector.tsx
+++ b/src/web/jdv/client/src/ui/LogSelector.tsx
@@ -60,6 +60,13 @@ interface LogSelectorProps {
     delegate: LogSelectorDelegate;
 }
 
+// What the status text beside the Copy to USB button should say, and how to style it
+interface UsbOffloadDisplay {
+    name: string;
+    className: string;
+    text: string;
+}
+
 interface LogSelectorState {
     logDict: LogDict;
     availableSpace: number;
@@ -178,9 +185,6 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
 
                 <div className="section">
                     <div>{this.availableSpaceString()} available</div>
-                    {this.state.usbOffloadStatus?.error ? (
-                        <div className="danger">{this.state.usbOffloadStatus.error}</div>
-                    ) : null}
                 </div>
 
                 {this.buttonsElement()}
@@ -258,9 +262,75 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
         return row;
     }
 
+    /**
+     * Describes the copy to USB in progress, or the outcome of the last one.  This is the only
+     * place the copy reports itself: the button beside it always reads the same.
+     *
+     * @returns {UsbOffloadDisplay} What to say and how to style it, or null before the session's
+     *   first copy, when there is nothing to report
+     */
+    usbOffloadDisplay(): UsbOffloadDisplay | null {
+        const status = this.state.usbOffloadStatus;
+
+        if (status == null || status.logsTotal == 0) {
+            return null;
+        }
+
+        if (status.errorMessage) {
+            return {
+                name: "failed",
+                className: "danger",
+                text: `Copy failed: ${status.errorMessage}`,
+            };
+        }
+
+        if (!status.isCopying) {
+            const logCount = `${status.logsTotal} log${status.logsTotal == 1 ? "" : "s"}`;
+            return {
+                name: "done",
+                className: "success",
+                text: `Copied ${logCount} — safe to remove drive`,
+            };
+        }
+
+        // Every byte is written well before the drive is unmounted, and unmounting a large copy
+        // flushes for long enough that a stalled "100%" would read as a hang
+        if (status.logsCopied == status.logsTotal) {
+            return {
+                name: "finishing",
+                className: "",
+                text: "Finishing — do not remove the drive",
+            };
+        }
+
+        const text = `Copying log ${status.logsCopied + 1} of ${status.logsTotal} — ${status.percentComplete}%`;
+        return { name: "copying", className: "", text };
+    }
+
+    /**
+     * Returns the status text shown beside the Copy to USB button
+     *
+     * @returns {ReactElement} The status element, or null if there is nothing to report
+     */
+    usbOffloadStatusElement(): ReactElement | null {
+        const display = this.usbOffloadDisplay();
+
+        if (display == null) {
+            return null;
+        }
+
+        // Keying on the state name remounts this element whenever the copy moves between states,
+        // replaying the highlight so the change is noticed.  The percentage ticking up within a
+        // state reuses the same key, and so does not flash.
+        return (
+            <div key={display.name} className={`copyStatus padded ${display.className}`}>
+                {display.text}
+            </div>
+        );
+    }
+
     buttonsElement() {
-        const usbOffloadStatus = this.state.usbOffloadStatus;
-        const isCopying = usbOffloadStatus?.isCopying ?? false;
+        const isDriveAvailable = this.state.usbOffloadStatus?.isDriveAvailable ?? false;
 
         return (
             <div className="buttonSection section">
@@ -274,12 +344,11 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
                 <button
                     className="padded"
                     onClick={this.copyToUSBClicked.bind(this)}
-                    disabled={Object.keys(this.state.selectedLogs).length == 0 || isCopying}
+                    disabled={Object.keys(this.state.selectedLogs).length == 0 || !isDriveAvailable}
                 >
-                    {isCopying
-                        ? `Copying ${usbOffloadStatus.logsTotal - usbOffloadStatus.logsRemaining}/${usbOffloadStatus.logsTotal}`
-                        : "Copy to USB"}
+                    Copy to USB
                 </button>
+                {this.usbOffloadStatusElement()}
                 <div className="spacer"></div>
                 <button className="padded" onClick={this.cancelClicked.bind(this)}>
                     Cancel

--- a/src/web/jdv/client/src/ui/LogSelector.tsx
+++ b/src/web/jdv/client/src/ui/LogSelector.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
 
 import { Log } from "../model/Log";
-import { LogApi } from "../model/LogApi";
+import { LogApi, UsbOffloadStatus } from "../model/LogApi";
 import { CustomAlert } from "../shared/CustomAlert";
 
 function getNavigatorLanguage() {
@@ -68,6 +68,7 @@ interface LogSelectorState {
     fromDate: string;
     toDate: string;
     selectedLogs: { [key: string]: Log };
+    usbOffloadStatus: UsbOffloadStatus;
 }
 
 // Dropdown menu showing all of the available logs to choose from
@@ -87,6 +88,7 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
             fromDate: localStorage.getItem("fromDate"),
             toDate: localStorage.getItem("toDate"),
             selectedLogs: {},
+            usbOffloadStatus: null,
         };
 
         this.refreshLogs();
@@ -176,6 +178,9 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
 
                 <div className="section">
                     <div>{this.availableSpaceString()} available</div>
+                    {this.state.usbOffloadStatus?.error ? (
+                        <div className="danger">{this.state.usbOffloadStatus.error}</div>
+                    ) : null}
                 </div>
 
                 {this.buttonsElement()}
@@ -254,6 +259,9 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
     }
 
     buttonsElement() {
+        const usbOffloadStatus = this.state.usbOffloadStatus;
+        const isCopying = usbOffloadStatus?.isCopying ?? false;
+
         return (
             <div className="buttonSection section">
                 <button
@@ -262,6 +270,15 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
                     disabled={Object.keys(this.state.selectedLogs).length == 0}
                 >
                     Delete Logs
+                </button>
+                <button
+                    className="padded"
+                    onClick={this.copyToUSBClicked.bind(this)}
+                    disabled={Object.keys(this.state.selectedLogs).length == 0 || isCopying}
+                >
+                    {isCopying
+                        ? `Copying ${usbOffloadStatus.logsTotal - usbOffloadStatus.logsRemaining}/${usbOffloadStatus.logsTotal}`
+                        : "Copy to USB"}
                 </button>
                 <div className="spacer"></div>
                 <button className="padded" onClick={this.cancelClicked.bind(this)}>
@@ -490,9 +507,25 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
     }
 
     /**
-     * Calls the API to get the list of logs, updating the GUI accordingly
+     * Copies the selected logs to the USB drive plugged into the hub
+     */
+    async copyToUSBClicked() {
+        const logNames = Object.values(this.state.selectedLogs).map((log) => {
+            return log.filename;
+        });
+
+        const usbOffloadStatus = await LogApi.postCopyToUSB(logNames);
+        this.setState({ usbOffloadStatus });
+    }
+
+    /**
+     * Calls the API to get the list of logs and the USB copy progress, updating the GUI accordingly
      */
     refreshLogs() {
+        LogApi.getCopyToUSBStatus().then((usbOffloadStatus) => {
+            this.setState({ usbOffloadStatus });
+        });
+
         LogApi.get_logs().then((response) => {
             const logDict = LogSelector.getLogDictFromLogList(response.logs);
             this.setState({ logDict, availableSpace: response.availableSpace });

--- a/src/web/jdv/client/src/ui/LogSelector.tsx
+++ b/src/web/jdv/client/src/ui/LogSelector.tsx
@@ -275,16 +275,21 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
     usbOffloadDisplay(): UsbOffloadDisplay | null {
         const status = this.state.usbOffloadStatus;
 
-        if (status == null || status.logsTotal == 0) {
+        if (status == null) {
             return null;
         }
 
+        // Checked before logsTotal, since a copy whose logs were all deleted ends with none
         if (status.errorMessage) {
             return {
                 name: "failed",
                 className: "danger",
                 text: `Copy failed: ${status.errorMessage}`,
             };
+        }
+
+        if (status.logsTotal == 0) {
+            return null;
         }
 
         if (!status.isCopying) {
@@ -587,9 +592,14 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
         this.copyStartedAt = Date.now();
         const usbOffloadStatus = await LogApi.postCopyToUSB(logNames);
 
-        if (usbOffloadStatus) {
-            this.setState({ usbOffloadStatus });
+        // LogApi.post resolves to undefined when the request fails.  No copy started, so there is
+        // no status for polling to report and the click would pass silently: say so directly.
+        if (!usbOffloadStatus) {
+            CustomAlert.alert("Could not start the copy to USB.  Please try again.");
+            return;
         }
+
+        this.setState({ usbOffloadStatus });
     }
 
     /**

--- a/src/web/jdv/client/src/ui/LogSelector.tsx
+++ b/src/web/jdv/client/src/ui/LogSelector.tsx
@@ -84,6 +84,9 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
 
     refreshTimer: NodeJS.Timeout;
 
+    // When Copy to USB was last clicked, used to discard status polls older than that click
+    copyStartedAt: number = 0;
+
     constructor(props: LogSelectorProps) {
         super(props);
 
@@ -581,16 +584,24 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
             return log.filename;
         });
 
+        this.copyStartedAt = Date.now();
         const usbOffloadStatus = await LogApi.postCopyToUSB(logNames);
-        this.setState({ usbOffloadStatus });
+
+        if (usbOffloadStatus) {
+            this.setState({ usbOffloadStatus });
+        }
     }
 
     /**
      * Calls the API to get the list of logs and the USB copy progress, updating the GUI accordingly
      */
     refreshLogs() {
+        const requestedAt = Date.now();
+
         LogApi.getCopyToUSBStatus().then((usbOffloadStatus) => {
-            this.setState({ usbOffloadStatus });
+            if (requestedAt >= this.copyStartedAt) {
+                this.setState({ usbOffloadStatus });
+            }
         });
 
         LogApi.get_logs().then((response) => {

--- a/src/web/jdv/client/src/ui/LogSelector.tsx
+++ b/src/web/jdv/client/src/ui/LogSelector.tsx
@@ -60,7 +60,7 @@ interface LogSelectorProps {
     delegate: LogSelectorDelegate;
 }
 
-// What the status text beside the Copy to USB button should say, and how to style it
+// What the status text beside the Copy to USB button says, and how to style it
 interface UsbOffloadDisplay {
     name: string;
     className: string;
@@ -267,7 +267,7 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
      * place the copy reports itself: the button beside it always reads the same.
      *
      * @returns {UsbOffloadDisplay} What to say and how to style it, or null before the session's
-     *   first copy, when there is nothing to report
+     *   first copy
      */
     usbOffloadDisplay(): UsbOffloadDisplay | null {
         const status = this.state.usbOffloadStatus;
@@ -293,8 +293,7 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
             };
         }
 
-        // Every byte is written well before the drive is unmounted, and unmounting a large copy
-        // flushes for long enough that a stalled "100%" would read as a hang
+        // Unmounting a large copy flushes for long enough that a stalled "100%" would read as a hang
         if (status.logsCopied == status.logsTotal) {
             return {
                 name: "finishing",
@@ -319,9 +318,8 @@ export default class LogSelector extends React.Component<LogSelectorProps, LogSe
             return null;
         }
 
-        // Keying on the state name remounts this element whenever the copy moves between states,
-        // replaying the highlight so the change is noticed.  The percentage ticking up within a
-        // state reuses the same key, and so does not flash.
+        // Keying on the state name remounts this element on every state change, replaying the
+        // highlight.  A ticking percentage keeps the same key, so it does not flash.
         return (
             <div key={display.name} className={`copyStatus padded ${display.className}`}>
                 {display.text}

--- a/src/web/jdv/server/jaiabot_data_vision.py
+++ b/src/web/jdv/server/jaiabot_data_vision.py
@@ -19,6 +19,8 @@ import traceback
 from pyjaia import jaialog_store
 from pyjaia.jaialog_store import moos_messages
 
+import usb_offload
+
 
 l = logging.getLogger(os.path.basename(__file__))
 
@@ -30,6 +32,12 @@ def parseFilenames(input: str):
         return None
     else:
         return input.split(',')
+
+def validateLogNames(logNames: list[str]):
+    '''Raises a ValueError if any of these log names could refer to a file outside the log directory'''
+    for logName in logNames:
+        if not logName or '/' in logName or '\\' in logName or logName.startswith('.') or '..' in logName:
+            raise ValueError(f'Invalid log name: {logName!r}')
 
 ####### Responses
 
@@ -80,6 +88,18 @@ def getLogs():
 def convertLogs():
     log_names = request.json
     return JSONResponse(jaialogStore.convertIfNeeded(log_names))
+
+@app.route('/jdv/copy-to-usb', methods=['POST'])
+def copyLogsToUSB():
+    '''Start copying a list of logs to the USB drive plugged into the hub'''
+    log_names = request.json
+    validateLogNames(log_names)
+    return JSONResponse(usbOffloadManager.addLogNames(log_names).to_dict())
+
+@app.route('/jdv/copy-to-usb', methods=['GET'])
+def getCopyToUSBStatus():
+    '''Get the progress of the current (or most recent) copy to a USB drive'''
+    return JSONResponse(usbOffloadManager.getStatus().to_dict())
 
 @app.route('/jdv/log/<logName>', methods=['DELETE'])
 def deleteLog(logName: str):
@@ -244,6 +264,7 @@ if __name__ == '__main__':
 
     # Setup the directory
     jaialogStore = jaialog_store.JaialogStore(args.directory)
+    usbOffloadManager = usb_offload.UsbOffloadManager(args.directory)
 
     # Print the URL for browser access
     l.info(f'Jaiabot Logs directory:           {os.path.abspath(args.directory)}')

--- a/src/web/jdv/server/tests/test_usb_offload.py
+++ b/src/web/jdv/server/tests/test_usb_offload.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+
+'''Tests for the USB log offload, with the mount and rsync layer stubbed out'''
+
+import json
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import usb_offload
+
+
+def lsblkOutput(devices):
+    '''Builds the flat lsblk JSON that findUsbPartition() parses'''
+    return json.dumps({'blockdevices': devices}).encode()
+
+
+def disk(name, tran='usb'):
+    return {'name': name, 'path': f'/dev/{name}', 'pkname': None, 'tran': tran,
+            'fstype': None, 'label': None, 'type': 'disk', 'size': 0, 'mountpoint': None}
+
+
+def partition(name, pkname, fstype='exfat', label=None, size=1000, mountpoint=None):
+    return {'name': name, 'path': f'/dev/{name}', 'pkname': pkname, 'tran': None,
+            'fstype': fstype, 'label': label, 'type': 'part', 'size': size,
+            'mountpoint': mountpoint}
+
+
+@pytest.fixture
+def fakeLsblk(monkeypatch):
+    def setDevices(devices):
+        monkeypatch.setattr(usb_offload.subprocess, 'check_output',
+                            lambda *args, **kwargs: lsblkOutput(devices))
+    return setDevices
+
+
+@pytest.fixture
+def manager(monkeypatch, tmp_path):
+    '''A manager whose privileged and slow calls do nothing, over a directory of fake logs'''
+    for name, size in (('tiny', 1_000), ('big', 100_000)):
+        for extension in ('goby', 'h5'):
+            (tmp_path / f'{name}.{extension}').write_bytes(b'x' * (size // 2))
+
+    monkeypatch.setattr(usb_offload, 'sudo', lambda *args: None)
+    monkeypatch.setattr(usb_offload.subprocess, 'run', lambda *args, **kwargs: None)
+    monkeypatch.setattr(usb_offload, 'findUsbPartition',
+                        lambda: {'path': '/dev/fake1', 'fstype': 'exfat'})
+
+    return usb_offload.UsbOffloadManager(str(tmp_path))
+
+
+def waitUntilIdle(manager, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if not manager.getStatus().isCopying:
+            return
+
+        time.sleep(0.01)
+
+    raise AssertionError('copy never finished')
+
+
+# Choosing the drive
+
+def test_finds_the_one_usb_partition(fakeLsblk):
+    fakeLsblk([disk('sda'), partition('sda1', 'sda')])
+    assert usb_offload.findUsbPartition()['path'] == '/dev/sda1'
+
+
+def test_ignores_the_hubs_own_media(fakeLsblk):
+    '''The hub boots from USB, and its fleet config card is on USB too'''
+    fakeLsblk([disk('sda'), partition('sda1', 'sda'),
+               disk('sdb'), partition('sdb1', 'sdb', 'vfat', 'boot', mountpoint='/boot/firmware'),
+               partition('sdb2', 'sdb', 'btrfs', 'rootfs', mountpoint='/'),
+               partition('sdb3', 'sdb', 'iso9660', 'updates')])
+    assert usb_offload.findUsbPartition()['path'] == '/dev/sda1'
+
+
+def test_ignores_non_usb_disks(fakeLsblk):
+    '''An SD card's partitions are hotplug, so the disk's transport is what rules them out'''
+    fakeLsblk([disk('mmcblk0', tran=None), partition('mmcblk0p1', 'mmcblk0'),
+               disk('sda'), partition('sda1', 'sda')])
+    assert usb_offload.findUsbPartition()['path'] == '/dev/sda1'
+
+
+def test_picks_the_largest_partition_of_one_drive(fakeLsblk):
+    '''A single stick can carry an EFI partition beside its data, and is still one drive'''
+    fakeLsblk([disk('sda'),
+               partition('sda1', 'sda', 'vfat', 'EFI', size=500_000),
+               partition('sda2', 'sda', 'exfat', 'DATA', size=64_000_000_000)])
+    assert usb_offload.findUsbPartition()['path'] == '/dev/sda2'
+
+
+def test_raises_when_no_drive_is_plugged_in(fakeLsblk):
+    fakeLsblk([disk('sdb'), partition('sdb1', 'sdb', 'btrfs', 'rootfs', mountpoint='/')])
+    with pytest.raises(RuntimeError, match='No USB drive found'):
+        usb_offload.findUsbPartition()
+
+
+def test_raises_when_two_drives_are_plugged_in(fakeLsblk):
+    fakeLsblk([disk('sda'), partition('sda1', 'sda'),
+               disk('sdc'), partition('sdc1', 'sdc')])
+    with pytest.raises(RuntimeError, match='2 USB drives found'):
+        usb_offload.findUsbPartition()
+
+
+def test_reports_whether_a_drive_is_available(fakeLsblk):
+    fakeLsblk([disk('sda'), partition('sda1', 'sda')])
+    assert usb_offload.hasUsbDrive()
+
+    fakeLsblk([disk('sda'), partition('sda1', 'sda', mountpoint='/media/elsewhere')])
+    assert not usb_offload.hasUsbDrive()
+
+
+# Mounting
+
+@pytest.mark.parametrize('fstype, expected', [
+    ('ntfs', ['-t', 'ntfs3']),   # plain "ntfs" resolves to the read-only driver
+    ('exfat', []),
+    ('vfat', []),
+    ('ext4', []),
+])
+def test_names_the_read_write_ntfs_driver_explicitly(monkeypatch, manager, fstype, expected):
+    calls = []
+    monkeypatch.setattr(usb_offload, 'sudo', lambda *args: calls.append(args))
+    monkeypatch.setattr(usb_offload, 'findUsbPartition',
+                        lambda: {'path': '/dev/fake1', 'fstype': fstype})
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress', lambda *args: None)
+
+    manager.addLogNames(['tiny'])
+    waitUntilIdle(manager)
+
+    mountCall = next(call for call in calls if call[0] == 'mount')
+    assert list(mountCall) == ['mount'] + expected + ['/dev/fake1', usb_offload.MOUNT_POINT]
+
+
+# The queue
+
+def test_copies_every_file_of_every_log(monkeypatch, manager):
+    copied = []
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress',
+                        lambda paths, destination, onProgress: copied.extend(paths))
+
+    manager.addLogNames(['tiny', 'big'])
+    waitUntilIdle(manager)
+
+    assert sorted(os.path.basename(path) for path in copied) == \
+        ['big.goby', 'big.h5', 'tiny.goby', 'tiny.h5']
+    assert manager.getStatus().logsCopied == 2
+    assert manager.getStatus().percentComplete == 100
+
+
+def test_logs_added_mid_copy_join_the_running_copy(monkeypatch, manager):
+    def slowRsync(paths, destination, onProgress):
+        time.sleep(0.2)
+
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress', slowRsync)
+
+    manager.addLogNames(['big'])
+    manager.addLogNames(['tiny'])
+
+    assert manager.getStatus().logsTotal == 2
+    assert manager.getStatus().isCopying
+
+    waitUntilIdle(manager)
+    assert manager.getStatus().logsCopied == 2
+
+
+def test_asking_for_the_same_log_twice_copies_it_once(monkeypatch, manager):
+    copied = []
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress',
+                        lambda paths, destination, onProgress: copied.extend(paths))
+
+    manager.addLogNames(['tiny', 'tiny'])
+    manager.addLogNames(['tiny'])
+    waitUntilIdle(manager)
+
+    assert manager.getStatus().logsTotal == 1
+    assert len(copied) == 2   # tiny.goby and tiny.h5, copied once
+
+
+def test_percentage_is_weighted_by_bytes(monkeypatch, manager):
+    '''A tiny log finishing must not report the copy as half done when a large one remains'''
+    percentWhenBigStarted = []
+
+    def rsync(paths, destination, onProgress):
+        if 'big' in os.path.basename(paths[0]):
+            percentWhenBigStarted.append(manager.getStatus().percentComplete)
+
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress', rsync)
+
+    manager.addLogNames(['tiny', 'big'])
+    waitUntilIdle(manager)
+
+    # tiny is 1% of the bytes, so counting logs instead would have claimed 50% here
+    assert percentWhenBigStarted == [0]
+    assert manager.getStatus().percentComplete == 100
+
+
+def test_a_log_deleted_before_it_is_copied_is_not_reported_as_copied(monkeypatch, manager):
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress', lambda *args: None)
+
+    manager.addLogNames(['tiny', 'vanished'])
+    waitUntilIdle(manager)
+
+    status = manager.getStatus()
+    assert status.logsCopied == 1
+    assert status.logsTotal == 1
+
+
+def test_log_names_are_matched_literally_not_as_glob_patterns(manager):
+    assert manager.pathsForLog('tiny') != []
+    assert manager.pathsForLog('*') == []
+    assert manager.pathsForLog('tin?') == []
+
+
+def test_a_failure_stops_the_copy_and_is_reported(monkeypatch, manager):
+    def failingRsync(paths, destination, onProgress):
+        raise RuntimeError('No space left on device')
+
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress', failingRsync)
+
+    manager.addLogNames(['tiny', 'big'])
+    waitUntilIdle(manager)
+
+    status = manager.getStatus()
+    assert status.errorMessage == 'No space left on device'
+    assert not status.isCopying
+    assert manager.logNamesQueue == []

--- a/src/web/jdv/server/tests/test_usb_offload.py
+++ b/src/web/jdv/server/tests/test_usb_offload.py
@@ -96,6 +96,22 @@ def test_picks_the_largest_partition_of_one_drive(fakeLsblk):
     assert usb_offload.findUsbPartition()['path'] == '/dev/sda2'
 
 
+def test_finds_a_stick_with_no_partition_table(fakeLsblk):
+    '''Some sticks carry their filesystem on the raw device rather than on a partition'''
+    wholeDisk = disk('sda')
+    wholeDisk.update(fstype='exfat', size=64_000_000_000)
+    fakeLsblk([wholeDisk])
+    assert usb_offload.findUsbPartition()['path'] == '/dev/sda'
+
+
+def test_ignores_an_unpartitioned_config_card(fakeLsblk):
+    '''A dd-ed fleet config ISO shows up as a whole disk, and is still not the operator's drive'''
+    configCard = disk('sda')
+    configCard.update(fstype='iso9660', label='updates', size=2_000_000_000)
+    fakeLsblk([configCard, disk('sdc'), partition('sdc1', 'sdc')])
+    assert usb_offload.findUsbPartition()['path'] == '/dev/sdc1'
+
+
 def test_raises_when_no_drive_is_plugged_in(fakeLsblk):
     fakeLsblk([disk('sdb'), partition('sdb1', 'sdb', 'btrfs', 'rootfs', mountpoint='/')])
     with pytest.raises(RuntimeError, match='No USB drive found'):
@@ -211,6 +227,34 @@ def test_a_log_deleted_before_it_is_copied_is_not_reported_as_copied(monkeypatch
     status = manager.getStatus()
     assert status.logsCopied == 1
     assert status.logsTotal == 1
+
+
+def test_a_log_deleted_after_queueing_does_not_strand_the_percentage(monkeypatch, manager, tmp_path):
+    '''Its bytes were counted when it was queued, so they have to come back out again'''
+    def deleteBigThenCopy(paths, destination, onProgress):
+        for path in tmp_path.glob('big.*'):
+            path.unlink()
+
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress', deleteBigThenCopy)
+
+    manager.addLogNames(['tiny', 'big'])
+    waitUntilIdle(manager)
+
+    status = manager.getStatus()
+    assert status.percentComplete == 100, 'percentage stalled below 100 after the skip'
+    assert status.logsCopied == 1
+    assert status.logsTotal == 1
+
+
+def test_a_copy_whose_logs_all_vanished_says_so(monkeypatch, manager):
+    monkeypatch.setattr(usb_offload, 'rsyncWithProgress', lambda *args: None)
+
+    manager.addLogNames(['gone', 'also-gone'])
+    waitUntilIdle(manager)
+
+    status = manager.getStatus()
+    assert status.logsTotal == 0
+    assert status.errorMessage == 'None of the selected logs are still on the hub'
 
 
 def test_log_names_are_matched_literally_not_as_glob_patterns(manager):

--- a/src/web/jdv/server/usb_offload.py
+++ b/src/web/jdv/server/usb_offload.py
@@ -43,7 +43,7 @@ class UsbOffloadStatus:
 
 
 def findUsbPartition():
-    '''Returns the device path of the USB partition plugged into the hub, raising unless there is exactly one'''
+    '''Returns the lsblk record of the USB partition plugged into the hub, raising unless there is exactly one'''
     output = subprocess.check_output(
         ['lsblk', '-J', '-l', '-o', 'NAME,PATH,PKNAME,TRAN,FSTYPE,LABEL,TYPE,MOUNTPOINT'])
     devices = json.loads(output)['blockdevices']
@@ -68,7 +68,7 @@ def findUsbPartition():
     if len(partitions) > 1:
         raise RuntimeError(f'{len(partitions)} USB drives found.  Please plug in only one drive.')
 
-    return partitions[0]['path']
+    return partitions[0]
 
 
 def hasUsbDrive():
@@ -203,8 +203,14 @@ class UsbOffloadManager:
         '''Mounts the drive, copies queued logs onto it until the queue is empty, then unmounts'''
         destination = f'{MOUNT_POINT}/{DESTINATION_SUBDIR}'
 
+        partition = findUsbPartition()
+
+        # The kernel's read-write NTFS driver registers as ntfs3, while the "ntfs" that lsblk
+        # reports resolves to the read-only one, which would fail the copy partway through
+        fsTypeArgs = ['-t', 'ntfs3'] if partition['fstype'] == 'ntfs' else []
+
         sudo('mkdir', '-p', MOUNT_POINT)
-        sudo('mount', findUsbPartition(), MOUNT_POINT)
+        sudo('mount', *fsTypeArgs, partition['path'], MOUNT_POINT)
 
         try:
             sudo('mkdir', '-p', destination)

--- a/src/web/jdv/server/usb_offload.py
+++ b/src/web/jdv/server/usb_offload.py
@@ -43,7 +43,7 @@ class UsbOffloadStatus:
 
 
 def findUsbPartition():
-    '''Returns the lsblk record of the USB partition plugged into the hub, raising unless there is exactly one'''
+    '''Returns the lsblk record of the USB filesystem plugged into the hub, raising unless there is exactly one'''
     output = subprocess.check_output(
         ['lsblk', '-J', '-l', '-b', '-o', 'NAME,PATH,PKNAME,TRAN,FSTYPE,LABEL,TYPE,SIZE,MOUNTPOINT'])
     devices = json.loads(output)['blockdevices']
@@ -53,16 +53,16 @@ def findUsbPartition():
     usbDiskNames = {device['name'] for device in devices
                     if device['type'] == 'disk' and device['tran'] == 'usb'}
 
-    # The fleet config card is on USB too, so skip the hub's own media.  Both checks are needed:
-    # fstab mounts the config card at boot, but our ansible tasks leave it unmounted.
-    partitions = [device for device in devices
-                  if device['type'] == 'part'
-                  and device['pkname'] in usbDiskNames
+    # A stick carries its filesystem either on a partition or, if it was never partitioned, on the
+    # disk itself.  The fleet config card is on USB too, so skip the hub's own media: both checks
+    # are needed, since fstab mounts that card at boot but our ansible tasks leave it unmounted.
+    candidates = [device for device in devices
+                  if (device['pkname'] in usbDiskNames or device['name'] in usbDiskNames)
                   and device['fstype'] is not None
                   and device['mountpoint'] is None
                   and device['label'] not in RESERVED_LABELS]
 
-    disksFound = {partition['pkname'] for partition in partitions}
+    disksFound = {device['pkname'] or device['name'] for device in candidates}
 
     if len(disksFound) == 0:
         raise RuntimeError("No USB drive found.  Please plug a drive into one of the hub's USB ports.")
@@ -71,7 +71,7 @@ def findUsbPartition():
         raise RuntimeError(f'{len(disksFound)} USB drives found.  Please plug in only one drive.')
 
     # One drive often holds more than one partition, so take the largest: the one with room for logs
-    return max(partitions, key=lambda partition: partition['size'])
+    return max(candidates, key=lambda device: device['size'])
 
 
 def hasUsbDrive():
@@ -126,8 +126,8 @@ class UsbOffloadManager:
     logNamesQueue: List[str]
     status: UsbOffloadStatus
 
-    logNamesAccepted: List[str]
-    '''Every log taken into this copy, so asking for one twice does not copy it twice'''
+    bytesForLog: Dict[str, int]
+    '''Size of every log taken into this copy, keyed by name so asking for one twice copies it once'''
 
     bytesTotal: int
 
@@ -146,7 +146,7 @@ class UsbOffloadManager:
     def __init__(self, logRootPath: str) -> None:
         self.logRootPath = logRootPath
         self.logNamesQueue = []
-        self.logNamesAccepted = []
+        self.bytesForLog = {}
         self.status = UsbOffloadStatus()
         self.bytesTotal = 0
         self.bytesCopied = 0
@@ -167,19 +167,20 @@ class UsbOffloadManager:
 
             if isNewCopy:
                 self.logNamesQueue = []
-                self.logNamesAccepted = []
+                self.bytesForLog = {}
                 self.status = UsbOffloadStatus(isCopying=True)
                 self.bytesTotal = 0
                 self.bytesCopied = 0
                 self.bytesInFlight = 0
 
             for logName in logNames:
-                if logName in self.logNamesAccepted:
+                if logName in self.bytesForLog:
                     continue
 
+                self.bytesForLog[logName] = sum(os.path.getsize(path)
+                                                for path in self.pathsForLog(logName))
                 self.logNamesQueue.append(logName)
-                self.logNamesAccepted.append(logName)
-                self.bytesTotal += sum(os.path.getsize(path) for path in self.pathsForLog(logName))
+                self.bytesTotal += self.bytesForLog[logName]
                 self.status.logsTotal += 1
 
             # Adding logs makes the copy bigger, so the percentage has to fall to match
@@ -234,7 +235,7 @@ class UsbOffloadManager:
                     logName = self.logNamesQueue.pop(0)
 
                 paths = self.pathsForLog(logName)
-                logBytes = sum(os.path.getsize(path) for path in paths)
+                logBytes = self.bytesForLog[logName]
 
                 def onProgress(fraction: float):
                     with self.lock:
@@ -242,10 +243,12 @@ class UsbOffloadManager:
                         self.refreshPercentComplete()
 
                 if len(paths) == 0:
-                    # Deleted since it was queued, so drop it rather than report it as copied
+                    # Deleted since it was queued, so drop it from the copy rather than report it
+                    # as copied.  Its bytes go too, or the percentage could never reach 100.
                     logging.warning(f'No files found for log: {logName}')
 
                     with self.lock:
+                        self.bytesTotal -= logBytes
                         self.status.logsTotal -= 1
                         self.refreshPercentComplete()
 
@@ -273,6 +276,12 @@ class UsbOffloadManager:
 
                     with self.lock:
                         if not self.logNamesQueue:
+                            # Everything asked for was deleted before it could be copied, which
+                            # would otherwise end the copy showing nothing at all
+                            if self.status.logsTotal == 0 and self.bytesForLog:
+                                self.status.errorMessage = \
+                                    'None of the selected logs are still on the hub'
+
                             self.status.isCopying = False
                             return
 

--- a/src/web/jdv/server/usb_offload.py
+++ b/src/web/jdv/server/usb_offload.py
@@ -1,0 +1,131 @@
+import glob
+import json
+import logging
+import subprocess
+
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+from threading import *
+from typing import *
+
+
+MOUNT_POINT = '/media/jaia-usb'
+'''Directory where the hub mounts the operator's USB drive'''
+
+DESTINATION_SUBDIR = 'jaia-logs'
+'''Directory created on the USB drive to hold the copied logs'''
+
+
+@dataclass_json
+@dataclass
+class UsbOffloadStatus:
+    '''Progress of the current (or most recent) copy of logs to a USB drive'''
+
+    isCopying: bool = False
+    '''True while a copy is in progress'''
+
+    logsRemaining: int = 0
+    '''Number of logs still to be copied'''
+
+    logsTotal: int = 0
+    '''Number of logs in the current copy'''
+
+    error: Optional[str] = None
+    '''Description of the failure that ended the last copy, if there was one'''
+
+
+def findUsbPartition():
+    '''Returns the device path of the USB partition plugged into the hub, raising unless there is exactly one'''
+    output = subprocess.check_output(['lsblk', '-J', '-o', 'PATH,TRAN,FSTYPE,TYPE,MOUNTPOINT'])
+
+    # Select on the parent disk's transport, since an SD card's partitions are hotplug but not USB
+    partitions = [partition
+                  for disk in json.loads(output)['blockdevices'] if disk['tran'] == 'usb'
+                  for partition in disk.get('children', [])
+                  if partition['fstype'] is not None]
+
+    if len(partitions) == 0:
+        raise RuntimeError("No USB drive found.  Please plug a drive into one of the hub's USB ports.")
+
+    if len(partitions) > 1:
+        raise RuntimeError(f'{len(partitions)} USB drives found.  Please plug in only one drive.')
+
+    return partitions[0]['path']
+
+
+def sudo(*args: str):
+    '''Runs a command as root, raising a RuntimeError containing its stderr if it fails'''
+    try:
+        subprocess.run(['sudo', *args], check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(e.stderr.decode().strip())
+
+
+class UsbOffloadManager:
+    '''This class runs on a thread, and copies the logs given to it onto a USB drive'''
+
+    logRootPath: str
+    logNamesQueue: List[str]
+    status: UsbOffloadStatus
+
+    thread: Thread
+
+
+    def __init__(self, logRootPath: str) -> None:
+        self.logRootPath = logRootPath
+        self.logNamesQueue = []
+        self.status = UsbOffloadStatus()
+
+
+    def addLogNames(self, logNames: List[str]):
+        '''Starts copying the named logs to a USB drive, unless a copy is already in progress'''
+        if not self.status.isCopying:
+            self.logNamesQueue = list(logNames)
+            self.status = UsbOffloadStatus(isCopying=True,
+                                           logsRemaining=len(logNames),
+                                           logsTotal=len(logNames))
+            self.startCopying()
+
+        return self.status
+
+
+    def getStatus(self):
+        return self.status
+
+
+    def startCopying(self):
+        def workFunc():
+            destination = f'{MOUNT_POINT}/{DESTINATION_SUBDIR}'
+
+            try:
+                # A previous copy may have been interrupted by a service restart, leaving the drive mounted
+                subprocess.run(['sudo', 'umount', MOUNT_POINT], capture_output=True)
+
+                sudo('mkdir', '-p', MOUNT_POINT)
+                sudo('mount', findUsbPartition(), MOUNT_POINT)
+                sudo('mkdir', '-p', destination)
+
+                while len(self.logNamesQueue) > 0:
+                    logName = self.logNamesQueue.pop(0)
+                    paths = glob.glob(f'{self.logRootPath}/{logName}.*')
+
+                    if len(paths) == 0:
+                        logging.warning(f'No files found for log: {logName}')
+                    else:
+                        # Copying without -p, since preserving ownership fails on the FAT filesystems most drives use
+                        sudo('cp', *paths, destination)
+
+                    self.status.logsRemaining = len(self.logNamesQueue)
+
+                logging.info(f'Copied {self.status.logsTotal} logs to {destination}')
+
+            except Exception as e:
+                logging.error(e)
+                self.status.error = str(e)
+
+            finally:
+                subprocess.run(['sudo', 'umount', MOUNT_POINT], capture_output=True)
+                self.status.isCopying = False
+
+        self.thread = Thread(target=workFunc, daemon=True)
+        self.thread.start()

--- a/src/web/jdv/server/usb_offload.py
+++ b/src/web/jdv/server/usb_offload.py
@@ -12,16 +12,14 @@ from typing import *
 
 
 MOUNT_POINT = '/media/jaia-usb'
-'''Directory where the hub mounts the operator's USB drive'''
 
 DESTINATION_SUBDIR = 'jaia-logs'
-'''Directory created on the USB drive to hold the copied logs'''
 
 RESERVED_LABELS = ['rootfs', 'boot', 'data', 'updates', 'overlay']
-'''Filesystem labels of the hub's own media, which is never the drive the operator plugged in'''
+'''Filesystem labels of the hub's own media, which is never the operator's drive'''
 
 PROGRESS_RE = re.compile(r'(\d+)%')
-'''Matches the percentage rsync --info=progress2 rewrites onto its output line'''
+'''Matches the percentage in rsync --info=progress2 output'''
 
 
 @dataclass_json
@@ -30,22 +28,18 @@ class UsbOffloadStatus:
     '''Progress of the current (or most recent) copy of logs to a USB drive'''
 
     isCopying: bool = False
-    '''True while a copy is in progress'''
 
     logsCopied: int = 0
-    '''Number of logs written to the drive so far'''
 
     logsTotal: int = 0
-    '''Number of logs in this copy, which grows when more are added while it runs'''
+    '''Grows when more logs are added while the copy runs'''
 
     percentComplete: int = 0
-    '''Percentage of this copy's total bytes written to the drive so far'''
+    '''Measured by bytes, so a large log counts for more than a small one'''
 
     errorMessage: Optional[str] = None
-    '''Description of the failure that ended the last copy, if there was one.'''
 
     isDriveAvailable: bool = False
-    '''True while there is a drive plugged in for the operator to copy to'''
 
 
 def findUsbPartition():
@@ -54,14 +48,13 @@ def findUsbPartition():
         ['lsblk', '-J', '-l', '-o', 'NAME,PATH,PKNAME,TRAN,FSTYPE,LABEL,TYPE,MOUNTPOINT'])
     devices = json.loads(output)['blockdevices']
 
-    # Ask for a flat list and pair each partition with its disk by PKNAME.  lsblk only nests
-    # partitions under their disk when the NAME column is requested, which is too subtle to rely on.
-    # Select on the disk's transport, since an SD card's partitions are hotplug but not USB.
+    # lsblk only nests partitions under their disk when the NAME column is asked for, so take the
+    # flat list and pair them up by PKNAME.  Match on transport: an SD card is hotplug but not USB.
     usbDiskNames = {device['name'] for device in devices
                     if device['type'] == 'disk' and device['tran'] == 'usb'}
 
-    # The fleet config card is attached over USB too, so skip media the hub has mounted or labelled
-    # for its own use: fstab mounts the config card at boot, but our ansible tasks leave it unmounted.
+    # The fleet config card is on USB too, so skip the hub's own media.  Both checks are needed:
+    # fstab mounts the config card at boot, but our ansible tasks leave it unmounted.
     partitions = [device for device in devices
                   if device['type'] == 'part'
                   and device['pkname'] in usbDiskNames
@@ -98,13 +91,12 @@ def sudo(*args: str):
 def rsyncWithProgress(paths: List[str], destination: str, onProgress: Callable[[float], None]):
     '''Copies files to the destination, calling onProgress with the fraction of them written so far.
 
-       rsync rather than cp, so that filling the drive leaves no truncated file that looks like a
-       whole log.  No -a, since preserving ownership fails on the FAT filesystems most drives use.'''
+       rsync rather than cp so a full drive leaves no truncated file posing as a whole log, and
+       without -a because preserving ownership fails on the FAT filesystems most drives use.'''
     process = subprocess.Popen(['sudo', 'rsync', '--info=progress2', *paths, destination],
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
-    # progress2 rewrites one line, ending each update with a carriage return rather than a newline.
-    # text=True puts stdout in universal newlines mode, so readline() returns on those too.
+    # progress2 ends each update with a carriage return; text=True makes readline() return on those
     for line in process.stdout:
         match = PROGRESS_RE.search(line)
         if match is not None:
@@ -125,20 +117,18 @@ class UsbOffloadManager:
     status: UsbOffloadStatus
 
     logNamesAccepted: List[str]
-    '''Every log taken into this copy, so that asking for one twice does not copy it twice'''
+    '''Every log taken into this copy, so asking for one twice does not copy it twice'''
 
     bytesTotal: int
-    '''Size of every log in this copy, which grows when more are added while it runs'''
 
     bytesCopied: int
-    '''Size of the logs written to the drive so far'''
 
     bytesInFlight: float
-    '''How much of the log currently being copied rsync has written so far'''
+    '''How much of the log being copied right now rsync has written'''
 
     lock: Lock
     '''Guards the queue, the byte totals and the status, which the worker thread and the
-       request threads serving addLogNames() both write'''
+       request threads both write'''
 
     thread: Thread
 
@@ -193,9 +183,8 @@ class UsbOffloadManager:
     def getStatus(self):
         '''Returns the copy progress, along with whether there is a drive available to copy to'''
         with self.lock:
-            # A copy that ended without unmounting - killed by a restart, or an unmount that failed -
-            # would hide the drive from findUsbPartition() and grey the button out for good, so
-            # reconcile it here, where the client's polling is certain to reach it
+            # A copy killed before it could unmount would hide the drive from findUsbPartition()
+            # for good, so reconcile it here, where the client's polling is certain to reach it
             if not self.status.isCopying and os.path.ismount(MOUNT_POINT):
                 subprocess.run(['sudo', 'umount', MOUNT_POINT], capture_output=True)
 
@@ -253,8 +242,8 @@ class UsbOffloadManager:
     def startCopying(self):
         def workFunc():
             try:
-                # Logs can be queued right up until the moment the drive is unmounted, so only
-                # stop once the queue is still empty with the drive already back off
+                # Logs can arrive right up to the moment the drive is unmounted, so only stop
+                # once the queue is still empty with the drive already back off
                 while True:
                     self.copyQueuedLogs()
 

--- a/src/web/jdv/server/usb_offload.py
+++ b/src/web/jdv/server/usb_offload.py
@@ -45,7 +45,7 @@ class UsbOffloadStatus:
 def findUsbPartition():
     '''Returns the lsblk record of the USB partition plugged into the hub, raising unless there is exactly one'''
     output = subprocess.check_output(
-        ['lsblk', '-J', '-l', '-o', 'NAME,PATH,PKNAME,TRAN,FSTYPE,LABEL,TYPE,MOUNTPOINT'])
+        ['lsblk', '-J', '-l', '-b', '-o', 'NAME,PATH,PKNAME,TRAN,FSTYPE,LABEL,TYPE,SIZE,MOUNTPOINT'])
     devices = json.loads(output)['blockdevices']
 
     # lsblk only nests partitions under their disk when the NAME column is asked for, so take the
@@ -62,13 +62,16 @@ def findUsbPartition():
                   and device['mountpoint'] is None
                   and device['label'] not in RESERVED_LABELS]
 
-    if len(partitions) == 0:
+    disksFound = {partition['pkname'] for partition in partitions}
+
+    if len(disksFound) == 0:
         raise RuntimeError("No USB drive found.  Please plug a drive into one of the hub's USB ports.")
 
-    if len(partitions) > 1:
-        raise RuntimeError(f'{len(partitions)} USB drives found.  Please plug in only one drive.')
+    if len(disksFound) > 1:
+        raise RuntimeError(f'{len(disksFound)} USB drives found.  Please plug in only one drive.')
 
-    return partitions[0]
+    # One drive often holds more than one partition, so take the largest: the one with room for logs
+    return max(partitions, key=lambda partition: partition['size'])
 
 
 def hasUsbDrive():
@@ -93,17 +96,24 @@ def rsyncWithProgress(paths: List[str], destination: str, onProgress: Callable[[
 
        rsync rather than cp so a full drive leaves no truncated file posing as a whole log, and
        without -a because preserving ownership fails on the FAT filesystems most drives use.'''
+    # stderr is merged in rather than given its own pipe, which nothing would read until rsync had
+    # already exited - long enough for a chatty failure to fill that pipe and deadlock the copy
     process = subprocess.Popen(['sudo', 'rsync', '--info=progress2', *paths, destination],
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    messages = []
 
     # progress2 ends each update with a carriage return; text=True makes readline() return on those
     for line in process.stdout:
         match = PROGRESS_RE.search(line)
+
         if match is not None:
             onProgress(int(match.group(1)) / 100)
+        elif line.strip():
+            messages.append(line.strip())
 
     if process.wait() != 0:
-        raise RuntimeError(process.stderr.read().strip())
+        raise RuntimeError(' '.join(messages[-3:]) or 'rsync failed')
 
 
 class UsbOffloadManager:
@@ -146,7 +156,8 @@ class UsbOffloadManager:
 
     def pathsForLog(self, logName: str):
         '''Returns every file belonging to a log: its .goby, .h5 and anything else sharing its name'''
-        return glob.glob(f'{self.logRootPath}/{logName}.*')
+        # Escaped so that a name containing *, ? or [ is matched literally rather than as a pattern
+        return glob.glob(f'{self.logRootPath}/{glob.escape(logName)}.*')
 
 
     def addLogNames(self, logNames: List[str]):
@@ -231,9 +242,16 @@ class UsbOffloadManager:
                         self.refreshPercentComplete()
 
                 if len(paths) == 0:
+                    # Deleted since it was queued, so drop it rather than report it as copied
                     logging.warning(f'No files found for log: {logName}')
-                else:
-                    rsyncWithProgress(paths, destination, onProgress)
+
+                    with self.lock:
+                        self.status.logsTotal -= 1
+                        self.refreshPercentComplete()
+
+                    continue
+
+                rsyncWithProgress(paths, destination, onProgress)
 
                 with self.lock:
                     self.bytesCopied += logBytes

--- a/src/web/jdv/server/usb_offload.py
+++ b/src/web/jdv/server/usb_offload.py
@@ -15,6 +15,9 @@ MOUNT_POINT = '/media/jaia-usb'
 DESTINATION_SUBDIR = 'jaia-logs'
 '''Directory created on the USB drive to hold the copied logs'''
 
+RESERVED_LABELS = ['rootfs', 'boot', 'data', 'updates', 'overlay']
+'''Filesystem labels of the hub's own media, which is never the drive the operator plugged in'''
+
 
 @dataclass_json
 @dataclass
@@ -36,13 +39,17 @@ class UsbOffloadStatus:
 
 def findUsbPartition():
     '''Returns the device path of the USB partition plugged into the hub, raising unless there is exactly one'''
-    output = subprocess.check_output(['lsblk', '-J', '-o', 'PATH,TRAN,FSTYPE,TYPE,MOUNTPOINT'])
+    output = subprocess.check_output(['lsblk', '-J', '-o', 'PATH,TRAN,FSTYPE,LABEL,TYPE,MOUNTPOINT'])
 
-    # Select on the parent disk's transport, since an SD card's partitions are hotplug but not USB
+    # Select on the parent disk's transport, since an SD card's partitions are hotplug but not USB.
+    # The fleet config card is also attached over USB, so skip media the hub has mounted or labelled
+    # for its own use: fstab mounts the config card at boot, but our ansible tasks leave it unmounted.
     partitions = [partition
                   for disk in json.loads(output)['blockdevices'] if disk['tran'] == 'usb'
                   for partition in disk.get('children', [])
-                  if partition['fstype'] is not None]
+                  if partition['fstype'] is not None
+                  and partition['mountpoint'] is None
+                  and partition['label'] not in RESERVED_LABELS]
 
     if len(partitions) == 0:
         raise RuntimeError("No USB drive found.  Please plug a drive into one of the hub's USB ports.")

--- a/src/web/jdv/server/usb_offload.py
+++ b/src/web/jdv/server/usb_offload.py
@@ -1,6 +1,8 @@
 import glob
 import json
 import logging
+import os
+import re
 import subprocess
 
 from dataclasses import dataclass
@@ -18,6 +20,9 @@ DESTINATION_SUBDIR = 'jaia-logs'
 RESERVED_LABELS = ['rootfs', 'boot', 'data', 'updates', 'overlay']
 '''Filesystem labels of the hub's own media, which is never the drive the operator plugged in'''
 
+PROGRESS_RE = re.compile(r'(\d+)%')
+'''Matches the percentage rsync --info=progress2 rewrites onto its output line'''
+
 
 @dataclass_json
 @dataclass
@@ -27,29 +32,42 @@ class UsbOffloadStatus:
     isCopying: bool = False
     '''True while a copy is in progress'''
 
-    logsRemaining: int = 0
-    '''Number of logs still to be copied'''
+    logsCopied: int = 0
+    '''Number of logs written to the drive so far'''
 
     logsTotal: int = 0
-    '''Number of logs in the current copy'''
+    '''Number of logs in this copy, which grows when more are added while it runs'''
 
-    error: Optional[str] = None
-    '''Description of the failure that ended the last copy, if there was one'''
+    percentComplete: int = 0
+    '''Percentage of this copy's total bytes written to the drive so far'''
+
+    errorMessage: Optional[str] = None
+    '''Description of the failure that ended the last copy, if there was one.'''
+
+    isDriveAvailable: bool = False
+    '''True while there is a drive plugged in for the operator to copy to'''
 
 
 def findUsbPartition():
     '''Returns the device path of the USB partition plugged into the hub, raising unless there is exactly one'''
-    output = subprocess.check_output(['lsblk', '-J', '-o', 'PATH,TRAN,FSTYPE,LABEL,TYPE,MOUNTPOINT'])
+    output = subprocess.check_output(
+        ['lsblk', '-J', '-l', '-o', 'NAME,PATH,PKNAME,TRAN,FSTYPE,LABEL,TYPE,MOUNTPOINT'])
+    devices = json.loads(output)['blockdevices']
 
-    # Select on the parent disk's transport, since an SD card's partitions are hotplug but not USB.
-    # The fleet config card is also attached over USB, so skip media the hub has mounted or labelled
+    # Ask for a flat list and pair each partition with its disk by PKNAME.  lsblk only nests
+    # partitions under their disk when the NAME column is requested, which is too subtle to rely on.
+    # Select on the disk's transport, since an SD card's partitions are hotplug but not USB.
+    usbDiskNames = {device['name'] for device in devices
+                    if device['type'] == 'disk' and device['tran'] == 'usb'}
+
+    # The fleet config card is attached over USB too, so skip media the hub has mounted or labelled
     # for its own use: fstab mounts the config card at boot, but our ansible tasks leave it unmounted.
-    partitions = [partition
-                  for disk in json.loads(output)['blockdevices'] if disk['tran'] == 'usb'
-                  for partition in disk.get('children', [])
-                  if partition['fstype'] is not None
-                  and partition['mountpoint'] is None
-                  and partition['label'] not in RESERVED_LABELS]
+    partitions = [device for device in devices
+                  if device['type'] == 'part'
+                  and device['pkname'] in usbDiskNames
+                  and device['fstype'] is not None
+                  and device['mountpoint'] is None
+                  and device['label'] not in RESERVED_LABELS]
 
     if len(partitions) == 0:
         raise RuntimeError("No USB drive found.  Please plug a drive into one of the hub's USB ports.")
@@ -60,6 +78,15 @@ def findUsbPartition():
     return partitions[0]['path']
 
 
+def hasUsbDrive():
+    '''Returns whether there is exactly one USB drive plugged in that we could copy logs to'''
+    try:
+        findUsbPartition()
+        return True
+    except Exception:
+        return False
+
+
 def sudo(*args: str):
     '''Runs a command as root, raising a RuntimeError containing its stderr if it fails'''
     try:
@@ -68,12 +95,50 @@ def sudo(*args: str):
         raise RuntimeError(e.stderr.decode().strip())
 
 
+def rsyncWithProgress(paths: List[str], destination: str, onProgress: Callable[[float], None]):
+    '''Copies files to the destination, calling onProgress with the fraction of them written so far.
+
+       rsync rather than cp, so that filling the drive leaves no truncated file that looks like a
+       whole log.  No -a, since preserving ownership fails on the FAT filesystems most drives use.'''
+    process = subprocess.Popen(['sudo', 'rsync', '--info=progress2', *paths, destination],
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    # progress2 rewrites one line, ending each update with a carriage return rather than a newline.
+    # text=True puts stdout in universal newlines mode, so readline() returns on those too.
+    for line in process.stdout:
+        match = PROGRESS_RE.search(line)
+        if match is not None:
+            onProgress(int(match.group(1)) / 100)
+
+    if process.wait() != 0:
+        raise RuntimeError(process.stderr.read().strip())
+
+
 class UsbOffloadManager:
-    '''This class runs on a thread, and copies the logs given to it onto a USB drive'''
+    '''Copies logs to a USB drive on a background thread, one log at a time.
+
+       Logs added while a copy is running join that copy rather than being turned away, so the
+       operator can keep browsing, selecting and queueing logs without waiting for it to finish.'''
 
     logRootPath: str
     logNamesQueue: List[str]
     status: UsbOffloadStatus
+
+    logNamesAccepted: List[str]
+    '''Every log taken into this copy, so that asking for one twice does not copy it twice'''
+
+    bytesTotal: int
+    '''Size of every log in this copy, which grows when more are added while it runs'''
+
+    bytesCopied: int
+    '''Size of the logs written to the drive so far'''
+
+    bytesInFlight: float
+    '''How much of the log currently being copied rsync has written so far'''
+
+    lock: Lock
+    '''Guards the queue, the byte totals and the status, which the worker thread and the
+       request threads serving addLogNames() both write'''
 
     thread: Thread
 
@@ -81,58 +146,130 @@ class UsbOffloadManager:
     def __init__(self, logRootPath: str) -> None:
         self.logRootPath = logRootPath
         self.logNamesQueue = []
+        self.logNamesAccepted = []
         self.status = UsbOffloadStatus()
+        self.bytesTotal = 0
+        self.bytesCopied = 0
+        self.bytesInFlight = 0
+        self.lock = Lock()
+
+
+    def pathsForLog(self, logName: str):
+        '''Returns every file belonging to a log: its .goby, .h5 and anything else sharing its name'''
+        return glob.glob(f'{self.logRootPath}/{logName}.*')
 
 
     def addLogNames(self, logNames: List[str]):
-        '''Starts copying the named logs to a USB drive, unless a copy is already in progress'''
-        if not self.status.isCopying:
-            self.logNamesQueue = list(logNames)
-            self.status = UsbOffloadStatus(isCopying=True,
-                                           logsRemaining=len(logNames),
-                                           logsTotal=len(logNames))
+        '''Queues logs to copy, joining the copy already in progress if there is one'''
+        with self.lock:
+            isNewCopy = not self.status.isCopying
+
+            if isNewCopy:
+                self.logNamesQueue = []
+                self.logNamesAccepted = []
+                self.status = UsbOffloadStatus(isCopying=True)
+                self.bytesTotal = 0
+                self.bytesCopied = 0
+                self.bytesInFlight = 0
+
+            for logName in logNames:
+                if logName in self.logNamesAccepted:
+                    continue
+
+                self.logNamesQueue.append(logName)
+                self.logNamesAccepted.append(logName)
+                self.bytesTotal += sum(os.path.getsize(path) for path in self.pathsForLog(logName))
+                self.status.logsTotal += 1
+
+            # Adding logs makes the copy bigger, so the percentage has to fall to match
+            self.refreshPercentComplete()
+
+        if isNewCopy:
             self.startCopying()
 
-        return self.status
+        return self.getStatus()
 
 
     def getStatus(self):
+        '''Returns the copy progress, along with whether there is a drive available to copy to'''
+        with self.lock:
+            # A copy that ended without unmounting - killed by a restart, or an unmount that failed -
+            # would hide the drive from findUsbPartition() and grey the button out for good, so
+            # reconcile it here, where the client's polling is certain to reach it
+            if not self.status.isCopying and os.path.ismount(MOUNT_POINT):
+                subprocess.run(['sudo', 'umount', MOUNT_POINT], capture_output=True)
+
+        # A copy in progress has the drive mounted, which is what findUsbPartition() skips on
+        self.status.isDriveAvailable = self.status.isCopying or hasUsbDrive()
         return self.status
+
+
+    def refreshPercentComplete(self):
+        '''Recomputes the percentage from the byte totals.  The caller must hold the lock.'''
+        written = self.bytesCopied + self.bytesInFlight
+        self.status.percentComplete = min(100, int(100 * written / max(self.bytesTotal, 1)))
+
+
+    def copyQueuedLogs(self):
+        '''Mounts the drive, copies queued logs onto it until the queue is empty, then unmounts'''
+        destination = f'{MOUNT_POINT}/{DESTINATION_SUBDIR}'
+
+        sudo('mkdir', '-p', MOUNT_POINT)
+        sudo('mount', findUsbPartition(), MOUNT_POINT)
+
+        try:
+            sudo('mkdir', '-p', destination)
+
+            while True:
+                with self.lock:
+                    if not self.logNamesQueue:
+                        return
+
+                    logName = self.logNamesQueue.pop(0)
+
+                paths = self.pathsForLog(logName)
+                logBytes = sum(os.path.getsize(path) for path in paths)
+
+                def onProgress(fraction: float):
+                    with self.lock:
+                        self.bytesInFlight = logBytes * fraction
+                        self.refreshPercentComplete()
+
+                if len(paths) == 0:
+                    logging.warning(f'No files found for log: {logName}')
+                else:
+                    rsyncWithProgress(paths, destination, onProgress)
+
+                with self.lock:
+                    self.bytesCopied += logBytes
+                    self.bytesInFlight = 0
+                    self.status.logsCopied += 1
+                    self.refreshPercentComplete()
+
+        finally:
+            subprocess.run(['sudo', 'umount', MOUNT_POINT], capture_output=True)
 
 
     def startCopying(self):
         def workFunc():
-            destination = f'{MOUNT_POINT}/{DESTINATION_SUBDIR}'
-
             try:
-                # A previous copy may have been interrupted by a service restart, leaving the drive mounted
-                subprocess.run(['sudo', 'umount', MOUNT_POINT], capture_output=True)
+                # Logs can be queued right up until the moment the drive is unmounted, so only
+                # stop once the queue is still empty with the drive already back off
+                while True:
+                    self.copyQueuedLogs()
 
-                sudo('mkdir', '-p', MOUNT_POINT)
-                sudo('mount', findUsbPartition(), MOUNT_POINT)
-                sudo('mkdir', '-p', destination)
-
-                while len(self.logNamesQueue) > 0:
-                    logName = self.logNamesQueue.pop(0)
-                    paths = glob.glob(f'{self.logRootPath}/{logName}.*')
-
-                    if len(paths) == 0:
-                        logging.warning(f'No files found for log: {logName}')
-                    else:
-                        # Copying without -p, since preserving ownership fails on the FAT filesystems most drives use
-                        sudo('cp', *paths, destination)
-
-                    self.status.logsRemaining = len(self.logNamesQueue)
-
-                logging.info(f'Copied {self.status.logsTotal} logs to {destination}')
+                    with self.lock:
+                        if not self.logNamesQueue:
+                            self.status.isCopying = False
+                            return
 
             except Exception as e:
                 logging.error(e)
-                self.status.error = str(e)
 
-            finally:
-                subprocess.run(['sudo', 'umount', MOUNT_POINT], capture_output=True)
-                self.status.isCopying = False
+                with self.lock:
+                    self.logNamesQueue = []
+                    self.status.errorMessage = str(e)
+                    self.status.isCopying = False
 
         self.thread = Thread(target=workFunc, daemon=True)
         self.thread.start()


### PR DESCRIPTION
## Summary

This PR adds a JDV button for offloading log files directly to an external, hub-mounted USB drive.

## Changes

- Backend:
  - Implemented `UsbOffloadManager` which runs on a background thread. It automatically detects USB drives and copies logs to a `jaia-logs` folder.
  - Added `REST` endpoints in `jaiabot_data_vision.py` to start the transfer and poll the progress.
- Frontend:
  - Updated `LogApi.ts` with the new `UsbOffloadStatus` interface and polling methods.
  - Updated the `LogSelector` component to include an updating "Copy to USB" button that displays transfer progress (e.g., "Copying 2 / 5") and surfaces any errors to the user.

## Testing

Test on a flat fleet:

- [x] Insert a USB drive into the hub and verify that pressing the button in the JDV tracks progress correctly and uploads files to USB. 
- [x] Try the process again without a USB plugged in to verify the frontend catches the issue. 