### PR TITLE
bug/fix-jdv-blank-screen-on-undefined-constant-heading-speed

### DIFF
--- a/src/web/shared/MissionFeatures.ts
+++ b/src/web/shared/MissionFeatures.ts
@@ -9,6 +9,9 @@ import { transformTranslate, point } from "@turf/turf";
 import { PortalBotStatus } from "./PortalStatus";
 import { getMapCoordinate } from "./Utilities";
 
+const CONSTANT_HEADING_DEFAULT_SPEED = 2; // meters per second
+const CONSTANT_HEADING_DEFAULT_TIME = 0; // seconds
+
 export function createMissionFeatures(
     map: Map,
     bot: PortalBotStatus,
@@ -83,13 +86,16 @@ export function createMissionFeatures(
         let task = goal.task;
         var startCoordinate: Coordinate;
 
-        if (task?.type == TaskType.CONSTANT_HEADING) {
+        const constantHeadingParameters =
+            task?.type == TaskType.CONSTANT_HEADING ? task.constant_heading : null;
+        let distance =
+            (constantHeadingParameters?.constant_heading_speed ?? CONSTANT_HEADING_DEFAULT_SPEED) *
+            (constantHeadingParameters?.constant_heading_time ?? CONSTANT_HEADING_DEFAULT_TIME);
+        let heading = constantHeadingParameters?.constant_heading;
+
+        if (isFinite(distance) && isFinite(heading)) {
             // Calculate targetPoint
             let constantHeadingStartPoint = point([location.lon, location.lat]);
-            let distance =
-                task.constant_heading.constant_heading_speed *
-                task.constant_heading.constant_heading_time;
-            let heading = task.constant_heading.constant_heading;
             let constantHeadingEndPoint = transformTranslate(
                 constantHeadingStartPoint,
                 distance,

--- a/src/web/shared/__tests__/MissionFeatures.test.ts
+++ b/src/web/shared/__tests__/MissionFeatures.test.ts
@@ -1,0 +1,123 @@
+import { LineString } from "ol/geom";
+import { Map } from "ol";
+import { toLonLat } from "ol/proj";
+import { createMissionFeatures } from "../MissionFeatures";
+import { MissionPlan, TaskType } from "../JAIAProtobuf";
+import { PortalBotStatus } from "../PortalStatus";
+
+const map = {
+    getView: () => ({
+        getProjection: () => "EPSG:3857",
+    }),
+} as unknown as Map;
+
+const bot: PortalBotStatus = {
+    bot_id: 1,
+};
+
+function getConstantHeadingFeature(features: any[]) {
+    return features.find((feature) => feature.get("isConstantHeading"));
+}
+
+describe("createMissionFeatures constant heading defaults", () => {
+    test("handles missing constant heading speed/time without throwing and creates zero-length heading segment", () => {
+        const plan: MissionPlan = {
+            goal: [
+                {
+                    location: { lon: -71.0, lat: 42.0 },
+                    task: {
+                        type: TaskType.CONSTANT_HEADING,
+                        constant_heading: {
+                            constant_heading: 90,
+                        },
+                    },
+                },
+            ],
+        };
+
+        expect(() => createMissionFeatures(map, bot, plan, 0, false, false)).not.toThrow();
+
+        const features = createMissionFeatures(map, bot, plan, 0, false, false);
+        const constantHeadingFeature = getConstantHeadingFeature(features);
+        expect(constantHeadingFeature).toBeDefined();
+
+        const geometry = constantHeadingFeature.getGeometry() as LineString;
+        const [start, end] = geometry.getCoordinates();
+        expect(start[0]).toBeCloseTo(end[0], 10);
+        expect(start[1]).toBeCloseTo(end[1], 10);
+    });
+
+    test("uses configured constant heading speed/time for heading endpoint and mission leg start", () => {
+        const plan: MissionPlan = {
+            goal: [
+                {
+                    location: { lon: -71.0, lat: 42.0 },
+                    task: {
+                        type: TaskType.CONSTANT_HEADING,
+                        constant_heading: {
+                            constant_heading: 90,
+                            constant_heading_speed: 2,
+                            constant_heading_time: 30,
+                        },
+                    },
+                },
+                {
+                    location: { lon: -70.999, lat: 42.0 },
+                },
+            ],
+        };
+
+        const features = createMissionFeatures(map, bot, plan, 0, false, false);
+        const constantHeadingFeature = getConstantHeadingFeature(features);
+        expect(constantHeadingFeature).toBeDefined();
+
+        const constantHeadingGeometry = constantHeadingFeature.getGeometry() as LineString;
+        const [segmentStart, segmentEnd] = constantHeadingGeometry.getCoordinates();
+        expect(segmentStart[0]).not.toBeCloseTo(segmentEnd[0], 10);
+
+        const missionLineFeature = features.find((feature) => feature.get("type") === "line");
+        expect(missionLineFeature).toBeDefined();
+
+        const missionLineGeometry = missionLineFeature.getGeometry() as LineString;
+        const [missionStart] = missionLineGeometry.getCoordinates();
+        expect(missionStart[0]).toBeCloseTo(segmentEnd[0], 10);
+        expect(missionStart[1]).toBeCloseTo(segmentEnd[1], 10);
+
+        const [startLon] = toLonLat(segmentStart, "EPSG:3857");
+        const [endLon] = toLonLat(segmentEnd, "EPSG:3857");
+        expect(endLon).toBeGreaterThan(startLon);
+    });
+
+    test("skips constant heading segment when heading is not finite", () => {
+        const plan: MissionPlan = {
+            goal: [
+                {
+                    location: { lon: -71.0, lat: 42.0 },
+                    task: {
+                        type: TaskType.CONSTANT_HEADING,
+                        constant_heading: {
+                            constant_heading: Number.NaN,
+                            constant_heading_speed: 2,
+                            constant_heading_time: 30,
+                        },
+                    },
+                },
+                {
+                    location: { lon: -70.999, lat: 42.0 },
+                },
+            ],
+        };
+
+        const features = createMissionFeatures(map, bot, plan, 0, false, false);
+        expect(getConstantHeadingFeature(features)).toBeUndefined();
+
+        const missionLineFeature = features.find((feature) => feature.get("type") === "line");
+        expect(missionLineFeature).toBeDefined();
+
+        const missionLineGeometry = missionLineFeature.getGeometry() as LineString;
+        const [missionStart] = missionLineGeometry.getCoordinates();
+        const [missionStartLon, missionStartLat] = toLonLat(missionStart, "EPSG:3857");
+        expect(missionStartLon).toBeCloseTo(-71.0, 6);
+        expect(missionStartLat).toBeCloseTo(42.0, 6);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes a JDV white screen when hovering over a log file graph. The issue was caused by undefined constant heading speed values which made the constant heading distance NaN. There was no error boundary so the throw escaped `componentDidUpdate` and unmounted the whole React setup. Constant heading speed now defaults to 2 m/s.

## Test Procedure

- [x] Tested on the hub/log file setup that surfaced this issue (Fleet 6 Hub 1, 2026-07-28 log). Hovering between 16:51:47–16:57:15 UTC blanked the screen before the fix and works after.