### PR TITLE
bug/fix-deploy-code-to-bot-script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ file(MAKE_DIRECTORY ${project_INTERMEDIATE_DIR})
 
 # Write the version to a simple text file for scripts to use
 if(PROJECT_VERSION_GITHASH)
-  file(WRITE ${project_SHARE_DIR}/version.txt ${PROJECT_VERSION_GITDESCRIBE})
+  file(WRITE ${project_SHARE_DIR}/version.txt "${PROJECT_GIT_VERSION}${PROJECT_DIRTY_REV_STRING}")
 endif()
 
 ## set the cmake defaults for libraries and binaries

--- a/config/gen/systemd-local.sh
+++ b/config/gen/systemd-local.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo -E /bin/bash -ic "export PATH=$PATH; ./systemd.py $*"
+sudo -E /bin/bash -ic 'export PATH="$1"; shift; ./systemd.py "$@"' systemd-local "$PATH" "$@"

--- a/scripts/arm64-deploy.sh
+++ b/scripts/arm64-deploy.sh
@@ -44,7 +44,7 @@ if [ ! -z "$jaiabot_systemd_type" ]; then
     if [[ "$jaiabot_systemd_type" == *"bot"* ]]; then
         cd ${HOME}/jaiabot/config/gen
         (set -x; export PATH=${HOME}/jaiabot/${build_dir}/bin:$PATH;
-        ./systemd-local.sh ${jaiabot_systemd_type} --bot_index $jaia_bot_index --fleet_index $jaia_fleet_index --electronics_stack $jaia_electronics_stack --imu_type $jaia_imu_type --imu_install_type $jaia_imu_install_type --arduino_type $jaia_arduino_type --bot_type ${jaia_bot_type,,} --bot_vin "${jaia_bot_vin:-unknown_vin}" --pam_connection_type ${jaia_pam_connection_type,,} $jaia_simulation --enable --motor_harness_type ${jaia_motor_harness_type,,} --camera_positions ${jaia_camera_positions,,} --additional_sensors ${jaia_additional_sensors}) || { echo "❌ Failed to install the $jaiabot_systemd_type systemd services, so this deploy is still running the previously installed code"; exit 1; }
+        ./systemd-local.sh ${jaiabot_systemd_type} --bot_index $jaia_bot_index --fleet_index $jaia_fleet_index --electronics_stack $jaia_electronics_stack --imu_type $jaia_imu_type --imu_install_type $jaia_imu_install_type --arduino_type $jaia_arduino_type --bot_type ${jaia_bot_type,,} --bot_vin "$jaia_bot_vin" --pam_connection_type ${jaia_pam_connection_type,,} $jaia_simulation --enable --motor_harness_type ${jaia_motor_harness_type,,} --camera_positions ${jaia_camera_positions,,} --additional_sensors ${jaia_additional_sensors}) || { echo "❌ Failed to install the $jaiabot_systemd_type systemd services, so this deploy is still running the previously installed code"; exit 1; }
 
     else
 

--- a/scripts/arm64-deploy.sh
+++ b/scripts/arm64-deploy.sh
@@ -44,13 +44,13 @@ if [ ! -z "$jaiabot_systemd_type" ]; then
     if [[ "$jaiabot_systemd_type" == *"bot"* ]]; then
         cd ${HOME}/jaiabot/config/gen
         (set -x; export PATH=${HOME}/jaiabot/${build_dir}/bin:$PATH;
-        ./systemd-local.sh ${jaiabot_systemd_type} --bot_index $jaia_bot_index --fleet_index $jaia_fleet_index --electronics_stack $jaia_electronics_stack --imu_type $jaia_imu_type --imu_install_type $jaia_imu_install_type --arduino_type $jaia_arduino_type --bot_type ${jaia_bot_type,,} --bot_vin "$jaia_bot_vin" --pam_connection_type ${jaia_pam_connection_type,,} $jaia_simulation --enable --motor_harness_type ${jaia_motor_harness_type,,} --camera_positions ${jaia_camera_positions,,} --additional_sensors ${jaia_additional_sensors})
+        ./systemd-local.sh ${jaiabot_systemd_type} --bot_index $jaia_bot_index --fleet_index $jaia_fleet_index --electronics_stack $jaia_electronics_stack --imu_type $jaia_imu_type --imu_install_type $jaia_imu_install_type --arduino_type $jaia_arduino_type --bot_type ${jaia_bot_type,,} --bot_vin "${jaia_bot_vin:-unknown_vin}" --pam_connection_type ${jaia_pam_connection_type,,} $jaia_simulation --enable --motor_harness_type ${jaia_motor_harness_type,,} --camera_positions ${jaia_camera_positions,,} --additional_sensors ${jaia_additional_sensors}) || { echo "❌ Failed to install the $jaiabot_systemd_type systemd services, so this deploy is still running the previously installed code"; exit 1; }
 
     else
 
         cd ${HOME}/jaiabot/config/gen
         (set -x; export PATH=${HOME}/jaiabot/${build_dir}/bin:$PATH;
-         ./systemd-local.sh ${jaiabot_systemd_type} --hub_index $jaia_hub_index --fleet_index $jaia_fleet_index --electronics_stack $jaia_electronics_stack --led_type hub_led $jaia_simulation --enable --user_role advanced)
+         ./systemd-local.sh ${jaiabot_systemd_type} --hub_index $jaia_hub_index --fleet_index $jaia_fleet_index --electronics_stack $jaia_electronics_stack --led_type hub_led $jaia_simulation --enable --user_role advanced) || { echo "❌ Failed to install the $jaiabot_systemd_type systemd services, so this deploy is still running the previously installed code"; exit 1; }
 
         sudo chmod o+x ${HOME}
         sudo a2ensite jcc

--- a/scripts/docker-arm64-build-and-deploy.sh
+++ b/scripts/docker-arm64-build-and-deploy.sh
@@ -90,7 +90,7 @@ else
         ssh ${botuser}@"${remote}" "jaiabot_systemd_type=${jaiabot_systemd_type} jaiabot_machine_type=${jaiabot_machine_type} docker_libgoby_version=${docker_libgoby_version} docker_libdccl_version=${docker_libdccl_version} bash -c \"./jaiabot/scripts/arm64-deploy.sh ${build_dir}\""
 
         if [ ! -z $jaiabot_systemd_type ]; then
-            echo "When you're ready, ssh ${botuser}@${hostname} and run 'sudo systemctl start jaiabot'"
+            echo "When you're ready, ssh ${botuser}@${remote} and run 'sudo systemctl start jaiabot'"
         fi
 
     done


### PR DESCRIPTION
## Summary

This PR fixes a few issues in the deployment scripts and updates the versioning format for development builds.

## Changes

- Changes the version text file to include the specific Git version and flags if there are any uncommitted changes.
- Fixes how arguments are passed to the local service script (systemd-local.sh) to prevent errors when starting.
- Adds clear error messages and stops the deployment process if the background services fail to install.

## Testing

- [x] Verify deploy script successfully deploys code to a bot
- [x] Confirm new Git versioning format is shown
- [x] Confirm a bot with no vin set no longer breaks the deploy
- [x] Confirm failed install reports failure