### PR TITLE
task/constant-heading-timer-in-quick-look

### DIFF
--- a/cmake/JaiaVersions.cmake
+++ b/cmake/JaiaVersions.cmake
@@ -81,4 +81,4 @@ set(PROJECT_SOVERSION "1")
 
 # increment when DCCL messages change. See also src/lib/messages/CMakeLists.txt
 # start at 1 as 0 would be used prior to introducing this version (goby::middleware::Group::broadcast_group == 0)
-set(PROJECT_INTERVEHICLE_API_VERSION 23)
+set(PROJECT_INTERVEHICLE_API_VERSION 24)

--- a/src/bin/fusion/fusion.cpp
+++ b/src/bin/fusion/fusion.cpp
@@ -515,6 +515,16 @@ jaiabot::apps::Fusion::Fusion() : ApplicationBase(5 * si::hertz)
             {
                 latest_bot_status_.clear_repeat_index();
             }
+
+            if (report.has_constant_heading_time_remaining())
+            {
+                latest_bot_status_.set_constant_heading_time_remaining(
+                    report.constant_heading_time_remaining());
+            }
+            else
+            {
+                latest_bot_status_.clear_constant_heading_time_remaining();
+            }
         });
 
     interprocess().subscribe<jaiabot::groups::raw_salinity>(

--- a/src/bin/mission_manager/mission_manager.cpp
+++ b/src/bin/mission_manager/mission_manager.cpp
@@ -662,6 +662,15 @@ void jaiabot::apps::MissionManager::publish_mission_report(protobuf::MissionStat
         report.set_repeat_index(in_mission->repeat_index());
     }
 
+    // Relay the time left in the constant heading task
+    const auto* constant_heading =
+        machine_->state_cast<const statechart::inmission::underway::task::ConstantHeading*>();
+
+    if (constant_heading)
+    {
+        report.set_constant_heading_time_remaining(constant_heading->time_remaining());
+    }
+
     // only report the goal index when not in recovery or trail
     if (in_mission && in_mission->goal_index() != statechart::InMission::RECOVERY_GOAL_INDEX)
     {

--- a/src/bin/mission_manager/mission_manager.cpp
+++ b/src/bin/mission_manager/mission_manager.cpp
@@ -663,12 +663,22 @@ void jaiabot::apps::MissionManager::publish_mission_report(protobuf::MissionStat
     }
 
     // Relay the time left in the constant heading task
-    const auto* constant_heading =
-        machine_->state_cast<const statechart::inmission::underway::task::ConstantHeading*>();
-
-    if (constant_heading)
+    if (state == protobuf::IN_MISSION__UNDERWAY__TASK__CONSTANT_HEADING)
     {
-        report.set_constant_heading_time_remaining(constant_heading->time_remaining());
+        const auto* constant_heading =
+            machine_->state_cast<const statechart::inmission::underway::task::ConstantHeading*>();
+
+        if (constant_heading)
+        {
+            report.set_constant_heading_time_remaining(constant_heading->time_remaining());
+        }
+        else if (in_mission && in_mission->current_goal().has_value())
+        {
+            // This report is published as the task is entered, before the state is active,
+            // so the whole configured time is still remaining
+            report.set_constant_heading_time_remaining(
+                in_mission->current_goal()->task().constant_heading().constant_heading_time());
+        }
     }
 
     // only report the goal index when not in recovery or trail

--- a/src/bin/mission_manager/mission_manager.cpp
+++ b/src/bin/mission_manager/mission_manager.cpp
@@ -665,16 +665,16 @@ void jaiabot::apps::MissionManager::publish_mission_report(protobuf::MissionStat
     // Relay the time left in the constant heading task
     if (state == protobuf::IN_MISSION__UNDERWAY__TASK__CONSTANT_HEADING)
     {
-        const auto* constant_heading =
-            machine_->state_cast<const statechart::inmission::underway::task::ConstantHeading*>();
-
-        if (constant_heading)
+        if (machine_->constant_heading_stop())
         {
-            report.set_constant_heading_time_remaining(constant_heading->time_remaining());
+            auto time_remaining = std::chrono::duration_cast<std::chrono::seconds>(
+                machine_->constant_heading_stop().get() - current_time);
+            report.set_constant_heading_time_remaining(
+                std::max<std::int64_t>(0, time_remaining.count()));
         }
         else if (in_mission && in_mission->current_goal().has_value())
         {
-            // This report is published as the task is entered, before the state is active,
+            // This report is published as the task is entered, before the deadline is set,
             // so the whole configured time is still remaining
             report.set_constant_heading_time_remaining(
                 in_mission->current_goal()->task().constant_heading().constant_heading_time());

--- a/src/bin/mission_manager/mission_manager_state_machine.h
+++ b/src/bin/mission_manager/mission_manager_state_machine.h
@@ -249,6 +249,16 @@ struct MissionManagerStateMachine
         return bottom_depth_safety_constant_heading_time_;
     }
 
+    void set_constant_heading_stop(const goby::time::SteadyClock::time_point& constant_heading_stop)
+    {
+        constant_heading_stop_ = constant_heading_stop;
+    }
+    void clear_constant_heading_stop() { constant_heading_stop_.reset(); }
+    const boost::optional<goby::time::SteadyClock::time_point>& constant_heading_stop()
+    {
+        return constant_heading_stop_;
+    }
+
     void set_bottom_safety_depth(const double& bottom_safety_depth)
     {
         bottom_safety_depth_ = bottom_safety_depth;
@@ -376,6 +386,7 @@ struct MissionManagerStateMachine
     double bottom_depth_safety_constant_heading_{0};
     double bottom_depth_safety_constant_heading_speed_{0};
     double bottom_depth_safety_constant_heading_time_{0};
+    boost::optional<goby::time::SteadyClock::time_point> constant_heading_stop_;
     double bottom_safety_depth_{cfg().min_depth_safety()};
     boost::units::quantity<boost::units::si::velocity> transit_speed_{
         2.0 * boost::units::si::meters_per_second};

--- a/src/bin/mission_manager/states/inmission/underway/task/constant_heading.h
+++ b/src/bin/mission_manager/states/inmission/underway/task/constant_heading.h
@@ -55,6 +55,9 @@ struct ConstantHeading
         goby::time::SteadyClock::duration setpoint_duration = std::chrono::seconds(setpoint_seconds);
         setpoint_stop_ = setpoint_start + setpoint_duration;
 
+        // Share the deadline so the mission report can count down to it
+        this->machine().set_constant_heading_stop(setpoint_stop_);
+
         // Turn on pid for constant heading (different than the transit pid)
         context<InMission>().set_use_heading_constant_pid(true);
     }
@@ -68,6 +71,8 @@ struct ConstantHeading
         this->interprocess().publish<groups::mission_ivp_behavior_update>(constantHeadingUpdate);
         this->interprocess().publish<groups::mission_ivp_behavior_update>(constantSpeedUpdate);
 
+        this->machine().clear_constant_heading_stop();
+
         // Turn off pid for constant heading (different than the transit pid)
         context<InMission>().set_use_heading_constant_pid(false);
     }
@@ -77,13 +82,6 @@ struct ConstantHeading
         goby::time::SteadyClock::time_point now = goby::time::SteadyClock::now();
         if (now >= setpoint_stop_)
             post_event(EvTaskComplete());
-    }
-
-    int time_remaining() const
-    {
-        auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
-            setpoint_stop_ - goby::time::SteadyClock::now());
-        return std::max<std::int64_t>(0, remaining.count());
     }
 
     using reactions = boost::mpl::list<

--- a/src/bin/mission_manager/states/inmission/underway/task/constant_heading.h
+++ b/src/bin/mission_manager/states/inmission/underway/task/constant_heading.h
@@ -79,6 +79,13 @@ struct ConstantHeading
             post_event(EvTaskComplete());
     }
 
+    int time_remaining() const
+    {
+        auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
+            setpoint_stop_ - goby::time::SteadyClock::now());
+        return std::max<std::int64_t>(0, remaining.count());
+    }
+
     using reactions = boost::mpl::list<
         boost::statechart::in_state_reaction<EvLoop, ConstantHeading, &ConstantHeading::loop>>;
 

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -97,9 +97,9 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xc4f31768df8d6cbe")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0x068d7939ccc601ca")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xc2b6ff5101df098c")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0x0f49a512d736e37c")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x353435896a1ea1a0")
-  check_dccl_md5_hash("jaiabot.protobuf.Hub2HubData" "0x4b4262065989785d")
+  check_dccl_md5_hash("jaiabot.protobuf.Hub2HubData" "0xb31f017bb7f705c9")
 endif()

--- a/src/lib/messages/jaia_dccl.proto
+++ b/src/lib/messages/jaia_dccl.proto
@@ -144,11 +144,11 @@ message CommandForHub
 message BotStatus
 {
     /*
-    Actual maximum size of message: 48 bytes / 384 bits
+    Actual maximum size of message: 55 bytes / 440 bits
         dccl.id head...........................8
         user head..............................0
-        body.................................369
-        padding to full byte...................7
+        body.................................432
+        padding to full byte...................0
     Allowed maximum size of message: 250 bytes / 2000 bits
     */
     option (dccl.msg) = {
@@ -341,6 +341,15 @@ message BotStatus
     ];
     optional int32 repeat_index = 44 [
         (dccl.field) = { min: 0 max: 1000 precision: 0 },
+        (jaia.field).rest_api.presence = GUARANTEED
+    ];
+    optional uint32 constant_heading_time_remaining = 45 [
+        (dccl.field) = {
+            min: 0
+            max: 3600
+            precision: 0
+            units { base_dimensions: "T" }
+        },
         (jaia.field).rest_api.presence = GUARANTEED
     ];
 

--- a/src/lib/messages/mission.proto
+++ b/src/lib/messages/mission.proto
@@ -176,6 +176,12 @@ message MissionReport
         [(dccl.field) = { min: 0 max: 100 precision: 0 }];
     optional int32 repeat_index = 16
         [(dccl.field) = { min: 0 max: 1000 precision: 0 }];
+    optional uint32 constant_heading_time_remaining = 17 [(dccl.field) = {
+        min: 0
+        max: 3600
+        precision: 0
+        units { base_dimensions: "T" }
+    }];
     optional uint32 command_from_hub_id = 70
         [(dccl.field) = { min: 0 max: 30 }];
     optional uint64 mission_command_time = 71 [

--- a/src/web/components/BotDetails/BotDetails.tsx
+++ b/src/web/components/BotDetails/BotDetails.tsx
@@ -29,6 +29,7 @@ import {
     getDistToWaypoint,
     isBotLogging,
     searchGhostMissions,
+    getConstantHeadingTimeRemaining,
 } from "./bot-details";
 
 import { accordionTheme, addDropdownListener } from "../../utils/style";
@@ -200,6 +201,15 @@ export default function BotDetails() {
                                                 {getDistToWaypoint(missionStatus)}
                                             </td>
                                         </tr>
+                                        {missionStatus?.missionState ===
+                                            "IN_MISSION__UNDERWAY__TASK__CONSTANT_HEADING" && (
+                                            <tr>
+                                                <td>Constant Heading Time</td>
+                                                <td>
+                                                    {getConstantHeadingTimeRemaining(missionStatus)}
+                                                </td>
+                                            </tr>
+                                        )}
                                         <tr>
                                             <td>Hub Distance</td>
                                             <td>

--- a/src/web/components/BotDetails/bot-details.ts
+++ b/src/web/components/BotDetails/bot-details.ts
@@ -125,6 +125,19 @@ export function getDistToWaypoint(missionStatus: MissionStatus) {
 }
 
 /**
+ * Constructs a string to display the time left in the Bot's constant heading task
+ *
+ * @param {MissionStatus} missionStatus Contains the time remaining in the constant heading task
+ * @returns {string} Time remaining in seconds or N/A
+ */
+export function getConstantHeadingTimeRemaining(missionStatus: MissionStatus) {
+    if (missionStatus.constantHeadingTimeRemaining === undefined) {
+        return "N/A";
+    }
+    return missionStatus.constantHeadingTimeRemaining + " s";
+}
+
+/**
  * Loops through the ghost missions to check if a Bot is carrying out a mission
  *
  * @param {number} botID Bot of interest

--- a/src/web/data/bots/__tests__/bots.test.ts
+++ b/src/web/data/bots/__tests__/bots.test.ts
@@ -24,3 +24,8 @@ test("Verify bots are sorted when adding", () => {
     expect(addedBots[1].getBotID()).toEqual(2);
     expect(addedBots[2].getBotID()).toEqual(5);
 });
+
+test("Verify a zero constant heading time remaining is preserved", () => {
+    bots.setBot({ bot_id: 1, constant_heading_time_remaining: 0 });
+    expect(bots.getBot(1).getMissionStatus().constantHeadingTimeRemaining).toEqual(0);
+});

--- a/src/web/data/bots/bots.ts
+++ b/src/web/data/bots/bots.ts
@@ -154,6 +154,10 @@ export class Bots {
             missionStatus.repeatIndex = botStatus.repeat_index;
         }
 
+        if (botStatus.constant_heading_time_remaining !== undefined) {
+            missionStatus.constantHeadingTimeRemaining = botStatus.constant_heading_time_remaining;
+        }
+
         bot.setMissionStatus(missionStatus);
 
         // BotSensors

--- a/src/web/shared/JAIAProtobuf.ts
+++ b/src/web/shared/JAIAProtobuf.ts
@@ -1030,6 +1030,7 @@ export interface BotStatus {
     distance_to_active_goal?: number;
     active_goal_timeout?: number;
     repeat_index?: number;
+    constant_heading_time_remaining?: number;
     salinity?: number;
     temperature?: number;
     battery_percent?: number;

--- a/src/web/types/jaia-system-types.ts
+++ b/src/web/types/jaia-system-types.ts
@@ -35,6 +35,7 @@ export interface MissionStatus {
     targetWaypoint?: number;
     distanceToTargetWaypoint?: number;
     repeatIndex?: number;
+    constantHeadingTimeRemaining?: number;
 }
 
 export interface TaskParameters {

--- a/src/web/types/protobuf-types.ts
+++ b/src/web/types/protobuf-types.ts
@@ -1040,6 +1040,7 @@ export interface BotStatus {
     distance_to_active_goal?: number;
     active_goal_timeout?: number;
     repeat_index?: number;
+    constant_heading_time_remaining?: number;
     salinity?: number;
     temperature?: number;
     battery_percent?: number;


### PR DESCRIPTION
## Summary

This PR adds a constant heading countdown timer to quick look. 

## Changes

- The `ConstantHeading` state now relays its remaining time, and the mission manager reports it in a new `constant_heading_time_remaining` field on `MissionReport` (in seconds).
- The same field was added to `BotStatus` so the value reaches the hub. 
  - This addition also required the `BotStatus` and `Hub2HubData` DCCL hashes to change. The intervehicle API version and both corresponding hashes were updated. 
- The quick look panel gains a "Constant Heading Time" row, rendered only while the bot's mission state is `IN_MISSION__UNDERWAY__TASK__CONSTANT_HEADING`. 
- Added a unit test covering a remaining time of zero. 

## Testing

- [x] Tested in sim
  - [x] Constant heading countdown does not appear before bot enters a constant heading task
  - [x] Constant heading decrements over time 
  - [x] Countdown field disappears after constant heading task is completed