### PR TITLE
task/investigate-small-base-map-layer-for-world-sw-2511

### DIFF
--- a/src/web/openlayers/layers/layers.ts
+++ b/src/web/openlayers/layers/layers.ts
@@ -1,5 +1,6 @@
 import { Layer } from "ol/layer";
 // Tile layers
+import { NaturalEarthLayer } from "./tile/natural-earth-layer";
 import { OSMLayer } from "./tile/osm-layer";
 import { arcGISSatelliteLayer } from "./tile/arc-gis-sattelite-layer";
 import { noaaENCLayer } from "./tile/noaa-enc-layer";
@@ -24,6 +25,7 @@ class Layers {
     constructor() {
         this.layers = new Map<LayerTitles, Layer>();
         // Tile layers
+        this.layers.set(LayerTitles.NATURAL_EARTH_LAYER, NaturalEarthLayer);
         this.layers.set(LayerTitles.OSM_LAYER, OSMLayer);
         this.layers.set(LayerTitles.ARC_GIS_SATELLITE_LAYER, arcGISSatelliteLayer);
         this.layers.set(LayerTitles.NOAA_ENC_LAYER, noaaENCLayer);
@@ -44,6 +46,9 @@ class Layers {
         this.layers.set(LayerTitles.EXCLUSION_ZONE_LAYER, exclusionZoneLayer.getVectorLayer());
         this.layers.set(LayerTitles.MEASURE_LAYER, measureLayer.getVectorLayer());
         this.layers.set(LayerTitles.HUB_COMMS_LAYER, hubCommsLayer.getVectorLayer());
+
+        console.log("Layers: ");
+        console.log(this.layers);
     }
 
     getLayers() {

--- a/src/web/openlayers/layers/tile/natural-earth-layer.ts
+++ b/src/web/openlayers/layers/tile/natural-earth-layer.ts
@@ -1,0 +1,16 @@
+import TileLayer from "ol/layer/Tile";
+import { XYZ } from "ol/source";
+import { NATURAL_EARTH_MAX_ZOOM } from "../../../utils/constants";
+
+export const NaturalEarthLayer = new TileLayer({
+    properties: {
+        title: "natural-earth-layer",
+    },
+    source: new XYZ({
+        url: "/maps/natural-earth/{z}/{x}/{y}",
+        attributions: "Map data: © Natural Earth contributors",
+        attributionsCollapsible: false,
+        wrapX: false,
+        maxZoom: NATURAL_EARTH_MAX_ZOOM,
+    }),
+});

--- a/src/web/server/map_tile_server/__init__.py
+++ b/src/web/server/map_tile_server/__init__.py
@@ -9,7 +9,7 @@ from rasterio.warp import transform
 from . import mime_types
 from . import geotiff
 from .utils import *
-
+from .mapnik_renderer import TileRenderer, MapnikTileRenderer
 
 logging.basicConfig()
 l = logging.getLogger(__name__)
@@ -95,8 +95,9 @@ class MapTileServer:
     maps_directory: str
     tiles_directory: str
     geotiffs_directory: str
+    natural_earth_renderer: TileRenderer
 
-    def __init__(self, maps_directory: str):
+    def __init__(self, maps_directory: str, natural_earth_renderer: TileRenderer=MapnikTileRenderer('/etc/jaiabot/10m.xml.template')):
         """Create a MapTileServer
 
         Args:
@@ -111,6 +112,8 @@ class MapTileServer:
         os.makedirs(self.geotiffs_directory, exist_ok=True)
 
         geotiff.watch_directory_and_convert_to_tiles(self.geotiffs_directory, self.tiles_directory)
+
+        self.natural_earth_renderer = natural_earth_renderer
 
 
     def get_maps(self):
@@ -146,7 +149,11 @@ class MapTileServer:
         Returns:
             bytes or None: Binary image data in png format, if the image exists.
         """
-        tile_path = f'{self.tiles_directory}/{map_name}/{z}/{x}/{y}.png'
+        if map_name == 'natural-earth':
+            tile_path = self.natural_earth_renderer.render_tile(z, x, y)
+        else:
+            tile_path = f'{self.tiles_directory}/{map_name}/{z}/{x}/{y}.png'
+
         if not os.path.isfile(tile_path):
             return None
         else:

--- a/src/web/server/map_tile_server/mapnik_renderer.py
+++ b/src/web/server/map_tile_server/mapnik_renderer.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from typing import Protocol
+import mapnik
+import flask
+from string import Template
+
+
+WEB_MERCATOR_MIN = -20037508.34
+WEB_MERCATOR_MAX = 20037508.34
+WEB_MERCATOR_SIZE = 40075016.68
+
+
+class TileRenderer(Protocol):
+    def __init__(self, map_name: str):
+        ...
+
+    def render_tile(self, z: int, x: int, y: int) -> str:
+        """Renders a tile if necessary, and returns the path to the tile.
+
+        Args:
+            z (int): Web mercator zoom level.
+            x (int): Web mercator tile x coordinate.
+            y (int): Web mercator tile y coordinate.
+
+        Returns:
+            str: Path to the rendered tile.
+        """
+        ...
+
+
+    def clear_cache(self) -> None:
+        """Clears the tile cache."""
+        ...    
+
+
+class MapnikTileRenderer(TileRenderer):
+    map_name: str
+    tiles_path: str
+    stylesheet_template: Template
+    base_path: str
+    _cached_tile_count: int = 0
+    max_cached_tiles: int = 2000
+
+    def __init__(self, xml_template: str, max_cached_tiles: int = 2000):
+        self.map_name = os.path.splitext(os.path.basename(xml_template))[0]
+
+        cache_dir = '/var/log/jaiabot/cache/mapnik_tiles'
+        self.tiles_path = os.path.join(cache_dir, f"{self.map_name}")
+        os.makedirs(self.tiles_path, exist_ok=True)
+
+        self._cached_tile_count = sum(1 for _ in os.scandir(self.tiles_path))
+        self.stylesheet_template = Template(open(xml_template).read())
+        self.base_path = os.path.dirname(xml_template)
+        self.max_cached_tiles = max_cached_tiles
+
+    def render_tile(self, z: int, x: int, y: int) -> str:
+        output = f"{self.tiles_path}/tile_{z}_{x}_{y}.png"
+
+        if os.path.exists(output):
+            return output
+
+        m = mapnik.Map(256, 256)
+
+        # True makes relative paths resolve from the XML file's directory.
+        mapnik.load_map_from_string(m, self.stylesheet_template.substitute(z=z), False, self.base_path)
+
+        tile_side = WEB_MERCATOR_SIZE / (2 ** z)
+
+        tile_bbox = mapnik.Box2d(
+            WEB_MERCATOR_MIN + tile_side * x,
+            WEB_MERCATOR_MAX - tile_side * y,
+            WEB_MERCATOR_MIN + tile_side * (x + 1),
+            WEB_MERCATOR_MAX - tile_side * (y + 1),
+        )
+
+        m.zoom_to_box(tile_bbox)
+        mapnik.render_to_file(m, output, "png", 2.0)
+
+        self._cached_tile_count += 1
+
+        # Remove the oldest (earliest access time) half of the tile cache if we have too many cached tiles.
+        if self._cached_tile_count > self.max_cached_tiles:
+            tiles = sorted(
+                os.scandir(self.tiles_path), key=lambda entry: entry.stat().st_atime
+            )
+
+            tiles_to_remove = len(tiles) // 2
+
+            for tile_index, tile in enumerate(tiles):
+                if tile_index >= tiles_to_remove:
+                    break
+
+                os.remove(tile.path)
+                self._cached_tile_count -= 1
+
+            self._cached_tile_count = len(tiles) - tiles_to_remove
+
+        return output
+
+
+    def clear_cache(self) -> None:
+        """Clears the tile cache."""
+        for tile in os.scandir(self.tiles_path):
+            os.remove(tile.path)
+        self._cached_tile_count = 0
+
+
+class TileServer:
+    app: flask.Flask
+    renderer: TileRenderer
+
+    def __init__(self, renderer: TileRenderer):
+        self.renderer = renderer
+        self.app = flask.Flask(__name__)
+        self.app.add_url_rule(
+            "/tiles/tile_<int:z>_<int:x>_<int:y>.png",
+            view_func=self.serve_tile,
+        )
+        self.app.add_url_rule("/", view_func=self.index)
+
+    def serve_tile(self, z: int, x: int, y: int) -> flask.Response:
+        tile_path = self.renderer.render_tile(z, x, y)
+        return flask.send_file(tile_path, mimetype="image/png")
+
+    def index(self) -> str:
+        return flask.send_file("index.html", mimetype="text/html")
+
+
+    def run(self, **kwargs) -> None:
+        self.app.run(**kwargs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Render a Mapnik XML stylesheet to an image."
+    )
+
+    parser.add_argument('xml_template', type=str, help='Path to the Mapnik XML template file.')
+    parser.add_argument('-c', '--clear-cache', action='store_true', help='Clear the tile cache before starting the server.')
+    args = parser.parse_args()
+
+    renderer = MapnikTileRenderer(args.xml_template)
+    server = TileServer(renderer)
+    if args.clear_cache:
+        renderer.clear_cache()
+    server.run(host="0.0.0.0", port=8080, threaded=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/web/types/openlayers-types.ts
+++ b/src/web/types/openlayers-types.ts
@@ -1,6 +1,7 @@
 export enum LayerTitles {
     // Empty string needed for MUI Select default
     NONE = "",
+    NATURAL_EARTH_LAYER = "natural-earth-layer",
     OSM_LAYER = "open-street-maps-layer",
     ARC_GIS_SATELLITE_LAYER = "arg-gis-satellite-layer",
     NOAA_ENC_LAYER = "noaa-enc-layer",

--- a/src/web/utils/constants.ts
+++ b/src/web/utils/constants.ts
@@ -13,6 +13,7 @@ export const TASK_PACKET_POLL_TIME = 1000; // milliseconds
 export const METADATA_POLL_TIME = 10_000; // milliseconds
 export const INTERNET_POLL_TIME = 15_000; // millisecondss
 export const GITHUB_POLL_TIME = 120_000; // milliseconds
+export const NATURAL_EARTH_MAX_ZOOM = 19;
 export const OSM_MAX_ZOOM = 19;
 export const ARC_GIS_MAX_ZOOM = 19;
 export const SCROLL_DELAY = 30; // milliseconds


### PR DESCRIPTION
## Summary
Add Natural Earth map layer that accesses local tiles at /maps/naturall-earth/<z>/<x>/<y>.

These tiles are rendered on demand and cached by the MapnikTileRenderer class.

## Test Procedure

Starting JCC with the proper Mapnik xml style template, and Natural Earth shapefiles in the correct location, will allow JCC to render the tiles as the backmost layer.

The xml template and Natural Earth data are not included in the repository for this draft pull request.  Discussion should take place about where this binary data should live.