### PR TITLE
feature/dual-fluorometer-support

### DIFF
--- a/cmake/JaiaProtobuf.cmake
+++ b/cmake/JaiaProtobuf.cmake
@@ -82,6 +82,10 @@ function(jaiabot_protobuf_make_symlinks)
     if("${lnk}" STREQUAL "NANOPB")
       set(NANOPB_PROTO /usr/lib/python3/dist-packages/proto/nanopb.proto)
       file(CREATE_LINK "${NANOPB_PROTO}" "${CMAKE_CURRENT_SOURCE_DIR}/nanopb.proto" SYMBOLIC)
+      # the sensor messages shared with the payload board MCU import nanopb.proto, so any
+      # application importing them needs protoc to resolve it from the shared include dir too
+      file(MAKE_DIRECTORY "${project_INC_DIR}")
+      file(CREATE_LINK "${NANOPB_PROTO}" "${project_INC_DIR}/nanopb.proto" SYMBOLIC)
     elseif("${lnk}" STREQUAL "DCCL")
       file(CREATE_LINK "${DCCL_INCLUDE_DIR}/dccl" "${CMAKE_CURRENT_SOURCE_DIR}/dccl" SYMBOLIC)
     elseif("${lnk}" STREQUAL "GOOGLE")

--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -147,10 +147,19 @@ try:
 except FileNotFoundError:
     xbee_info = 'xbee {}'
 
-try:
-    fluorometer_coefficients = 'fluorometer_coefficients { \n' + open('/etc/jaiabot/fluorometer_coefficients.pb.cfg').read() + '\n}\n'
-except FileNotFoundError:
-    fluorometer_coefficients = 'fluorometer_coefficients {}'
+def read_fluorometer_coefficients(*paths):
+    for path in paths:
+        try:
+            return 'fluorometer_coefficients { \n' + open(path).read() + '\n}\n'
+        except FileNotFoundError:
+            continue
+    return 'fluorometer_coefficients {}'
+
+# bots provisioned before dual fluorometer support have a single unnumbered file, which
+# belongs to the first fluorometer
+fluorometer_coefficients = read_fluorometer_coefficients('/etc/jaiabot/fluorometer_coefficients_1.pb.cfg',
+                                                         '/etc/jaiabot/fluorometer_coefficients.pb.cfg')
+fluorometer_coefficients_2 = read_fluorometer_coefficients('/etc/jaiabot/fluorometer_coefficients_2.pb.cfg')
 
 ack_timeout=10
 iridium_ack_timeout=120
@@ -359,7 +368,8 @@ elif common.app == 'jaiabot_sensors':
                                      interprocess_block=interprocess_common,
                                      port='/dev/ttyUSB0',
                                      baud=115200,
-                                     fluorometer_coefficients=fluorometer_coefficients))
+                                     fluorometer_coefficients=fluorometer_coefficients,
+                                     fluorometer_coefficients_2=fluorometer_coefficients_2))
 elif common.app == 'jaiabot_engineering':
     print(config.template_substitute(templates_dir+'/bot/jaiabot_engineering.pb.cfg.in',
                                      app_block=app_common,

--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -153,7 +153,8 @@ def read_fluorometer_coefficients(*paths):
             return 'fluorometer_coefficients { \n' + open(path).read() + '\n}\n'
         except FileNotFoundError:
             continue
-    return 'fluorometer_coefficients {}'
+    # leaving the block out entirely is how the driver knows this fluorometer is not set up
+    return ''
 
 # bots provisioned before dual fluorometer support have a single unnumbered file, which
 # belongs to the first fluorometer

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -673,7 +673,10 @@ if 'none' not in camera_positions_in_use:
     ]
     jaiabot_apps.extend(jaiabot_apps_camera)
 
-if 'turner_c_fluor' in jaia_additional_sensors or 'turner_c_flour' in jaia_additional_sensors:
+# on BIO bots the fluorometers are read through the payload board by jaiabot_sensors, so this
+# standalone analog driver would publish a second, indistinguishable stream on the same group
+if ('turner_c_fluor' in jaia_additional_sensors or 'turner_c_flour' in jaia_additional_sensors) \
+   and jaia_bot_type != BOT_TYPE.BIO:
     jaiabot_turner_c_fluor = [
         {'exe': 'jaiabot_turner_c_fluor_sensor_driver',
         'description': 'JaiaBot Turner C Fluor Sensor Driver',

--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -68,7 +68,7 @@ parser.add_argument('--rf_encryption_password', default ='', help='Encryption ke
 parser.add_argument('--comms_links', choices=['xbee', 'wifi', 'iridium'], nargs="+", default=['xbee'], help='Select one or more comms_links')
 parser.add_argument('--camera_positions', choices=['aft', 'fore', 'outward', 'none'], nargs="+", default=['none'], help='Select one or more camera_positions')
 parser.add_argument('--dccl_encryption_password', default ='', help='Encryption passphrase for DCCL (intervehicle) messages: can be any string')
-parser.add_argument('--additional_sensors', choices=['turner_c_flour', 'aml', 'ppk', 'none'], nargs="+", default=['none'], help='Select one or more additional sensors')
+parser.add_argument('--additional_sensors', choices=['turner_c_fluor', 'turner_c_flour', 'aml', 'ppk', 'none'], nargs="+", default=['none'], help='Select one or more additional sensors')
 parser.add_argument('--tail_serial_number', default='unknown_serial_number', help='Tail serial number to use for this bot (defaults to "unknown_serial_number")')
 
 args=parser.parse_args()
@@ -673,7 +673,7 @@ if 'none' not in camera_positions_in_use:
     ]
     jaiabot_apps.extend(jaiabot_apps_camera)
 
-if 'turner_c_flour' in jaia_additional_sensors:
+if 'turner_c_fluor' in jaia_additional_sensors or 'turner_c_flour' in jaia_additional_sensors:
     jaiabot_turner_c_fluor = [
         {'exe': 'jaiabot_turner_c_fluor_sensor_driver',
         'description': 'JaiaBot Turner C Fluor Sensor Driver',

--- a/config/templates/bot/fluorometer_coefficients.pb.cfg
+++ b/config/templates/bot/fluorometer_coefficients.pb.cfg
@@ -1,3 +1,0 @@
-offset: 10.0
-coefficient: 942.0
-serial_number: 87654321

--- a/config/templates/bot/fluorometer_coefficients_1.pb.cfg
+++ b/config/templates/bot/fluorometer_coefficients_1.pb.cfg
@@ -1,0 +1,4 @@
+offset: 10.0
+coefficient: 942.0
+serial_number: 87654321
+analyte_name: "Chlorophyll-a"

--- a/config/templates/bot/fluorometer_coefficients_2.pb.cfg
+++ b/config/templates/bot/fluorometer_coefficients_2.pb.cfg
@@ -1,0 +1,4 @@
+offset: 9.5
+coefficient: 1010.0
+serial_number: 87654322
+analyte_name: "CDOM"

--- a/config/templates/bot/jaiabot_sensors.pb.cfg.in
+++ b/config/templates/bot/jaiabot_sensors.pb.cfg.in
@@ -12,3 +12,10 @@ fluorometer {
     $fluorometer_coefficients
 }
 
+fluorometer_2 {
+    sample_rate: 10
+    report_timeout_seconds: 20
+    resend_cfg_timeout_seconds: 20
+    $fluorometer_coefficients_2
+}
+

--- a/debian/jaiabot-embedded.templates
+++ b/debian/jaiabot-embedded.templates
@@ -157,7 +157,7 @@ Description: Encryption passphrase for DCCL (intervehicle) messages: can be any 
 
 Template: jaiabot-embedded/additional_sensors
 Type: multiselect
-Choices: turner_c_flour, aml, ppk, none
+Choices: turner_c_fluor, aml, ppk, none
 Default: none
 Description: Which additional sensors?
 

--- a/src/bin/drivers/turner_c_fluor_sensor/app.cpp
+++ b/src/bin/drivers/turner_c_fluor_sensor/app.cpp
@@ -77,6 +77,9 @@ jaiabot::apps::TurnerCFluorSensorDriver::TurnerCFluorSensorDriver()
 
         jaiabot::sensor::protobuf::TurnerCFluor turner_c_fluor_msg;
 
+        // this driver reads a single fluorometer off the Arduino analog pin
+        turner_c_fluor_msg.set_instance(jaiabot::sensor::protobuf::INSTANCE_1);
+
         if (arduino_response.has_generic_gpio_voltage())
         {
             turner_c_fluor_msg.set_concentration_voltage(arduino_response.generic_gpio_voltage());
@@ -87,6 +90,11 @@ jaiabot::apps::TurnerCFluorSensorDriver::TurnerCFluorSensorDriver()
                 fcoefficients_ = cfg().fluorometer_coefficients();
                 double concentration = (turner_c_fluor_msg.concentration_voltage() - fcoefficients_.offset()) * fcoefficients_.coefficient();
                 turner_c_fluor_msg.set_concentration(concentration);
+
+                if (fcoefficients_.has_analyte_name())
+                {
+                    turner_c_fluor_msg.set_analyte_name(fcoefficients_.analyte_name());
+                }
             }
         }
 

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -69,12 +69,15 @@ class Sensors : public zeromq::MultiThreadApplication<config::Sensors>
     void receive_metadata_from_mcu(const sensor::protobuf::Metadata& metadata);
 
   private:
-    std::set<jaiabot::sensor::protobuf::Sensor> drivers_launched_;
-    std::set<jaiabot::sensor::protobuf::Sensor> failed_initializations;
-    std::map<jaiabot::sensor::protobuf::Sensor, jaiabot::protobuf::Error>
-        initialization_error_names;
-    std::map<jaiabot::sensor::protobuf::Sensor, jaiabot::protobuf::Warning>
-        initialization_warning_names;
+    // several instances of the same sensor may be present on the payload board, so all
+    // per-sensor state is keyed by sensor and instance together
+    using SensorKey =
+        std::pair<jaiabot::sensor::protobuf::Sensor, jaiabot::sensor::protobuf::SensorInstance>;
+
+    std::set<SensorKey> drivers_launched_;
+    std::set<SensorKey> failed_initializations;
+    std::map<SensorKey, jaiabot::protobuf::Error> initialization_error_names;
+    std::map<SensorKey, jaiabot::protobuf::Warning> initialization_warning_names;
     boost::crc_32_type crc32_calc_;
 };
 
@@ -109,19 +112,23 @@ jaiabot::apps::Sensors::Sensors()
 
     launch_thread<MCUSerialThread>(cfg().mcu_serial());
 
-    initialization_error_names = {{jaiabot::sensor::protobuf::BLUE_ROBOTICS__BAR30,
-                                   jaiabot::protobuf::ERROR__INIT_FAILED__BLUE_ROBOTICS__BAR30}};
+    initialization_error_names = {
+        {{jaiabot::sensor::protobuf::BLUE_ROBOTICS__BAR30, jaiabot::sensor::protobuf::INSTANCE_1},
+         jaiabot::protobuf::ERROR__INIT_FAILED__BLUE_ROBOTICS__BAR30}};
 
     initialization_warning_names = {
-        {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_DO,
+        {{jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_DO,
+          jaiabot::sensor::protobuf::INSTANCE_1},
          jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_DO},
-        {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_EC,
+        {{jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_EC,
+          jaiabot::sensor::protobuf::INSTANCE_1},
          jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_EC},
-        {jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_PH,
+        {{jaiabot::sensor::protobuf::ATLAS_SCIENTIFIC__OEM_PH,
+          jaiabot::sensor::protobuf::INSTANCE_1},
          jaiabot::protobuf::WARNING__INIT_FAILED__ATLAS_SCIENTIFIC__OEM_PH},
-        {jaiabot::sensor::protobuf::TURNER__C_FLUOR,
+        {{jaiabot::sensor::protobuf::TURNER__C_FLUOR, jaiabot::sensor::protobuf::INSTANCE_1},
          jaiabot::protobuf::WARNING__INIT_FAILED__TURNER__C_FLUOR},
-        {jaiabot::sensor::protobuf::AML__SENSOR, 
+        {{jaiabot::sensor::protobuf::AML__SENSOR, jaiabot::sensor::protobuf::INSTANCE_1},
          jaiabot::protobuf::WARNING__INIT_FAILED__AML}};
 }
 
@@ -138,7 +145,7 @@ void jaiabot::apps::Sensors::health(goby::middleware::protobuf::ThreadHealth& he
 {
     health.ClearExtension(jaiabot::protobuf::jaiabot_thread);
 
-    for (const jaiabot::sensor::protobuf::Sensor& sensor : failed_initializations)
+    for (const SensorKey& sensor : failed_initializations)
     {
         if (initialization_error_names.count(sensor) == 1)
         {
@@ -237,10 +244,15 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
 
 void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::Metadata& metadata)
 {
-    if (drivers_launched_.count(metadata.sensor()))
+    // MCUs predating multiple instances of a sensor leave instance unset, which reads back
+    // as INSTANCE_1
+    SensorKey sensor_key{metadata.sensor(), metadata.instance()};
+
+    if (drivers_launched_.count(sensor_key))
     {
         glog.is_warn() && glog << "Driver already launched for sensor: "
-                               << sensor::protobuf::Sensor_Name(metadata.sensor())
+                               << sensor::protobuf::Sensor_Name(metadata.sensor()) << " instance: "
+                               << sensor::protobuf::SensorInstance_Name(metadata.instance())
                                << ", not launching another." << std::endl;
 
         return;
@@ -248,7 +260,7 @@ void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::M
 
     if (metadata.init_failed())
     {
-        failed_initializations.insert(metadata.sensor());
+        failed_initializations.insert(sensor_key);
         return;
     }
 
@@ -276,8 +288,12 @@ void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::M
             launch_thread<AtlasScientificOEMDODriver>(cfg().dissolved_oxygen());
             break;
 
+        // launched with an index so that a second fluorometer gets its own thread
         case sensor::protobuf::TURNER__C_FLUOR:
-            launch_thread<TurnerCFluorDriver>(cfg().fluorometer());
+            launch_thread<TurnerCFluorDriver>(metadata.instance(),
+                                              metadata.instance() == sensor::protobuf::INSTANCE_2
+                                                  ? cfg().fluorometer_2()
+                                                  : cfg().fluorometer());
             break;
 
         case sensor::protobuf::AML__SENSOR: 
@@ -289,5 +305,5 @@ void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::M
                                    << sensor::protobuf::Sensor_Name(metadata.sensor()) << std::endl;
     }
 
-    drivers_launched_.insert(metadata.sensor());
+    drivers_launched_.insert(sensor_key);
 }

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -205,7 +205,10 @@ void jaiabot::apps::Sensors::receive_from_mcu(const goby::middleware::protobuf::
         std::size_t i = 0;
         for (auto it = encoded.rbegin(), end = encoded.rbegin() + bytes_in_crc32; it != end;
              ++it, ++i)
-            provided_crc |= (*it) << (i * bits_in_byte);
+            // cast is required as char is signed on some platforms, which would sign-extend
+            // any CRC byte >= 0x80 and corrupt the comparison
+            provided_crc |= static_cast<std::uint32_t>(static_cast<std::uint8_t>(*it))
+                            << (i * bits_in_byte);
 
         if (computed_crc != provided_crc)
         {

--- a/src/bin/sensors/app.cpp
+++ b/src/bin/sensors/app.cpp
@@ -290,10 +290,22 @@ void jaiabot::apps::Sensors::receive_metadata_from_mcu(const sensor::protobuf::M
 
         // launched with an index so that a second fluorometer gets its own thread
         case sensor::protobuf::TURNER__C_FLUOR:
-            launch_thread<TurnerCFluorDriver>(metadata.instance(),
-                                              metadata.instance() == sensor::protobuf::INSTANCE_2
-                                                  ? cfg().fluorometer_2()
-                                                  : cfg().fluorometer());
+            // the payload board announces every fluorometer it can carry, whether or not a
+            // probe is plugged in, so run the second one only where it has been set up
+            if (metadata.instance() == sensor::protobuf::INSTANCE_2 &&
+                !cfg().fluorometer_2().has_fluorometer_coefficients())
+            {
+                glog.is_verbose() && glog << "No coefficients configured for the second "
+                                             "fluorometer, not launching its driver."
+                                          << std::endl;
+            }
+            else
+            {
+                launch_thread<TurnerCFluorDriver>(
+                    metadata.instance(), metadata.instance() == sensor::protobuf::INSTANCE_2
+                                             ? cfg().fluorometer_2()
+                                             : cfg().fluorometer());
+            }
             break;
 
         case sensor::protobuf::AML__SENSOR: 

--- a/src/bin/sensors/config.proto
+++ b/src/bin/sensors/config.proto
@@ -82,5 +82,6 @@ message Sensors
     optional AtlasOEMPHThreadConfig ph = 30;
     optional AtlasOEMDOThreadConfig dissolved_oxygen = 40;
     optional TurnerCFluorThreadConfig fluorometer = 50;  
+    optional TurnerCFluorThreadConfig fluorometer_2 = 51;
     optional AMLThreadConfig aml = 60;
 }

--- a/src/bin/sensors/drivers/turner__c_fluor.cpp
+++ b/src/bin/sensors/drivers/turner__c_fluor.cpp
@@ -31,14 +31,22 @@
 using goby::glog;
 
 jaiabot::apps::TurnerCFluorDriver::TurnerCFluorDriver(
-    const jaiabot::config::TurnerCFluorThreadConfig& config)
-    : goby::middleware::SimpleThread<jaiabot::config::TurnerCFluorThreadConfig>(config)
+    const jaiabot::config::TurnerCFluorThreadConfig& config, int index)
+    : goby::middleware::SimpleThread<jaiabot::config::TurnerCFluorThreadConfig>(config, 0, index)
 {
-    glog.add_group("turner_c_fluor", goby::util::Colors::blue);
+    // which of the fluorometers on the payload board this thread serves
+    instance_ = static_cast<jaiabot::sensor::protobuf::SensorInstance>(index);
+
+    if (instance_ == jaiabot::sensor::protobuf::INSTANCE_2)
+        glog_group_ = "turner_c_fluor_2";
+
+    glog.add_group(glog_group_, goby::util::Colors::blue);
 
     interthread().subscribe<jaiabot::groups::mcu_pb_data_in>(
         [this](const sensor::protobuf::SensorData& sensor_data) {
-            if (sensor_data.has_c_fluor())
+            // MCUs predating dual fluorometer support leave instance unset, which reads
+            // back as INSTANCE_1
+            if (sensor_data.has_c_fluor() && sensor_data.c_fluor().instance() == instance_)
                 receive_data(sensor_data.c_fluor());
         });
 
@@ -62,7 +70,7 @@ jaiabot::apps::TurnerCFluorDriver::TurnerCFluorDriver(
 void jaiabot::apps::TurnerCFluorDriver::receive_data(
     const sensor::protobuf::TurnerCFluor& turner_c_fluor_data)
 {
-    glog.is_debug1() && glog << group("turner_c_fluor") << "Received turner_c_fluor_data: "
+    glog.is_debug1() && glog << group(glog_group_) << "Received turner_c_fluor_data: "
                              << turner_c_fluor_data.ShortDebugString() << std::endl;
 
     jaiabot::sensor::protobuf::TurnerCFluor turner_c_fluor_msg;
@@ -74,11 +82,26 @@ void jaiabot::apps::TurnerCFluorDriver::receive_data(
     {
         turner_c_fluor_msg.set_concentration_voltage(turner_c_fluor_data.concentration_voltage());
     }
-    interprocess().publish<jaiabot::groups::fluorometer>(turner_c_fluor_msg);
+    turner_c_fluor_msg.set_instance(instance_);
+
+    // the probes are analog, so only the configured coefficients know what is being measured
+    if (fluorometer_coefficients_.has_analyte_name())
+    {
+        turner_c_fluor_msg.set_analyte_name(fluorometer_coefficients_.analyte_name());
+    }
+
+    if (instance_ == jaiabot::sensor::protobuf::INSTANCE_2)
+    {
+        interprocess().publish<jaiabot::groups::fluorometer_2>(turner_c_fluor_msg);
+    }
+    else
+    {
+        interprocess().publish<jaiabot::groups::fluorometer>(turner_c_fluor_msg);
+    }
 
     last_report_time_ = goby::time::SteadyClock::now();
 
-    // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA threadcd
+    // TODO - add calibration and metadata ID, convert to standardized message, and publish over to QA thread
 }
 
 void jaiabot::apps::TurnerCFluorDriver::send_cfg()
@@ -87,6 +110,7 @@ void jaiabot::apps::TurnerCFluorDriver::send_cfg()
     request.set_time_with_units(goby::time::SystemClock::now<goby::time::MicroTime>());
     auto& sensor_cfg = *request.mutable_cfg();
     sensor_cfg.set_sensor(jaiabot::sensor::protobuf::TURNER__C_FLUOR);
+    sensor_cfg.set_instance(instance_);
 
     sensor_cfg.set_sample_freq_with_units(sample_rate_ * boost::units::si::hertz);
 
@@ -99,16 +123,16 @@ void jaiabot::apps::TurnerCFluorDriver::send_cfg()
 
     if (fluorometer_coefficients_.has_coefficient())
     {
-        auto* cal_offset = sensor_cfg.add_cfg();
-        cal_offset->set_key("coefficient");
-        cal_offset->set_value(std::to_string(fluorometer_coefficients_.coefficient()));
+        auto* cal_coefficient = sensor_cfg.add_cfg();
+        cal_coefficient->set_key("coefficient");
+        cal_coefficient->set_value(std::to_string(fluorometer_coefficients_.coefficient()));
     }
 
     if (fluorometer_coefficients_.has_serial_number())
     {
-        auto* cal_offset = sensor_cfg.add_cfg();
-        cal_offset->set_key("serial_number");
-        cal_offset->set_value(std::to_string(fluorometer_coefficients_.serial_number()));
+        auto* cal_serial_number = sensor_cfg.add_cfg();
+        cal_serial_number->set_key("serial_number");
+        cal_serial_number->set_value(std::to_string(fluorometer_coefficients_.serial_number()));
     }
 
     interprocess().publish<jaiabot::groups::mcu_pb_data_out>(request);
@@ -120,7 +144,8 @@ void jaiabot::apps::TurnerCFluorDriver::health(goby::middleware::protobuf::Threa
 
     if (last_report_time_ + std::chrono::seconds(report_timeout_) < goby::time::SteadyClock::now())
     {
-        glog.is_warn() && glog << "Timeout on turner c fluorometer report" << std::endl;
+        glog.is_warn() && glog << group(glog_group_) << "Timeout on turner c fluorometer report"
+                               << std::endl;
         health_state = goby::middleware::protobuf::HEALTH__DEGRADED;
         health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
             ->add_warning(protobuf::WARNING__MISSING_DATA__TURNER_C_FLUOR_DATA);

--- a/src/bin/sensors/drivers/turner__c_fluor.h
+++ b/src/bin/sensors/drivers/turner__c_fluor.h
@@ -25,6 +25,7 @@
 
 #include "config.pb.h"
 #include "jaiabot/messages/health.pb.h"
+#include "jaiabot/messages/sensor/catalog.pb.h"
 #include "jaiabot/messages/sensor/sensor_core.pb.h"
 #include "jaiabot/messages/sensor/turner__c_fluor.pb.h"
 #include <goby/zeromq/application/multi_thread.h>
@@ -37,7 +38,9 @@ class TurnerCFluorDriver
     : public goby::middleware::SimpleThread<jaiabot::config::TurnerCFluorThreadConfig>
 {
   public:
-    TurnerCFluorDriver(const jaiabot::config::TurnerCFluorThreadConfig& config);
+    // index is the jaiabot::sensor::protobuf::SensorInstance this thread serves, which
+    // distinguishes the driver threads when the payload board has more than one fluorometer
+    TurnerCFluorDriver(const jaiabot::config::TurnerCFluorThreadConfig& config, int index);
 
   private:
     void receive_data(const sensor::protobuf::TurnerCFluor& fluor_data);
@@ -50,6 +53,9 @@ class TurnerCFluorDriver
     int32_t sample_rate_{10};
     int32_t report_timeout_{20};
     int32_t resend_cfg_timeout_{20};
+    jaiabot::sensor::protobuf::SensorInstance instance_{jaiabot::sensor::protobuf::INSTANCE_1};
+    // distinct per instance so the two threads are distinguishable in the debug log
+    std::string glog_group_{"turner_c_fluor"};
     jaiabot::sensor::protobuf::FluorCoefficients fluorometer_coefficients_;
 };
 

--- a/src/doc/markdown/page122_working_with_h5_files_in_jdv.md
+++ b/src/doc/markdown/page122_working_with_h5_files_in_jdv.md
@@ -167,19 +167,31 @@ https://github.com/jaiarobotics/jaiabot/tree/task/developer-log-analysis-tools
 ### Fluorometer Data
 - ***Concentration*** - *The concentration of a fluorophore reported by the fluorometer* <br>
 - ***Sensor Voltage*** - *The raw voltage reported by the fluorometer, before a calibration coefficient or offset have been applied* <br>
+- ***Analyte*** - *What the probe measures, taken from its configured coefficients. The probes are analog, so this cannot be detected and comes from `/etc/jaiabot/fluorometer_coefficients_N.pb.cfg`* <br>
 - *Measured via a **Turner Designs C Fluor***
   - http://docs.turnerdesigns.com/t2/doc/spec-guides/998-2125.pdf
+
+A BIO payload board may carry two fluorometers. The second reports under `jaiabot::fluorometer_2`; the paths are otherwise identical.
 
 ##### Data Paths
 | Data Field       | Unit   | Frequency | JDV Path                                       | HDF5 Log Path                                                                    |
 |------------------|--------|-----------|------------------------------------------------|----------------------------------------------------------------------------------|
 |**Concentration** |*Varies*|*10 Hz*    |`jaiabot::fluorometer` ➔ `concentration`        |`/jaiabot::fluorometer/jaiabot.sensor.protobuf.TurnerCFluor/concentration`        |
 |**Sensor Voltage**|*V*     |*10 Hz*    |`jaiabot::fluorometer` ➔ `concentration_voltage`|`/jaiabot::fluorometer/jaiabot.sensor.protobuf.TurnerCFluor/concentration_voltage`|
+|**Analyte**       |*N/A*   |*10 Hz*    |`jaiabot::fluorometer` ➔ `analyte_name`         |`/jaiabot::fluorometer/jaiabot.sensor.protobuf.TurnerCFluor/analyte_name`        |
+
+##### Data Paths (Second Fluorometer)
+| Data Field       | Unit   | Frequency | JDV Path                                         | HDF5 Log Path                                                                      |
+|------------------|--------|-----------|--------------------------------------------------|------------------------------------------------------------------------------------|
+|**Concentration** |*Varies*|*10 Hz*    |`jaiabot::fluorometer_2` ➔ `concentration`        |`/jaiabot::fluorometer_2/jaiabot.sensor.protobuf.TurnerCFluor/concentration`        |
+|**Sensor Voltage**|*V*     |*10 Hz*    |`jaiabot::fluorometer_2` ➔ `concentration_voltage`|`/jaiabot::fluorometer_2/jaiabot.sensor.protobuf.TurnerCFluor/concentration_voltage`|
+|**Analyte**       |*N/A*   |*10 Hz*    |`jaiabot::fluorometer_2` ➔ `analyte_name`         |`/jaiabot::fluorometer_2/jaiabot.sensor.protobuf.TurnerCFluor/analyte_name`        |
 
 ##### Timestamp Paths
-| Units        | JDV Path                         | HDF5 Log Path                                                      |
-|--------------|----------------------------------|--------------------------------------------------------------------|
-|*Microseconds*|`jaiabot::fluorometer` ➔ `_utime_`|`/jaiabot::fluorometer/jaiabot.sensor.protobuf.TurnerCFluor/_utime_`|
+| Units        | JDV Path                           | HDF5 Log Path                                                        |
+|--------------|------------------------------------|----------------------------------------------------------------------|
+|*Microseconds*|`jaiabot::fluorometer` ➔ `_utime_`  |`/jaiabot::fluorometer/jaiabot.sensor.protobuf.TurnerCFluor/_utime_`  |
+|*Microseconds*|`jaiabot::fluorometer_2` ➔ `_utime_`|`/jaiabot::fluorometer_2/jaiabot.sensor.protobuf.TurnerCFluor/_utime_`|
 <br>
 
 

--- a/src/lib/groups.h
+++ b/src/lib/groups.h
@@ -44,6 +44,7 @@ constexpr goby::middleware::Group salinity{"jaiabot::salinity"};
 constexpr goby::middleware::Group dissolved_oxygen{"jaiabot::dissolved_oxygen"};
 constexpr goby::middleware::Group ph{"jaiabot::ph"};
 constexpr goby::middleware::Group fluorometer{"jaiabot::fluorometer"};
+constexpr goby::middleware::Group fluorometer_2{"jaiabot::fluorometer_2"};
 constexpr goby::middleware::Group echo{"jaiabot::echo"};
 constexpr goby::middleware::Group tsys01{"jaiabot::tsys01"};
 constexpr goby::middleware::Group ctd{"jaiabot::ctd"};

--- a/src/lib/messages/sensor/catalog.proto
+++ b/src/lib/messages/sensor/catalog.proto
@@ -13,3 +13,10 @@ enum Sensor
     TURNER__C_FLUOR = 6;
     AML__SENSOR = 7;
 }
+
+// which of several identical sensors on the payload board this is
+enum SensorInstance
+{
+    INSTANCE_1 = 1;
+    INSTANCE_2 = 2;
+}

--- a/src/lib/messages/sensor/configuration.proto
+++ b/src/lib/messages/sensor/configuration.proto
@@ -22,4 +22,5 @@ message Configuration
         required string value = 2 [(nanopb).max_size = 64];
     }
     repeated Cfg cfg = 3 [(nanopb).max_count = 16];
+    optional SensorInstance instance = 4 [default = INSTANCE_1];
 }

--- a/src/lib/messages/sensor/metadata.proto
+++ b/src/lib/messages/sensor/metadata.proto
@@ -40,5 +40,6 @@ message Metadata
 
     repeated MetadataValue metadata = 5 [(nanopb).max_count = 16];
     optional bool init_failed = 7;
+    optional SensorInstance instance = 8 [default = INSTANCE_1];
 }
 

--- a/src/lib/messages/sensor/turner__c_fluor.proto
+++ b/src/lib/messages/sensor/turner__c_fluor.proto
@@ -1,6 +1,8 @@
 syntax = "proto2";
 
 import "dccl/option_extensions.proto";
+import "jaiabot/messages/sensor/catalog.proto";
+import "nanopb.proto";
 
 package jaiabot.sensor.protobuf;
 
@@ -13,6 +15,9 @@ message TurnerCFluor
     // notional - add units and additional fields as needed
     optional double concentration = 1;
     optional double concentration_voltage = 2;
+    optional SensorInstance instance = 3 [default = INSTANCE_1];
+    // set by the driver from this instance's coefficients, never by the MCU
+    optional string analyte_name = 4 [(nanopb).max_size = 32];
 }
 
 message FluorCoefficients
@@ -20,6 +25,8 @@ message FluorCoefficients
     optional double offset = 1;
     optional double coefficient = 2;
     optional int32 serial_number = 3;
+    // what this probe measures, e.g. "Chlorophyll-a"
+    optional string analyte_name = 4;
 }
 
 

--- a/src/python/pyjaia/src/pyjaia/jaialog_store/path_descriptors.py
+++ b/src/python/pyjaia/src/pyjaia/jaialog_store/path_descriptors.py
@@ -247,6 +247,32 @@ path_descriptors = [
         frequency=10,
         description='Temperature as reported by the dissolved oxygen sensor.'
     ),
+    # both fluorometers log the same message type, so the second one is matched on its group
+    # name and must be listed before the suffix-matched entries below
+    PathDescriptor(
+        name='Fluorometer 2 Concentration',
+        path_suffix=None,
+        path_regex=r'.*jaiabot::fluorometer_2/.*TurnerCFluor/concentration$',
+        units='See fluorometer spec. sheet.',
+        frequency=10,
+        description='Concentration as reported by the second fluorometer.'
+    ),
+    PathDescriptor(
+        name='Fluorometer 2 Concentration Voltage',
+        path_suffix=None,
+        path_regex=r'.*jaiabot::fluorometer_2/.*TurnerCFluor/concentration_voltage$',
+        units='V',
+        frequency=10,
+        description='Raw voltage reported by the second analog fluorometer sensor.'
+    ),
+    PathDescriptor(
+        name='Fluorometer 2 Analyte',
+        path_suffix=None,
+        path_regex=r'.*jaiabot::fluorometer_2/.*TurnerCFluor/analyte_name$',
+        units='',
+        frequency=10,
+        description='What the second fluorometer measures, from its configured coefficients.'
+    ),
     PathDescriptor(
         name='Fluorometer Concentration',
         path_suffix='TurnerCFluor/concentration',
@@ -261,6 +287,13 @@ path_descriptors = [
         frequency=10,
         description='Raw voltage reported by the analog fluorometer sensor.'
     ), 
+    PathDescriptor(
+        name='Fluorometer Analyte',
+        path_suffix='TurnerCFluor/analyte_name',
+        units='',
+        frequency=10,
+        description='What the fluorometer measures, from its configured coefficients.'
+    ),
     PathDescriptor(
         name='Latitude',
         path_suffix='TimePositionVelocity/location/lat',


### PR DESCRIPTION
## Summary

Adds support for a second fluorometer on the BIO payload board.

The board can now say which of two fluorometers a reading came from. Each one gets its own calibration, its own driver, and its own place in the mission log. A vehicle with one fluorometer behaves exactly as before.

A fluorometer probe doesn't identify itself, it just puts out a voltage. The board can only say which port a reading came from, not what that probe measures. The name of what's being measured is set in the calibration file for that port and gets recorded with every reading.

## Changes

- Sensor messages carry a port number, so two of the same sensor can be told apart. Defaults to the first, so existing boards are unaffected.
- Fluorometer readings also carry the name of what's being measured.
- `jaiabot_sensors` starts one driver per fluorometer instead of refusing the second. Each reads only its own port and reports on its own channel.
- Calibration comes from `fluorometer_coefficients_1.pb.cfg` and `_2.pb.cfg`. Vehicles using the older unnumbered file keep working.
- Log plots name the two fluorometers separately.

Related fixes:

- Two programs were both reporting fluorometer readings on BIO vehicles, with no way to tell them apart. The older analog one no longer runs there.
- The setup option was incorrectly spelled `turner_c_flour`. 

## Testing

### Tested on a BIO vehicle (fleet 6 bot 40) running as a normal service

- [x] The system successfully loaded calibration settings for both fluorometers.
- [x] The first fluorometer sent live data at the expected speed (10 times per second) with the correct label.
- [x] The second fluorometer channel remained quiet, confirming it doesn't send unnecessary data when inactive.
- [x] The old background driver was automatically disabled to prevent duplicate data streams.
- [x] Confirm data plots from both fluorometers are available in the JDV. 

### Not yet tested

- [ ] Real readings in water. 

## Notes 

Updating an existing bot doesn't automatically delete old background services. If a vehicle was previously set up to use the old fluorometer service, you'll need to manually turn off that old service after upgrading to avoid duplicate data. New setups won't have this issue.