### PR TITLE
3.y / Add initramfs configuration for VirtualBox image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,8 @@ filter-template-debian-builds: &filter-template-debian-builds
       only:
         - "3.y"
         - "claude/remove-runtime-env-simplify-system-6thi11"
-        
+        - "claude/festive-knuth-qj9tfk"
+
 # which branches to run the normal source build
 filter-template-normal-builds: &filter-template-normal-builds
   filters:
@@ -179,6 +180,7 @@ filter-template-normal-builds: &filter-template-normal-builds
       ignore:
         - "3.y"
         - "claude/remove-runtime-env-simplify-system-6thi11"
+        - "claude/festive-knuth-qj9tfk"
 
 # which branches to run the pi-zero filesystem builds
 filter-template-pi0-rootfs-builds: &filter-template-pi0-rootfs-builds
@@ -198,6 +200,7 @@ filter-template-rootfs-builds: &filter-template-rootfs-builds
       only:
         - "3.y"
         - "claude/remove-runtime-env-simplify-system-6thi11"
+        - "claude/festive-knuth-qj9tfk"
 
 # which branches to run the AWS virtual machine conversion (must be same as or subset of filter-template-rootfs-builds)
 filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
@@ -208,6 +211,7 @@ filter-template-aws-rootfs-builds: &filter-template-aws-rootfs-builds
       only:
         - "3.y"
         - "claude/remove-runtime-env-simplify-system-6thi11"
+        - "claude/festive-knuth-qj9tfk"
 
 # which branches to build Docker simulator
 filter-template-docker-sim-builds: &filter-template-docker-sim-builds

--- a/rootfs/virtualbox/includes.chroot/etc/initramfs-tools/initramfs.conf
+++ b/rootfs/virtualbox/includes.chroot/etc/initramfs-tools/initramfs.conf
@@ -1,0 +1,85 @@
+#
+# initramfs.conf
+# Configuration file for mkinitramfs(8). See initramfs.conf(5).
+#
+# Note that configuration options from this file can be overridden
+# by config files in the /etc/initramfs-tools/conf.d directory.
+
+#
+# MODULES: [ most | netboot | dep | list ]
+#
+# most - Add most filesystem and all harddrive drivers.
+#
+# dep - Try and guess which modules to load.
+#
+# netboot - Add the base modules, network modules, but skip block devices.
+#
+# list - Only include modules from the 'additional modules' list
+#
+
+# Overrides the Raspberry Pi's MODULES=list: the VM has no boot partition size
+# constraint, and needs the amd64 storage drivers (AHCI, virtio, NVMe) that a
+# list generated on the Pi cannot provide.
+MODULES=most
+
+#
+# BUSYBOX: [ y | n | auto ]
+#
+# Use busybox shell and utilities.  If set to n, klibc utilities will be used.
+# If set to auto (or unset), busybox will be used if installed and klibc will
+# be used otherwise.
+#
+
+BUSYBOX=auto
+
+#
+# COMPRESS: [ gzip | bzip2 | lz4 | lzma | lzop | xz | zstd ]
+#
+
+COMPRESS=zstd
+
+#
+# COMPRESSLEVEL: ...
+#
+# Set a compression level for the compressor.
+# Defaults vary by compressor.
+#
+# Valid values are:
+# 1 -  9 for gzip|bzip2|lzma|lzop
+# 0 -  9 for  lz4|xz
+# 0 - 19 for zstd
+#
+# COMPRESSLEVEL=1
+
+#
+# DEVICE: ...
+#
+# Specify a specific network interface, like eth0
+# Overridden by optional ip= or BOOTIF= bootarg
+#
+
+DEVICE=
+
+#
+# NFSROOT: [ auto | HOST:MOUNT ]
+#
+
+NFSROOT=auto
+
+#
+# RUNSIZE: ...
+#
+# The size of the /run tmpfs mount point, like 256M or 10%
+# Overridden by optional initramfs.runsize= bootarg
+#
+
+RUNSIZE=10%
+
+#
+# FSTYPE: ...
+#
+# The filesystem type(s) to support, or "auto" to use the current root
+# filesystem type
+#
+
+FSTYPE=auto

--- a/rootfs/virtualbox/includes.chroot/etc/initramfs-tools/modules
+++ b/rootfs/virtualbox/includes.chroot/etc/initramfs-tools/modules
@@ -1,0 +1,15 @@
+# List of modules that you want to include in your initramfs.
+# They will be loaded at boot time in the order below.
+#
+# Syntax:  module_name [args ...]
+#
+# You must run update-initramfs(8) to effect this change.
+#
+# Examples:
+#
+# raid1
+# sd_mod
+
+# Empty by design: MODULES=most already covers the VM's storage and filesystem
+# drivers. The Raspberry Pi's list is arm64/Pi-specific (xor-neon, mmc_block)
+# and must not leak into the amd64 image.


### PR DESCRIPTION
I tested against VirtualBox fleet - fixes issue.

# Claude


## Summary

Add initramfs configuration files for the VirtualBox image build:

- **initramfs.conf**: Sets `MODULES=most` to include all filesystem and storage drivers needed for amd64 VirtualBox VMs (AHCI, virtio, NVMe), overriding the Raspberry Pi's constrained `MODULES=list` setting. Also configures compression to zstd and filesystem type to auto-detect.

- **modules**: Empty module list by design, since `MODULES=most` already provides necessary drivers. Prevents Pi-specific modules (xor-neon, mmc_block) from leaking into the amd64 image.

These files ensure the VirtualBox image has proper initramfs configuration distinct from the Raspberry Pi build.

## Test Procedure

N/A - Configuration file addition. Verify during VirtualBox image build that initramfs is generated correctly with the specified compression and module settings.

https://claude.ai/code/session_01RWTBCbWhBu4x5AiF1kf3KB