### PR TITLE
3.y / Replace configure_file with add_custom_command for shell scripts

### DIFF
--- a/src/sh/CMakeLists.txt
+++ b/src/sh/CMakeLists.txt
@@ -43,7 +43,25 @@ set(scripts_to_install
   )
 
 # Iterate over each script to install and copy
+#
+# Note: the build-directory copy is done with a build-time add_custom_command
+# rather than configure_file(), because configure_file() registers its input
+# as a CMake reconfigure dependency. Since this is a single monolithic CMake
+# project, touching any one of these scripts would then force a full
+# reconfigure (and consequent rebuild churn) of the entire repo.
+set(sh_scripts_bin_copies)
 foreach(script ${scripts_to_install})
     install(PROGRAMS ${project_SH_DIR}/${script} DESTINATION ${CMAKE_INSTALL_BINDIR})
-    configure_file(${project_SH_DIR}/${script} ${project_BIN_DIR} COPYONLY)
+
+    get_filename_component(script_name ${script} NAME)
+    set(script_bin_copy ${project_BIN_DIR}/${script_name})
+    add_custom_command(
+      OUTPUT ${script_bin_copy}
+      COMMAND ${CMAKE_COMMAND} -E copy ${project_SH_DIR}/${script} ${script_bin_copy}
+      DEPENDS ${project_SH_DIR}/${script}
+      COMMENT "Copying ${script} to ${project_BIN_DIR}"
+      )
+    list(APPEND sh_scripts_bin_copies ${script_bin_copy})
 endforeach()
+
+add_custom_target(copy_sh_scripts ALL DEPENDS ${sh_scripts_bin_copies})


### PR DESCRIPTION
## Summary

Replace `configure_file()` with `add_custom_command()` for copying shell scripts to the build directory. This avoids registering script files as CMake reconfigure dependencies, which was causing unnecessary full rebuilds of the entire repository whenever any shell script was modified.

The change introduces a new `copy_sh_scripts` custom target that handles the build-time copying of shell scripts, while the install step remains unchanged.

## Test Procedure

- Verify that shell scripts are correctly copied to the build directory during the build process
- Confirm that modifying a shell script no longer triggers a full CMake reconfigure
- Ensure installation of scripts to `CMAKE_INSTALL_BINDIR` continues to work as expected

https://claude.ai/code/session_01MvNbRfBbrD6feWVbNfhLHr