### PR TITLE
Remove unused jaia_cloudhub_type configuration variable

### DIFF
--- a/config/gen/systemd.py
+++ b/config/gen/systemd.py
@@ -421,7 +421,6 @@ service_environment = {
     'jaia_rf_encryption_password': dc('rf_encryption_password'),
     'jaia_dccl_encryption_password': dc('dccl_encryption_password'),
     'jaia_comms_mode': ','.join(comms_links_in_use),
-    'jaia_cloudhub_type': cloudhub_type_str,
     'jaia_camera_positions': ','.join(camera_positions_in_use),
     'jaia_additional_sensors': ','.join(jaia_additional_sensors),
     # previously derived by preseed.goby from $PATH


### PR DESCRIPTION
## Summary
Removed the `jaia_cloudhub_type` configuration variable from the systemd configuration generation. This variable was being set but is no longer needed in the system configuration.

## Test Procedure
N/A - This is a simple removal of an unused configuration variable. Existing CI tests will verify that the configuration generation still works correctly.

https://claude.ai/code/session_01GxmYjwtiSGV2MWJC4tfgKK