### PR TITLE
3.y / Add jaia dev build, clean, setup, and docker subcommands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,6 +55,23 @@ script_dir=$(dirname $0)
 
 ARCH=$(dpkg --print-architecture)
 
+# --- Generator selection: Ninja by default, pass --make to use GNU Make instead ---
+GENERATOR=Ninja
+args=()
+for arg in "$@"; do
+    if [ "${arg}" = "--make" ]; then
+        GENERATOR="Unix Makefiles"
+    else
+        args+=("${arg}")
+    fi
+done
+set -- "${args[@]}"
+
+if [ "${GENERATOR}" = "Ninja" ] && ! command -v ninja > /dev/null; then
+    echo "Error: ninja not found. Install it with 'jaia dev setup' (or scripts/build/setup-tools-build.sh), or pass --make to use GNU Make instead." >&2
+    exit 1
+fi
+
 # Make sure we're using the nvm versions of npm and webpack
 if [ -n "${XDG_CONFIG_HOME-}" ] && [ -d "${XDG_CONFIG_HOME}/nvm" ]; then
     export NVM_DIR="${XDG_CONFIG_HOME}/nvm"
@@ -73,8 +90,15 @@ mkdir -p ${script_dir}/build/${ARCH}
 # Initialize and update submodules
 git submodule update --init
 
-echo "Configuring..."
+echo "Configuring (generator: ${GENERATOR})..."
 cd ${script_dir}/build/${ARCH}
-(set -x; cmake ${JAIABOT_CMAKE_FLAGS} ../..)
+
+# cmake refuses to reconfigure a directory that another generator wrote
+if [ -f CMakeCache.txt ] && ! grep -q "^CMAKE_GENERATOR:INTERNAL=${GENERATOR}\$" CMakeCache.txt; then
+    echo "Discarding the CMake cache left by a previous generator"
+    rm -rf CMakeCache.txt CMakeFiles
+fi
+
+(set -x; cmake -G "${GENERATOR}" ${JAIABOT_CMAKE_FLAGS} ../..)
 echo "Building with ${JAIA_BUILD_NPROC} parallel processes..."
 (set -x; time cmake --build . -- -j${JAIA_BUILD_NPROC} ${JAIABOT_MAKE_FLAGS} $@)

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Bootstraps a fresh clone of this repository: there's no 'jaia' tool yet to run
+# "jaia dev setup" or "jaia dev build", so this script runs their underlying steps directly
+# (scripts/build/setup-tools-build.sh, then "./build.sh jaia" to build just the 'jaia' CLI),
+# then puts build/<arch>/bin on PATH so 'jaia' is available right away.
+#
+# Usage: source ./init.sh   (recommended: also updates PATH in this shell)
+#        ./init.sh          (still builds jaia, but only future shells pick up the PATH change)
+
+# True if this file is being sourced rather than executed, so we can safely 'return' on error
+# and export PATH into the calling shell
+if [ -n "${BASH_SOURCE:-}" ] && [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    sourced=true
+elif [ -n "${ZSH_EVAL_CONTEXT:-}" ] && [[ "${ZSH_EVAL_CONTEXT}" == *:file:* ]]; then
+    sourced=true
+else
+    sourced=false
+fi
+
+if [ -n "${BASH_SOURCE:-}" ]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+else
+    script_dir=$(cd "$(dirname "$0")" && pwd)
+fi
+
+# Note: 'return' from a function only returns from that function, not the sourced script, so
+# the halt-on-error below is inlined at the top level rather than in a shared helper function
+if ! "${script_dir}/scripts/build/setup-tools-build.sh"; then
+    echo "❌ scripts/build/setup-tools-build.sh failed" >&2
+    if [ "${sourced}" = true ]; then return 1; else exit 1; fi
+fi
+
+if ! "${script_dir}/build.sh" jaia; then
+    echo "❌ ./build.sh jaia failed" >&2
+    if [ "${sourced}" = true ]; then return 1; else exit 1; fi
+fi
+
+arch=$(dpkg --print-architecture)
+bin_dir="${script_dir}/build/${arch}/bin"
+
+if [ ! -x "${bin_dir}/jaia" ]; then
+    echo "❌ Expected ${bin_dir}/jaia to exist after building" >&2
+    if [ "${sourced}" = true ]; then return 1; else exit 1; fi
+fi
+
+rc_file="${HOME}/.bashrc"
+case "${SHELL:-}" in
+    */zsh) rc_file="${HOME}/.zshrc" ;;
+esac
+
+if ! grep -qsF "${bin_dir}" "${rc_file}" 2>/dev/null; then
+    {
+        echo ""
+        echo "# added by jaiabot/init.sh"
+        echo "export PATH=\"${bin_dir}:\${PATH}\""
+    } >> "${rc_file}"
+    echo "🟢 Added ${bin_dir} to PATH in ${rc_file}: future shells will pick this up"
+else
+    echo "🟢 ${bin_dir} is already in ${rc_file}"
+fi
+
+case ":${PATH}:" in
+    *":${bin_dir}:"*) ;;
+    *) export PATH="${bin_dir}:${PATH}" ;;
+esac
+
+if [ "${sourced}" = true ]; then
+    echo "🟢 jaia is now on PATH for this shell too: $(command -v jaia)"
+else
+    echo "🟡 Run 'source ./init.sh' (instead of './init.sh') next time to put jaia on PATH in this shell too, or start a new shell to pick up the change"
+fi
+
+echo "🟢 Bootstrap complete. Run 'jaia dev build' to finish building the rest of the project."

--- a/scripts/build/container-build-and-deploy.sh
+++ b/scripts/build/container-build-and-deploy.sh
@@ -34,7 +34,7 @@ cd "${jaia_root}"
 remote_locale="LC_ALL=C.UTF-8"
 
 docker_run() {
-    docker run --env JAIA_BUILD_NPROC --env jaiabot_machine_type \
+    docker run --label jaiabot_build=true --env JAIA_BUILD_NPROC --env jaiabot_machine_type \
            -v "${jaia_root}":/home/${botuser}/jaiabot -w /home/${botuser}/jaiabot "$@"
 }
 

--- a/scripts/build/container-image-build.sh
+++ b/scripts/build/container-image-build.sh
@@ -8,4 +8,5 @@ source "$(dirname "$0")/build-config.sh"
 
 (set -x; docker build --build-arg distro="${distro}" --build-arg repo="${repo}" \
         --build-arg version="${version}" --no-cache -t "${image_name}" \
+        --label jaiabot_build=true \
         "${jaia_root}/.docker/${distro}/${arch}")

--- a/scripts/build/setup-tools-build.sh
+++ b/scripts/build/setup-tools-build.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+#
+# Installs the tools required to build this source tree: apt build dependencies (including the
+# ninja and clang cross-compilers), arduino-cli (for compiling .ino sketches), and
+# nvm/node/npm/webpack (for the web frontend). Requires root or sudo.
+#
+# Prints only a high-level status line per step; each step's full output is captured and only
+# shown (then this script exits) if that step fails.
 
 set -u -e
 
@@ -12,78 +19,114 @@ else
 fi
 
 script_dir=$(dirname $BASH_SOURCE)
-set -a; source ${script_dir}/../common-versions.env; set +a 
+set -a; source ${script_dir}/../common-versions.env; set +a
 
-# Prereqs
-$SUDO apt-get -y update
-$SUDO apt-get -y install gnupg lsb-release curl git
-# Install the public key for packages.gobysoft.org / packages.jaia.tech
 export GOBYSOFT_SIGNING_KEY=19478082E2F8D3FE
 export JAIABOT_SIGNING_KEY=954A004CD5D8CF32
-$SUDO install -d -m 0755 /etc/apt/keyrings
 
-if [ ! -e /etc/apt/keyrings/gobysoft.gpg ]; then
-    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${GOBYSOFT_SIGNING_KEY} && gpg --export ${GOBYSOFT_SIGNING_KEY} | $SUDO tee /etc/apt/keyrings/gobysoft.gpg > /dev/null
-fi
-if [ ! -e /etc/apt/keyrings/jaiabot.gpg ]; then
-    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${JAIABOT_SIGNING_KEY} && gpg --export ${JAIABOT_SIGNING_KEY} | $SUDO tee /etc/apt/keyrings/jaiabot.gpg > /dev/null
-fi
+log=$(mktemp)
+trap 'rm -f "${log}"' EXIT
 
-# Add packages.gobysoft.org mirror to your apt sources
-default_version=${jaia_version_release_branch}
-target_ubuntu_codename=${jaia_version_ubuntu_codename}
-echo "deb [signed-by=/etc/apt/keyrings/gobysoft.gpg] http://packages.jaia.tech/ubuntu/gobysoft/continuous/${default_version}/ $(. /etc/os-release; echo "$VERSION_CODENAME")/" | $SUDO tee /etc/apt/sources.list.d/gobysoft_continuous.list
-echo "deb-src [signed-by=/etc/apt/keyrings/jaiabot.gpg] http://packages.jaia.tech/ubuntu/continuous/${default_version}/ ${target_ubuntu_codename}/" | $SUDO tee /etc/apt/sources.list.d/jaiabot_continuous.list
-# Update apt
-$SUDO apt-get -y update
-# Install the required dependencies
-$SUDO apt-get -y build-dep jaiabot --install-recommends
-# (BUG) Need non-soversioned lib?
-# gmake[2]: *** No rule to make target '/usr/lib/x86_64-linux-gnu/libais.so', needed by 'lib/libjaiabot_messages.so.2.6.0+0+ge328122e'.  Stop.
-$SUDO apt-get -y install libais-dev
+# Runs "$@" (a command or a function name) with its output captured to $log; on failure, dumps
+# that output and exits.
+step() {
+    local description=$1
+    shift
+    echo "🟢 ${description}..."
+    if ! "$@" > "${log}" 2>&1; then
+        echo "❌ ${description} failed:" >&2
+        cat "${log}" >&2
+        exit 1
+    fi
+}
 
-# Install Arduino command line interface for local compilation of ino files into hex
-export BINDIR=/usr/local/bin
-curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | $SUDO env BINDIR="$BINDIR" sh -s ${jaia_version_arduino_cli}
-arduino-cli config init --overwrite
-arduino-cli core update-index
-arduino-cli core install arduino:avr
+install_prereqs() {
+    $SUDO apt-get -y update
+    $SUDO apt-get -y install gnupg lsb-release curl git
+}
 
-# Install nvm, npm, and webpack
-curl https://raw.githubusercontent.com/creationix/nvm/${jaia_version_nvm}/install.sh | bash
+install_apt_keys() {
+    $SUDO install -d -m 0755 /etc/apt/keyrings
 
-export NODE_VERSION=${jaia_version_nodejs}
+    if [ ! -e /etc/apt/keyrings/gobysoft.gpg ]; then
+        gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${GOBYSOFT_SIGNING_KEY}
+        gpg --export ${GOBYSOFT_SIGNING_KEY} | $SUDO tee /etc/apt/keyrings/gobysoft.gpg > /dev/null
+    fi
+    if [ ! -e /etc/apt/keyrings/jaiabot.gpg ]; then
+        gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${JAIABOT_SIGNING_KEY}
+        gpg --export ${JAIABOT_SIGNING_KEY} | $SUDO tee /etc/apt/keyrings/jaiabot.gpg > /dev/null
+    fi
+}
 
-if [ -n "${XDG_CONFIG_HOME-}" ] && [ -d "${XDG_CONFIG_HOME}/nvm" ]; then
-    export NVM_DIR="${XDG_CONFIG_HOME}/nvm"
-elif [ -d "${HOME}/.nvm" ]; then
-    export NVM_DIR="${HOME}/.nvm"
-else
-    echo "Error: Neither \$XDG_CONFIG_HOME/nvm nor \$HOME/.nvm exists." >&2
-    exit 1
-fi
+add_apt_sources() {
+    default_version=${jaia_version_release_branch}
+    target_ubuntu_codename=${jaia_version_ubuntu_codename}
+    echo "deb [signed-by=/etc/apt/keyrings/gobysoft.gpg] http://packages.jaia.tech/ubuntu/gobysoft/continuous/${default_version}/ $(. /etc/os-release; echo "$VERSION_CODENAME")/" | $SUDO tee /etc/apt/sources.list.d/gobysoft_continuous.list
+    echo "deb-src [signed-by=/etc/apt/keyrings/jaiabot.gpg] http://packages.jaia.tech/ubuntu/continuous/${default_version}/ ${target_ubuntu_codename}/" | $SUDO tee /etc/apt/sources.list.d/jaiabot_continuous.list
+    $SUDO apt-get -y update
+}
 
-# We have to source the "~/.nvm/nvm.sh" script in order to set the paths to use the
-#   nvm versions of webpack and npm
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+install_build_deps() {
+    $SUDO apt-get -y build-dep jaiabot --install-recommends
+    # (BUG) Need non-soversioned lib?
+    # gmake[2]: *** No rule to make target '/usr/lib/x86_64-linux-gnu/libais.so', needed by 'lib/libjaiabot_messages.so.2.6.0+0+ge328122e'.  Stop.
+    $SUDO apt-get -y install libais-dev ninja-build
+}
 
-# Now we use nvm to install the correct version of node FIRST, so npm is compatible
-nvm install ${NODE_VERSION}
-nvm alias default ${NODE_VERSION}
-nvm use ${NODE_VERSION}
-# Now npm can upgrade itself
-npm install -g npm@${jaia_version_npm}
-# Then, npm can install webpack
-npm install -g --no-audit webpack@${jaia_version_webpack} webpack-cli@${jaia_version_webpack_cli}
+install_arduino_cli() {
+    export BINDIR=/usr/local/bin
+    curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | $SUDO env BINDIR="$BINDIR" sh -s ${jaia_version_arduino_cli}
+    arduino-cli config init --overwrite
+    arduino-cli core update-index
+    arduino-cli core install arduino:avr
+}
 
-# Check if pre-commit hook is installed
-if [ ! -e ${script_dir}/../../.git/hooks/pre-commit ]; then
-   # Check if there is a broken symlink
-   if [ -L ${script_dir}/../../.git/hooks/pre-commit ]; then
-      rm ${script_dir}/../../.git/hooks/pre-commit
-   fi
-   # Install the pre-commit hook
-   cd ${script_dir}/../git-hooks/clang-format-hooks
-   ./git-pre-commit-format install
-fi
+install_node_toolchain() {
+    curl https://raw.githubusercontent.com/creationix/nvm/${jaia_version_nvm}/install.sh | bash
+
+    export NODE_VERSION=${jaia_version_nodejs}
+
+    if [ -n "${XDG_CONFIG_HOME-}" ] && [ -d "${XDG_CONFIG_HOME}/nvm" ]; then
+        export NVM_DIR="${XDG_CONFIG_HOME}/nvm"
+    elif [ -d "${HOME}/.nvm" ]; then
+        export NVM_DIR="${HOME}/.nvm"
+    else
+        echo "Error: Neither \$XDG_CONFIG_HOME/nvm nor \$HOME/.nvm exists." >&2
+        return 1
+    fi
+
+    # We have to source the "~/.nvm/nvm.sh" script in order to set the paths to use the
+    #   nvm versions of webpack and npm
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+    [ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+    # Now we use nvm to install the correct version of node FIRST, so npm is compatible
+    nvm install ${NODE_VERSION}
+    nvm alias default ${NODE_VERSION}
+    nvm use ${NODE_VERSION}
+    # Now npm can upgrade itself
+    npm install -g npm@${jaia_version_npm}
+    # Then, npm can install webpack
+    npm install -g --no-audit webpack@${jaia_version_webpack} webpack-cli@${jaia_version_webpack_cli}
+}
+
+install_precommit_hook() {
+    # Check if there is a broken symlink
+    if [ -L ${script_dir}/../../.git/hooks/pre-commit ] && [ ! -e ${script_dir}/../../.git/hooks/pre-commit ]; then
+        rm ${script_dir}/../../.git/hooks/pre-commit
+    fi
+
+    if [ ! -e ${script_dir}/../../.git/hooks/pre-commit ]; then
+        (cd ${script_dir}/../git-hooks/clang-format-hooks && ./git-pre-commit-format install)
+    fi
+}
+
+step "Updating apt and installing prerequisites" install_prereqs
+step "Installing the packages.jaia.tech / packages.gobysoft.org apt signing keys" install_apt_keys
+step "Adding the packages.jaia.tech / packages.gobysoft.org apt mirror" add_apt_sources
+step "Installing apt build dependencies (this can take a while)" install_build_deps
+step "Installing arduino-cli" install_arduino_cli
+step "Installing nvm, node, npm and webpack" install_node_toolchain
+step "Installing the clang-format pre-commit hook" install_precommit_hook
+
+echo "🟢 Setup complete."

--- a/scripts/sim-docker/build-image.sh
+++ b/scripts/sim-docker/build-image.sh
@@ -1,2 +1,2 @@
 (cd ../..; cmake -P cmake/ConfigureDockerfiles.cmake)
-docker build  --no-cache -t jaiauser:jaia-sim-image .
+docker build --no-cache -t jaiauser:jaia-sim-image --label jaiabot_build=true .

--- a/scripts/sim-docker/launch-container.sh
+++ b/scripts/sim-docker/launch-container.sh
@@ -12,4 +12,4 @@ if [[ -z "$JAIA_SIM_FLEET" ]]; then
     export JAIA_SIM_FLEET=30
 fi
 
-docker run --rm --name jaia-sim-container -d -i -t -p 40001:40001 -p 9092:9092 -p 40011:40011 --env JAIA_SIM_BOTS=$JAIA_SIM_BOTS --env JAIA_SIM_WARP=$JAIA_SIM_WARP --env JAIA_SIM_FLEET=$JAIA_SIM_FLEET -v ./jdv_data:/var/log/jaiabot/bot_offload jaiauser:jaia-sim-image /bin/bash
+docker run --rm --name jaia-sim-container --label jaiabot_build=true -d -i -t -p 40001:40001 -p 9092:9092 -p 40011:40011 --env JAIA_SIM_BOTS=$JAIA_SIM_BOTS --env JAIA_SIM_WARP=$JAIA_SIM_WARP --env JAIA_SIM_FLEET=$JAIA_SIM_FLEET -v ./jdv_data:/var/log/jaiabot/bot_offload jaiauser:jaia-sim-image /bin/bash

--- a/src/bin/drivers/aml/app.cpp
+++ b/src/bin/drivers/aml/app.cpp
@@ -148,6 +148,8 @@ void jaiabot::apps::AMLSensorDriver::handle_sensor_output(const goby::middleware
     std::istringstream input_stream{io_data.data()};
     switch (sensor_name_)
     {
+        case jaiabot::sensor::protobuf::AML::DEFAULT: break;
+
         case jaiabot::sensor::protobuf::AML::CONDUCTIVITY:
             double conductivity{};
             double temperature{};

--- a/src/bin/tool/CMakeLists.txt
+++ b/src/bin/tool/CMakeLists.txt
@@ -20,6 +20,10 @@ add_jaiabot_application(TARGET jaia
     actions/admin/fleet/vpn_authorize.proto
     actions/dev.proto
     actions/dev/local_deploy.proto
+    actions/dev/build.proto
+    actions/dev/clean.proto
+    actions/dev/setup.proto
+    actions/dev/docker.proto
   SOURCES jaia_tool.cpp
     actions/version.cpp
     actions/ctl.cpp
@@ -42,5 +46,9 @@ add_jaiabot_application(TARGET jaia
     actions/admin/fleet/vpn_authorize.cpp
     actions/dev.cpp
     actions/dev/local_deploy.cpp
+    actions/dev/build.cpp
+    actions/dev/clean.cpp
+    actions/dev/setup.cpp
+    actions/dev/docker.cpp
   LINK_LIBRARIES goby jaiabot_messages
 )

--- a/src/bin/tool/actions/dev.cpp
+++ b/src/bin/tool/actions/dev.cpp
@@ -1,7 +1,11 @@
 #include "goby/middleware/application/tool.h"
 
 #include "dev.h"
+#include "dev/build.h"
+#include "dev/clean.h"
+#include "dev/docker.h"
 #include "dev/local_deploy.h"
+#include "dev/setup.h"
 
 jaiabot::apps::DevTool::DevTool()
 {
@@ -24,6 +28,30 @@ jaiabot::apps::DevTool::DevTool()
                                 action_for_help);
                             break;
 
+                        case jaiabot::config::DevTool::build:
+                            tool_helper.help<jaiabot::apps::dev::BuildTool,
+                                             jaiabot::apps::dev::BuildToolConfigurator>(
+                                action_for_help);
+                            break;
+
+                        case jaiabot::config::DevTool::clean:
+                            tool_helper.help<jaiabot::apps::dev::CleanTool,
+                                             jaiabot::apps::dev::CleanToolConfigurator>(
+                                action_for_help);
+                            break;
+
+                        case jaiabot::config::DevTool::setup:
+                            tool_helper.help<jaiabot::apps::dev::SetupTool,
+                                             jaiabot::apps::dev::SetupToolConfigurator>(
+                                action_for_help);
+                            break;
+
+                        case jaiabot::config::DevTool::docker:
+                            tool_helper.help<jaiabot::apps::dev::DockerTool,
+                                             jaiabot::apps::dev::DockerToolConfigurator>(
+                                action_for_help);
+                            break;
+
                         default:
                             throw(goby::Exception(
                                 "Help was expected to be handled by external tool"));
@@ -35,6 +63,26 @@ jaiabot::apps::DevTool::DevTool()
             case jaiabot::config::DevTool::local_deploy:
                 tool_helper.run_subtool<jaiabot::apps::dev::LocalDeployTool,
                                         jaiabot::apps::dev::LocalDeployToolConfigurator>();
+                break;
+
+            case jaiabot::config::DevTool::build:
+                tool_helper.run_subtool<jaiabot::apps::dev::BuildTool,
+                                        jaiabot::apps::dev::BuildToolConfigurator>();
+                break;
+
+            case jaiabot::config::DevTool::clean:
+                tool_helper.run_subtool<jaiabot::apps::dev::CleanTool,
+                                        jaiabot::apps::dev::CleanToolConfigurator>();
+                break;
+
+            case jaiabot::config::DevTool::setup:
+                tool_helper.run_subtool<jaiabot::apps::dev::SetupTool,
+                                        jaiabot::apps::dev::SetupToolConfigurator>();
+                break;
+
+            case jaiabot::config::DevTool::docker:
+                tool_helper.run_subtool<jaiabot::apps::dev::DockerTool,
+                                        jaiabot::apps::dev::DockerToolConfigurator>();
                 break;
 
             default:

--- a/src/bin/tool/actions/dev.proto
+++ b/src/bin/tool/actions/dev.proto
@@ -46,6 +46,45 @@ message DevTool
         local_deploy = 1 [(goby.ev).cfg = {
             short_help_msg: "Cross-compile this source tree and deploy it to bots and hubs",
         }];
+        build = 2 [(goby.ev).cfg = {
+            short_help_msg: "Build this source tree using ./build.sh",
+            full_help_msg: "Runs ./build.sh to configure (CMake) and build (make) this source tree.\n"
+                           "\n"
+                           "Example commands:\n"
+                           "  jaia dev build: build all targets\n"
+                           "  jaia dev build jaia: build only the 'jaia' target\n"
+                           "  jaia dev build --cmake_var build_doc=ON: set a CMake variable (as -Dbuild_doc=ON)\n"
+                           "  jaia dev build --make_var VERBOSE=1: set a variable passed to the underlying build tool\n"
+                           "\n"
+                           "Requires that 'jaia dev setup' has been run first to install the required build tools."
+        }];
+        clean = 3 [(goby.ev).cfg = {
+            short_help_msg: "Remove the entire build directory",
+            full_help_msg: "Removes the \"build\" directory (for all machine architectures) from this source "
+                           "tree, so the next \"jaia dev build\" starts from a clean CMake configuration."
+        }];
+        setup = 4 [(goby.ev).cfg = {
+            short_help_msg: "Install the tools required to build this source tree",
+            full_help_msg: "Runs scripts/build/setup-tools-build.sh, which installs the compilers, CMake, apt "
+                           "build dependencies, arduino-cli, and nvm/npm/webpack required by \"jaia dev build\". "
+                           "Requires root or sudo."
+        }];
+        docker = 5 [(goby.ev).cfg = {
+            short_help_msg: "Frontend to 'docker' scoped to this repository's images and containers",
+            full_help_msg: "Runs 'docker' with the given command, automatically scoped (via \"--filter "
+                           "label=jaiabot_build=true\") to the images and containers created by this "
+                           "repository (the cross-compile build image/container and the simulator image/"
+                           "container), for the 'docker' commands that support filtering.\n"
+                           "\n"
+                           "Example commands:\n"
+                           "  jaia dev docker: list this repository's running containers ('docker ps')\n"
+                           "  jaia dev docker ps -a: list all of this repository's containers, running or not\n"
+                           "  jaia dev docker image list: list this repository's images\n"
+                           "  jaia dev docker container prune: remove this repository's stopped containers\n"
+                           "\n"
+                           "Commands that operate on an explicit container/image (e.g. \"docker logs\", "
+                           "\"docker exec\", \"docker rm\") are passed through to 'docker' unmodified."
+        }];
     }
     optional Action action = 2 [
         default = help,

--- a/src/bin/tool/actions/dev.proto
+++ b/src/bin/tool/actions/dev.proto
@@ -59,9 +59,13 @@ message DevTool
                            "Requires that 'jaia dev setup' has been run first to install the required build tools."
         }];
         clean = 3 [(goby.ev).cfg = {
-            short_help_msg: "Remove the entire build directory",
-            full_help_msg: "Removes the \"build\" directory (for all machine architectures) from this source "
-                           "tree, so the next \"jaia dev build\" starts from a clean CMake configuration."
+            short_help_msg: "Remove the build directory",
+            full_help_msg: "By default, removes this machine's local build directory (e.g. \"build/amd64\"), "
+                           "so the next \"jaia dev build\" starts from a clean CMake configuration.\n"
+                           "\n"
+                           "With \"--docker\", also removes the cross-compile build directories created by "
+                           "\"jaia dev local_deploy\" (e.g. \"build/resolute-3.y-arm64\"), which are owned by "
+                           "root inside the build container and so are removed with \"sudo\"."
         }];
         setup = 4 [(goby.ev).cfg = {
             short_help_msg: "Install the tools required to build this source tree",

--- a/src/bin/tool/actions/dev.proto
+++ b/src/bin/tool/actions/dev.proto
@@ -61,7 +61,10 @@ message DevTool
         clean = 3 [(goby.ev).cfg = {
             short_help_msg: "Remove the build directory",
             full_help_msg: "By default, removes this machine's local build directory (e.g. \"build/amd64\"), "
-                           "so the next \"jaia dev build\" starts from a clean CMake configuration.\n"
+                           "so the next \"jaia dev build\" starts from a clean CMake configuration. If "
+                           "'jaia' itself was built from this tree (e.g. by ./init.sh), the running "
+                           "binary and the shared libraries it has loaded are skipped rather than "
+                           "removed out from under it; rebuild (\"jaia dev build jaia\") to replace them.\n"
                            "\n"
                            "With \"--docker\", also removes the cross-compile build directories created by "
                            "\"jaia dev local_deploy\" (e.g. \"build/resolute-3.y-arm64\"), which are owned by "

--- a/src/bin/tool/actions/dev.proto
+++ b/src/bin/tool/actions/dev.proto
@@ -48,13 +48,15 @@ message DevTool
         }];
         build = 2 [(goby.ev).cfg = {
             short_help_msg: "Build this source tree using ./build.sh",
-            full_help_msg: "Runs ./build.sh to configure (CMake) and build (make) this source tree.\n"
+            full_help_msg: "Runs ./build.sh to configure (CMake, using Ninja by default) and build this "
+                           "source tree.\n"
                            "\n"
                            "Example commands:\n"
                            "  jaia dev build: build all targets\n"
                            "  jaia dev build jaia: build only the 'jaia' target\n"
                            "  jaia dev build --cmake_var build_doc=ON: set a CMake variable (as -Dbuild_doc=ON)\n"
                            "  jaia dev build --make_var VERBOSE=1: set a variable passed to the underlying build tool\n"
+                           "  jaia dev build --make: use GNU Make instead of the default Ninja generator\n"
                            "\n"
                            "Requires that 'jaia dev setup' has been run first to install the required build tools."
         }];

--- a/src/bin/tool/actions/dev/build.cpp
+++ b/src/bin/tool/actions/dev/build.cpp
@@ -1,0 +1,113 @@
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+#include <boost/filesystem.hpp>
+#include <goby/util/debug_logger.h>
+
+#include "build.h"
+#include "util.h"
+
+using goby::glog;
+
+namespace
+{
+constexpr const char* build_script = "build.sh";
+
+bool command_exists(const std::string& command)
+{
+    return std::system(("command -v " + command + " > /dev/null 2>&1").c_str()) == 0;
+}
+
+bool nvm_is_installed()
+{
+    if (const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME"))
+    {
+        if (boost::filesystem::exists(boost::filesystem::path(xdg_config_home) / "nvm"))
+            return true;
+    }
+
+    if (const char* home = std::getenv("HOME"))
+    {
+        if (boost::filesystem::exists(boost::filesystem::path(home) / ".nvm"))
+            return true;
+    }
+
+    return false;
+}
+
+// Checks for the tools that "jaia dev setup" installs, so a missing setup step produces a clear
+// error instead of a confusing failure partway through build.sh
+void check_setup_has_run()
+{
+    std::vector<std::string> missing;
+    if (!command_exists("cmake"))
+        missing.push_back("cmake");
+    if (!command_exists("arduino-cli"))
+        missing.push_back("arduino-cli");
+    if (!nvm_is_installed())
+        missing.push_back("nvm (Node Version Manager)");
+
+    if (!missing.empty())
+    {
+        std::string tools;
+        for (size_t i = 0; i < missing.size(); ++i) tools += (i == 0 ? "" : ", ") + missing[i];
+
+        throw std::runtime_error(
+            "Missing build tool(s): " + tools +
+            ". It looks like 'jaia dev setup' has not been (successfully) run on this machine. "
+            "Run 'jaia dev setup' to install the required build dependencies, then try again.");
+    }
+}
+
+// Appends flag=value pairs (as "<prefix><var>") from `vars` to the given environment variable,
+// preserving any value the variable already has, and sets the result in the environment.
+void append_to_env(const char* env_var, const std::string& prefix,
+                   const google::protobuf::RepeatedPtrField<std::string>& vars)
+{
+    if (vars.empty())
+        return;
+
+    std::string value;
+    if (const char* existing = std::getenv(env_var))
+        value = std::string(existing) + " ";
+
+    for (const auto& var : vars) value += prefix + var + " ";
+
+    setenv(env_var, value.c_str(), true);
+}
+
+} // namespace
+
+jaiabot::apps::dev::BuildTool::BuildTool()
+{
+    std::vector<std::string> args;
+
+    try
+    {
+        check_setup_has_run();
+
+        args.push_back(jaiabot::apps::dev::find_in_repo(build_script).string());
+
+        append_to_env("JAIABOT_CMAKE_FLAGS", "-D", app_cfg().cmake_var());
+        append_to_env("JAIABOT_MAKE_FLAGS", "", app_cfg().make_var());
+
+        for (const auto& target : app_cfg().target()) args.push_back(target);
+    }
+    catch (const std::exception& e)
+    {
+        glog.is_die() && glog << e.what() << std::endl;
+    }
+
+    std::vector<char*> c_args;
+    for (const auto& arg : args) c_args.push_back(const_cast<char*>(arg.c_str()));
+    c_args.push_back(nullptr); // execvp expects a null-terminated array
+
+    execvp(c_args[0], c_args.data());
+    // If execvp returns, there was an error
+    glog.is_die() && glog << "ERROR executing " << args[0] << std::endl;
+    quit(0);
+}

--- a/src/bin/tool/actions/dev/build.cpp
+++ b/src/bin/tool/actions/dev/build.cpp
@@ -1,11 +1,11 @@
 #include <cstdlib>
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include <unistd.h>
 
-#include <boost/filesystem.hpp>
 #include <goby/util/debug_logger.h>
 
 #include "build.h"
@@ -26,13 +26,13 @@ bool nvm_is_installed()
 {
     if (const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME"))
     {
-        if (boost::filesystem::exists(boost::filesystem::path(xdg_config_home) / "nvm"))
+        if (std::filesystem::exists(std::filesystem::path(xdg_config_home) / "nvm"))
             return true;
     }
 
     if (const char* home = std::getenv("HOME"))
     {
-        if (boost::filesystem::exists(boost::filesystem::path(home) / ".nvm"))
+        if (std::filesystem::exists(std::filesystem::path(home) / ".nvm"))
             return true;
     }
 

--- a/src/bin/tool/actions/dev/build.cpp
+++ b/src/bin/tool/actions/dev/build.cpp
@@ -41,11 +41,13 @@ bool nvm_is_installed()
 
 // Checks for the tools that "jaia dev setup" installs, so a missing setup step produces a clear
 // error instead of a confusing failure partway through build.sh
-void check_setup_has_run()
+void check_setup_has_run(bool use_make)
 {
     std::vector<std::string> missing;
     if (!command_exists("cmake"))
         missing.push_back("cmake");
+    if (!use_make && !command_exists("ninja"))
+        missing.push_back("ninja");
     if (!command_exists("arduino-cli"))
         missing.push_back("arduino-cli");
     if (!nvm_is_installed())
@@ -88,12 +90,15 @@ jaiabot::apps::dev::BuildTool::BuildTool()
 
     try
     {
-        check_setup_has_run();
+        check_setup_has_run(app_cfg().make());
 
         args.push_back(jaiabot::apps::dev::find_in_repo(build_script).string());
 
         append_to_env("JAIABOT_CMAKE_FLAGS", "-D", app_cfg().cmake_var());
         append_to_env("JAIABOT_MAKE_FLAGS", "", app_cfg().make_var());
+
+        if (app_cfg().make())
+            args.push_back("--make");
 
         for (const auto& target : app_cfg().target()) args.push_back(target);
     }

--- a/src/bin/tool/actions/dev/build.h
+++ b/src/bin/tool/actions/dev/build.h
@@ -1,0 +1,59 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_BUILD_H
+#define JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_BUILD_H
+
+#include "goby/middleware/application/interface.h"
+
+#include "actions/dev/build.pb.h"
+
+namespace jaiabot
+{
+namespace apps
+{
+namespace dev
+{
+class BuildToolConfigurator
+    : public goby::middleware::ProtobufConfigurator<jaiabot::config::dev::BuildTool>
+{
+  public:
+    BuildToolConfigurator(int argc, char* argv[])
+        : goby::middleware::ProtobufConfigurator<jaiabot::config::dev::BuildTool>(argc, argv)
+    {
+    }
+};
+
+class BuildTool : public goby::middleware::Application<jaiabot::config::dev::BuildTool>
+{
+  public:
+    BuildTool();
+    ~BuildTool() override {}
+
+  private:
+    void run() override { assert(false); }
+};
+
+} // namespace dev
+} // namespace apps
+} // namespace jaiabot
+#endif

--- a/src/bin/tool/actions/dev/build.proto
+++ b/src/bin/tool/actions/dev/build.proto
@@ -51,4 +51,11 @@ message BuildTool
         description: "Set a variable passed to the underlying build tool (make), e.g. \"--make_var VERBOSE=1\". Can be repeated",
         cfg { cli_short: "M" }
     }];
+
+    optional bool make = 5 [
+        default = false,
+        (goby.field) = {
+            description: "Use GNU Make instead of the default Ninja generator"
+        }
+    ];
 }

--- a/src/bin/tool/actions/dev/build.proto
+++ b/src/bin/tool/actions/dev/build.proto
@@ -1,0 +1,54 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+syntax = "proto2";
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/protobuf/option_extensions.proto";
+
+package jaiabot.config.dev;
+
+message BuildTool
+{
+    option (goby.msg).cfg.tool = {
+        is_tool: true
+        has_subtools: false
+        has_help_action: false
+    };
+
+    optional goby.middleware.protobuf.AppConfig app = 1
+        [(goby.field) = { cfg { action: DEVELOPER } }];
+
+    repeated string target = 2 [(goby.field) = {
+        description: "Specific build target(s) to build, e.g. 'jaia'. If omitted, all targets are built",
+        cfg { position: { enable: true, max_count: -1 } }
+    }];
+
+    repeated string cmake_var = 3 [(goby.field) = {
+        description: "Set a CMake variable, e.g. \"--cmake_var build_doc=ON\" (equivalent to passing -Dbuild_doc=ON to cmake). Can be repeated",
+        cfg { cli_short: "D" }
+    }];
+
+    repeated string make_var = 4 [(goby.field) = {
+        description: "Set a variable passed to the underlying build tool (make), e.g. \"--make_var VERBOSE=1\". Can be repeated",
+        cfg { cli_short: "M" }
+    }];
+}

--- a/src/bin/tool/actions/dev/clean.cpp
+++ b/src/bin/tool/actions/dev/clean.cpp
@@ -1,6 +1,14 @@
+#include <array>
+#include <cctype>
+#include <cstdio>
+#include <filesystem>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
-#include <boost/filesystem.hpp>
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include <goby/util/debug_logger.h>
 
 #include "clean.h"
@@ -11,23 +19,81 @@ using goby::glog;
 namespace
 {
 constexpr const char* build_script = "build.sh";
+
+// e.g. "amd64", "arm64": matches the directory build.sh itself creates and builds into
+std::string local_arch()
+{
+    std::array<char, 256> line{};
+    FILE* pipe = popen("dpkg --print-architecture", "r");
+    if (!pipe || !fgets(line.data(), line.size(), pipe))
+        throw std::runtime_error("Could not determine this machine's architecture (dpkg "
+                                 "--print-architecture failed)");
+    pclose(pipe);
+
+    std::string arch(line.data());
+    while (!arch.empty() && std::isspace(static_cast<unsigned char>(arch.back()))) arch.pop_back();
+    return arch;
+}
+
+void remove_as_root(const std::vector<std::filesystem::path>& dirs)
+{
+    if (dirs.empty())
+        return;
+
+    std::vector<std::string> args{"sudo", "rm", "-rf"};
+    for (const auto& dir : dirs) args.push_back(dir.string());
+
+    pid_t pid = fork();
+    if (pid < 0)
+        throw std::runtime_error("Could not fork to run sudo rm");
+
+    if (pid == 0)
+    {
+        std::vector<char*> c_args;
+        for (const auto& arg : args) c_args.push_back(const_cast<char*>(arg.c_str()));
+        c_args.push_back(nullptr);
+        execvp(c_args[0], c_args.data());
+        _exit(127); // only reached if execvp failed
+    }
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        throw std::runtime_error("sudo rm -rf failed removing the docker build directories");
+}
+
 } // namespace
 
 jaiabot::apps::dev::CleanTool::CleanTool()
 {
     try
     {
-        auto build_dir = jaiabot::apps::dev::find_in_repo(build_script).parent_path() / "build";
+        auto build_root = jaiabot::apps::dev::find_in_repo(build_script).parent_path() / "build";
+        auto local_build_dir = build_root / local_arch();
 
-        if (boost::filesystem::exists(build_dir))
+        if (std::filesystem::exists(local_build_dir))
         {
-            glog.is_verbose() && glog << "Removing " << build_dir << std::endl;
-            boost::filesystem::remove_all(build_dir);
+            glog.is_verbose() && glog << "Removing " << local_build_dir << std::endl;
+            std::filesystem::remove_all(local_build_dir);
         }
         else
         {
-            glog.is_verbose() && glog << build_dir << " does not exist, nothing to clean"
+            glog.is_verbose() && glog << local_build_dir << " does not exist, nothing to clean"
                                       << std::endl;
+        }
+
+        if (app_cfg().docker() && std::filesystem::exists(build_root))
+        {
+            std::vector<std::filesystem::path> docker_dirs;
+            for (const auto& entry : std::filesystem::directory_iterator(build_root))
+            {
+                if (entry.path() != local_build_dir)
+                    docker_dirs.push_back(entry.path());
+            }
+
+            for (const auto& dir : docker_dirs)
+                glog.is_verbose() && glog << "Removing " << dir << " (as root)" << std::endl;
+            remove_as_root(docker_dirs);
         }
     }
     catch (const std::exception& e)

--- a/src/bin/tool/actions/dev/clean.cpp
+++ b/src/bin/tool/actions/dev/clean.cpp
@@ -1,0 +1,39 @@
+#include <stdexcept>
+
+#include <boost/filesystem.hpp>
+#include <goby/util/debug_logger.h>
+
+#include "clean.h"
+#include "util.h"
+
+using goby::glog;
+
+namespace
+{
+constexpr const char* build_script = "build.sh";
+} // namespace
+
+jaiabot::apps::dev::CleanTool::CleanTool()
+{
+    try
+    {
+        auto build_dir = jaiabot::apps::dev::find_in_repo(build_script).parent_path() / "build";
+
+        if (boost::filesystem::exists(build_dir))
+        {
+            glog.is_verbose() && glog << "Removing " << build_dir << std::endl;
+            boost::filesystem::remove_all(build_dir);
+        }
+        else
+        {
+            glog.is_verbose() && glog << build_dir << " does not exist, nothing to clean"
+                                      << std::endl;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        glog.is_die() && glog << e.what() << std::endl;
+    }
+
+    quit(0);
+}

--- a/src/bin/tool/actions/dev/clean.cpp
+++ b/src/bin/tool/actions/dev/clean.cpp
@@ -2,6 +2,8 @@
 #include <cctype>
 #include <cstdio>
 #include <filesystem>
+#include <fstream>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -33,6 +35,78 @@ std::string local_arch()
     std::string arch(line.data());
     while (!arch.empty() && std::isspace(static_cast<unsigned char>(arch.back()))) arch.pop_back();
     return arch;
+}
+
+// Paths of every file this process currently has mapped -- its own executable plus any shared
+// libraries it has loaded (e.g. libjaiabot_messages.so.1 out of build/<arch>/lib) -- read from
+// /proc/self/maps, so clean can avoid deleting any of them out from under itself. Empty if this
+// can't be determined (e.g. not running on Linux).
+std::set<std::filesystem::path> protected_paths()
+{
+    std::set<std::filesystem::path> paths;
+
+    std::error_code ec;
+    auto exe = std::filesystem::canonical("/proc/self/exe", ec);
+    if (!ec)
+        paths.insert(exe);
+
+    std::ifstream maps("/proc/self/maps");
+    std::string line;
+    while (std::getline(maps, line))
+    {
+        auto slash = line.find('/');
+        if (slash == std::string::npos)
+            continue;
+
+        auto path = std::filesystem::canonical(line.substr(slash), ec);
+        if (!ec)
+            paths.insert(path);
+    }
+
+    return paths;
+}
+
+// Recursively removes everything under `dir` except any path in `protect`, and the chain of
+// directories needed to reach it (which are left in place, otherwise empty). Returns the
+// protected paths found (and so preserved) under `dir`.
+std::vector<std::filesystem::path> remove_all_except(const std::filesystem::path& dir,
+                                                     const std::set<std::filesystem::path>& protect)
+{
+    std::vector<std::filesystem::path> found;
+
+    for (const auto& entry : std::filesystem::directory_iterator(dir))
+    {
+        const auto& path = entry.path();
+
+        // A symlink (e.g. the libfoo.so.1 SONAME symlink dynamic loading actually looks up)
+        // pointing at a protected file must be kept too, not just the file it resolves to
+        bool is_protected = protect.count(path) != 0;
+        if (!is_protected && entry.is_symlink())
+        {
+            std::error_code ec;
+            auto target = std::filesystem::canonical(path, ec);
+            is_protected = !ec && protect.count(target) != 0;
+        }
+
+        if (is_protected)
+        {
+            found.push_back(path);
+        }
+        else if (entry.is_directory() && !entry.is_symlink())
+        {
+            auto nested = remove_all_except(path, protect);
+            if (!nested.empty())
+                found.insert(found.end(), nested.begin(), nested.end());
+            else
+                std::filesystem::remove_all(path);
+        }
+        else
+        {
+            std::filesystem::remove(path);
+        }
+    }
+
+    return found;
 }
 
 void remove_as_root(const std::vector<std::filesystem::path>& dirs)
@@ -74,7 +148,31 @@ jaiabot::apps::dev::CleanTool::CleanTool()
         if (std::filesystem::exists(local_build_dir))
         {
             glog.is_verbose() && glog << "Removing " << local_build_dir << std::endl;
-            std::filesystem::remove_all(local_build_dir);
+
+            auto protect = protected_paths();
+            auto skipped = protect.empty() ? std::vector<std::filesystem::path>{}
+                                           : remove_all_except(local_build_dir, protect);
+
+            if (!skipped.empty())
+            {
+                std::string list;
+                for (size_t i = 0; i < skipped.size(); ++i)
+                    list += (i == 0 ? "" : ", ") + skipped[i].string();
+
+                glog.is_warn() &&
+                    glog << "Skipped removing " << list
+                         << ": still in use by the currently running 'jaia' tool. Rebuild (e.g. "
+                            "\"jaia dev build jaia\") to replace them, or remove them manually "
+                            "once you're done using it."
+                         << std::endl;
+            }
+            else
+            {
+                if (protect.empty())
+                    std::filesystem::remove_all(local_build_dir);
+                else
+                    std::filesystem::remove(local_build_dir);
+            }
         }
         else
         {

--- a/src/bin/tool/actions/dev/clean.h
+++ b/src/bin/tool/actions/dev/clean.h
@@ -1,0 +1,59 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_CLEAN_H
+#define JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_CLEAN_H
+
+#include "goby/middleware/application/interface.h"
+
+#include "actions/dev/clean.pb.h"
+
+namespace jaiabot
+{
+namespace apps
+{
+namespace dev
+{
+class CleanToolConfigurator
+    : public goby::middleware::ProtobufConfigurator<jaiabot::config::dev::CleanTool>
+{
+  public:
+    CleanToolConfigurator(int argc, char* argv[])
+        : goby::middleware::ProtobufConfigurator<jaiabot::config::dev::CleanTool>(argc, argv)
+    {
+    }
+};
+
+class CleanTool : public goby::middleware::Application<jaiabot::config::dev::CleanTool>
+{
+  public:
+    CleanTool();
+    ~CleanTool() override {}
+
+  private:
+    void run() override { assert(false); }
+};
+
+} // namespace dev
+} // namespace apps
+} // namespace jaiabot
+#endif

--- a/src/bin/tool/actions/dev/clean.proto
+++ b/src/bin/tool/actions/dev/clean.proto
@@ -36,4 +36,15 @@ message CleanTool
 
     optional goby.middleware.protobuf.AppConfig app = 1
         [(goby.field) = { cfg { action: DEVELOPER } }];
+
+    optional bool docker = 2 [
+        default = false,
+        (goby.field) = {
+            description: "Also remove the cross-compile build directories created by 'jaia dev "
+                         "local_deploy' (scripts/build/container-build-and-deploy.sh), e.g. "
+                         "build/resolute-3.y-arm64. These are owned by root inside the build "
+                         "container, so 'sudo' is used to remove them",
+            cfg { cli_short: "d" }
+        }
+    ];
 }

--- a/src/bin/tool/actions/dev/clean.proto
+++ b/src/bin/tool/actions/dev/clean.proto
@@ -1,0 +1,39 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+syntax = "proto2";
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/protobuf/option_extensions.proto";
+
+package jaiabot.config.dev;
+
+message CleanTool
+{
+    option (goby.msg).cfg.tool = {
+        is_tool: true
+        has_subtools: false
+        has_help_action: false
+    };
+
+    optional goby.middleware.protobuf.AppConfig app = 1
+        [(goby.field) = { cfg { action: DEVELOPER } }];
+}

--- a/src/bin/tool/actions/dev/docker.cpp
+++ b/src/bin/tool/actions/dev/docker.cpp
@@ -1,0 +1,63 @@
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <unistd.h>
+
+#include <goby/util/debug_logger.h>
+
+#include "docker.h"
+
+using goby::glog;
+
+namespace
+{
+// Every image and container this repository creates (see container-image-build.sh,
+// container-build-and-deploy.sh and scripts/sim-docker) is tagged with this Docker label
+constexpr const char* jaia_label_filter = "label=jaiabot_build=true";
+
+// 'docker' subcommands (or "<command> <subcommand>" pairs) that accept "--filter" and are worth
+// scoping to just this repository's images/containers
+bool accepts_jaia_filter(const std::vector<std::string>& docker_args)
+{
+    if (docker_args.empty())
+        return false;
+
+    static const std::set<std::string> single_word_commands = {"ps", "images"};
+    static const std::set<std::pair<std::string, std::string>> two_word_commands = {
+        {"image", "ls"},       {"image", "list"},      {"image", "prune"}, {"container", "ls"},
+        {"container", "list"}, {"container", "prune"}, {"network", "ls"},  {"network", "list"},
+        {"network", "prune"},  {"volume", "ls"},       {"volume", "list"}, {"volume", "prune"},
+        {"system", "prune"},
+    };
+
+    if (single_word_commands.count(docker_args[0]))
+        return true;
+
+    return docker_args.size() > 1 && two_word_commands.count({docker_args[0], docker_args[1]});
+}
+
+} // namespace
+
+jaiabot::apps::dev::DockerTool::DockerTool()
+{
+    std::vector<std::string> docker_args{app_cfg().command()};
+    for (const auto& cli_extra : app_cfg().app().tool_cfg().extra_cli_param())
+        docker_args.push_back(cli_extra);
+
+    if (accepts_jaia_filter(docker_args))
+        docker_args.push_back(std::string("--filter=") + jaia_label_filter);
+
+    std::vector<std::string> args{"docker"};
+    for (const auto& arg : docker_args) args.push_back(arg);
+
+    std::vector<char*> c_args;
+    for (const auto& arg : args) c_args.push_back(const_cast<char*>(arg.c_str()));
+    c_args.push_back(nullptr); // execvp expects a null-terminated array
+
+    execvp(c_args[0], c_args.data());
+    // If execvp returns, there was an error
+    glog.is_die() && glog << "ERROR executing docker" << std::endl;
+    quit(0);
+}

--- a/src/bin/tool/actions/dev/docker.h
+++ b/src/bin/tool/actions/dev/docker.h
@@ -1,0 +1,59 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_DOCKER_H
+#define JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_DOCKER_H
+
+#include "goby/middleware/application/interface.h"
+
+#include "actions/dev/docker.pb.h"
+
+namespace jaiabot
+{
+namespace apps
+{
+namespace dev
+{
+class DockerToolConfigurator
+    : public goby::middleware::ProtobufConfigurator<jaiabot::config::dev::DockerTool>
+{
+  public:
+    DockerToolConfigurator(int argc, char* argv[])
+        : goby::middleware::ProtobufConfigurator<jaiabot::config::dev::DockerTool>(argc, argv)
+    {
+    }
+};
+
+class DockerTool : public goby::middleware::Application<jaiabot::config::dev::DockerTool>
+{
+  public:
+    DockerTool();
+    ~DockerTool() override {}
+
+  private:
+    void run() override { assert(false); }
+};
+
+} // namespace dev
+} // namespace apps
+} // namespace jaiabot
+#endif

--- a/src/bin/tool/actions/dev/docker.proto
+++ b/src/bin/tool/actions/dev/docker.proto
@@ -1,0 +1,50 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+syntax = "proto2";
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/protobuf/option_extensions.proto";
+
+package jaiabot.config.dev;
+
+message DockerTool
+{
+    option (goby.msg).cfg.tool = {
+        is_tool: true
+        // Not actually a dispatcher with its own subtools, but this is what gives the CLI parser
+        // the same lenient, pass-everything-through-unmodified behavior used by e.g. "jaia ssh"
+        // and "jaia ctl" to forward arbitrary trailing 'docker' flags and arguments unmodified
+        has_subtools: true
+        has_help_action: false
+    };
+
+    optional goby.middleware.protobuf.AppConfig app = 1
+        [(goby.field) = { cfg { action: DEVELOPER } }];
+
+    optional string command = 2 [
+        default = "ps",
+        (goby.field) = {
+            description: "The 'docker' command to run, e.g. \"image\", \"ps\", \"logs\"; the rest of the command line is passed to 'docker' unmodified",
+            cfg { position: { enable: true } }
+        }
+    ];
+}

--- a/src/bin/tool/actions/dev/local_deploy.cpp
+++ b/src/bin/tool/actions/dev/local_deploy.cpp
@@ -10,6 +10,7 @@
 
 #include "jaiabot/utils/ip.h"
 #include "local_deploy.h"
+#include "util.h"
 
 using goby::glog;
 
@@ -17,20 +18,6 @@ namespace
 {
 constexpr const char* deploy_script = "scripts/build/container-build-and-deploy.sh";
 constexpr const char* range_separator = "..";
-
-boost::filesystem::path find_deploy_script()
-{
-    for (auto dir = boost::filesystem::current_path(); !dir.empty(); dir = dir.parent_path())
-    {
-        auto script = dir / deploy_script;
-        if (boost::filesystem::exists(script))
-            return script;
-    }
-
-    throw std::runtime_error(std::string("Could not find ") + deploy_script +
-                             " in the current directory or any of its parents: 'local_deploy' "
-                             "deploys the jaiabot source tree it is run from");
-}
 
 // Expands a single target into the hosts it refers to: either one host code (e.g. "b1f6") or an
 // inclusive range of them (e.g. "b1f6..b3f6")
@@ -75,7 +62,7 @@ jaiabot::apps::dev::LocalDeployTool::LocalDeployTool()
             throw std::invalid_argument(
                 "At least one target is required, e.g. \"jaia dev local_deploy b1f6..b3f6 h1f6\"");
 
-        args.push_back(find_deploy_script().string());
+        args.push_back(jaiabot::apps::dev::find_in_repo(deploy_script).string());
 
         int fleet_id = -1;
         if (app_cfg().has_fleet())

--- a/src/bin/tool/actions/dev/local_deploy.cpp
+++ b/src/bin/tool/actions/dev/local_deploy.cpp
@@ -5,7 +5,6 @@
 
 #include <unistd.h>
 
-#include <boost/filesystem.hpp>
 #include <goby/util/debug_logger.h>
 
 #include "jaiabot/utils/ip.h"

--- a/src/bin/tool/actions/dev/setup.cpp
+++ b/src/bin/tool/actions/dev/setup.cpp
@@ -1,0 +1,40 @@
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+#include <goby/util/debug_logger.h>
+
+#include "setup.h"
+#include "util.h"
+
+using goby::glog;
+
+namespace
+{
+constexpr const char* setup_script = "scripts/build/setup-tools-build.sh";
+} // namespace
+
+jaiabot::apps::dev::SetupTool::SetupTool()
+{
+    std::vector<std::string> args;
+
+    try
+    {
+        args.push_back(jaiabot::apps::dev::find_in_repo(setup_script).string());
+    }
+    catch (const std::exception& e)
+    {
+        glog.is_die() && glog << e.what() << std::endl;
+    }
+
+    std::vector<char*> c_args;
+    for (const auto& arg : args) c_args.push_back(const_cast<char*>(arg.c_str()));
+    c_args.push_back(nullptr); // execvp expects a null-terminated array
+
+    execvp(c_args[0], c_args.data());
+    // If execvp returns, there was an error
+    glog.is_die() && glog << "ERROR executing " << args[0] << std::endl;
+    quit(0);
+}

--- a/src/bin/tool/actions/dev/setup.h
+++ b/src/bin/tool/actions/dev/setup.h
@@ -1,0 +1,59 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_SETUP_H
+#define JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_SETUP_H
+
+#include "goby/middleware/application/interface.h"
+
+#include "actions/dev/setup.pb.h"
+
+namespace jaiabot
+{
+namespace apps
+{
+namespace dev
+{
+class SetupToolConfigurator
+    : public goby::middleware::ProtobufConfigurator<jaiabot::config::dev::SetupTool>
+{
+  public:
+    SetupToolConfigurator(int argc, char* argv[])
+        : goby::middleware::ProtobufConfigurator<jaiabot::config::dev::SetupTool>(argc, argv)
+    {
+    }
+};
+
+class SetupTool : public goby::middleware::Application<jaiabot::config::dev::SetupTool>
+{
+  public:
+    SetupTool();
+    ~SetupTool() override {}
+
+  private:
+    void run() override { assert(false); }
+};
+
+} // namespace dev
+} // namespace apps
+} // namespace jaiabot
+#endif

--- a/src/bin/tool/actions/dev/setup.proto
+++ b/src/bin/tool/actions/dev/setup.proto
@@ -1,0 +1,39 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+syntax = "proto2";
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/protobuf/option_extensions.proto";
+
+package jaiabot.config.dev;
+
+message SetupTool
+{
+    option (goby.msg).cfg.tool = {
+        is_tool: true
+        has_subtools: false
+        has_help_action: false
+    };
+
+    optional goby.middleware.protobuf.AppConfig app = 1
+        [(goby.field) = { cfg { action: DEVELOPER } }];
+}

--- a/src/bin/tool/actions/dev/util.h
+++ b/src/bin/tool/actions/dev/util.h
@@ -23,10 +23,9 @@
 #ifndef JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_UTIL_H
 #define JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_UTIL_H
 
+#include <filesystem>
 #include <stdexcept>
 #include <string>
-
-#include <boost/filesystem.hpp>
 
 namespace jaiabot
 {
@@ -36,12 +35,12 @@ namespace dev
 {
 // Walks up from the current directory looking for `relative_path` (e.g. "build.sh"), so these
 // tools can be run from anywhere within a jaiabot source tree, not just its root.
-inline boost::filesystem::path find_in_repo(const std::string& relative_path)
+inline std::filesystem::path find_in_repo(const std::string& relative_path)
 {
-    for (auto dir = boost::filesystem::current_path(); !dir.empty(); dir = dir.parent_path())
+    for (auto dir = std::filesystem::current_path(); !dir.empty(); dir = dir.parent_path())
     {
         auto candidate = dir / relative_path;
-        if (boost::filesystem::exists(candidate))
+        if (std::filesystem::exists(candidate))
             return candidate;
     }
 

--- a/src/bin/tool/actions/dev/util.h
+++ b/src/bin/tool/actions/dev/util.h
@@ -1,0 +1,57 @@
+// Copyright 2026:
+//   JaiaRobotics LLC
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the JaiaBot Project Binaries
+// ("The Jaia Binaries").
+//
+// The Jaia Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Jaia Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with the Jaia Binaries.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_UTIL_H
+#define JAIABOT_SRC_BIN_TOOL_ACTIONS_DEV_UTIL_H
+
+#include <stdexcept>
+#include <string>
+
+#include <boost/filesystem.hpp>
+
+namespace jaiabot
+{
+namespace apps
+{
+namespace dev
+{
+// Walks up from the current directory looking for `relative_path` (e.g. "build.sh"), so these
+// tools can be run from anywhere within a jaiabot source tree, not just its root.
+inline boost::filesystem::path find_in_repo(const std::string& relative_path)
+{
+    for (auto dir = boost::filesystem::current_path(); !dir.empty(); dir = dir.parent_path())
+    {
+        auto candidate = dir / relative_path;
+        if (boost::filesystem::exists(candidate))
+            return candidate;
+    }
+
+    throw std::runtime_error(
+        "Could not find " + relative_path +
+        " in the current directory or any of its parents: this command must be run from within "
+        "a jaiabot source tree");
+}
+
+} // namespace dev
+} // namespace apps
+} // namespace jaiabot
+#endif

--- a/src/doc/markdown/page020_build.md
+++ b/src/doc/markdown/page020_build.md
@@ -8,7 +8,7 @@ The JaiaBot software depends on Goby3, MOOS, and other packages.
 
 When using the `jaiabot` Debian packages (see the CI/CD section below), these dependencies are automatically installed by `apt`.
 
-When building from source, these can be installed from the regular Ubuntu package repositories plus the `packages.jaia.tech` mirror of the `packages.gobysoft.org` repository (also reference the steps in jaiabot/.docker/resolute/amd64/Dockerfile):
+When building from source, these can be installed from the regular Ubuntu package repositories plus the `packages.jaia.tech` mirror of the `packages.gobysoft.org` repository (also reference the steps in jaiabot/.docker/resolute/amd64/Dockerfile). If you have the `jaia` tool already installed (e.g. from a package), `jaia dev setup` runs these steps for you (see below).
 
 ```
 # add mirror of packages.gobysoft.org to your apt sources
@@ -71,6 +71,43 @@ Build documentation as well:
 ```
 export JAIABOT_CMAKE_FLAGS="-Dbuild_doc=ON"
 ./build.sh
+```
+
+### Using `jaia dev`
+
+If you have the `jaia` tool available (from a package, or already built from this source tree), `jaia dev` provides a friendlier front end for the day-to-day build workflow:
+
+```bash
+# install the compilers, CMake, apt build dependencies, arduino-cli and nvm/npm/webpack
+# needed to build this source tree (requires root or sudo)
+jaia dev setup
+
+# equivalent to ./build.sh
+jaia dev build
+# build only the 'jaia' target
+jaia dev build jaia
+# set a CMake variable, equivalent to `export JAIABOT_CMAKE_FLAGS="-Dbuild_doc=ON"; ./build.sh`
+jaia dev build --cmake_var build_doc=ON
+# set a variable passed to the underlying build tool (make)
+jaia dev build --make_var VERBOSE=1
+
+# remove the entire build directory (all architectures), for a clean rebuild
+jaia dev clean
+```
+
+`jaia dev build` checks for the tools `jaia dev setup` installs before invoking `build.sh`, so a missing setup step is reported clearly (e.g. "It looks like 'jaia dev setup' has not been (successfully) run on this machine") instead of failing partway through configuration.
+
+`jaia dev docker` is a front end for `docker` scoped to the images and containers this repository creates (the cross-compile build image/container from `container-image-build.sh` / `container-build-and-deploy.sh`, and the simulator image/container from `scripts/sim-docker`), which are all tagged with the Docker label `jaiabot_build=true`. For `docker` commands that support `--filter` (`ps`, `images`, `image ls`, `container ls`, `network ls`, `volume ls`, the `prune` commands, etc.), `jaia dev docker` automatically adds `--filter label=jaiabot_build=true` so only this repository's images/containers are shown or affected; other commands (e.g. `docker logs`, `docker exec`, `docker rm`) are passed through to `docker` unmodified:
+
+```bash
+# list this repository's running containers ('docker ps --filter label=jaiabot_build=true')
+jaia dev docker
+# list all of this repository's containers, running or not
+jaia dev docker ps -a
+# list this repository's images
+jaia dev docker image list
+# remove this repository's stopped containers
+jaia dev docker container prune
 ```
 
 ## CI/CD

--- a/src/doc/markdown/page020_build.md
+++ b/src/doc/markdown/page020_build.md
@@ -2,6 +2,16 @@
 
 JaiaBot development is done on Ubuntu Linux, with the version of Ubuntu supported aligned with the `jaiabot` release branch (see [Repository](page019_repository.md) page).
 
+## Bootstrapping a fresh clone
+
+On a fresh clone there's no `jaia` tool yet to run `jaia dev setup` or `jaia dev build`, so `init.sh` bridges that gap: it runs the underlying setup and build steps directly, then puts `build/<arch>/bin` on `PATH` so `jaia` is available right away.
+
+```bash
+source ./init.sh
+```
+
+Source it (rather than running it) so the `PATH` change also applies to your current shell; future shells pick it up automatically, since `init.sh` also appends it to your shell rc file. Once it finishes, run `jaia dev build` to finish building the rest of the project.
+
 ## Dependencies
 
 The JaiaBot software depends on Goby3, MOOS, and other packages.

--- a/src/doc/markdown/page020_build.md
+++ b/src/doc/markdown/page020_build.md
@@ -42,12 +42,13 @@ sudo apt-get -y install libgoby3:amd64 \
             curl:amd64 \
             nodejs:amd64 \
             webpack:amd64 \
-            npm:amd64
+            npm:amd64 \
+            ninja-build:amd64
 ```
 
 ## CMake
 
-The `jaiabot` software is configured using CMake which (by default) then generates Makefiles that the `make` tool uses to invoke the C++ compiler and linker.
+The `jaiabot` software is configured using CMake, which generates a Ninja build by default (Ninja is faster than, and otherwise a drop-in replacement for, the Makefiles CMake generates by default).
 
 This process is summarized by:
 
@@ -56,12 +57,12 @@ This process is summarized by:
 mkdir -p build/amd64
 cd build/amd64
 # configure the project
-cmake ../..
-# build it (using make by default)
+cmake -G Ninja ../..
+# build it
 cmake --build .
 ```
 
-This project provides a convenience script called `build.sh` that runs cmake to configure and build the project (using as many jobs as your machine has processors). The build.sh script segregates the CMake working directory by machine architecture (e.g. build/amd64, build/arm64, etc.). Additionally, you can set the environmental variables `JAIABOT_CMAKE_FLAGS` and/or `JAIABOT_MAKE_FLAGS` to pass command line parameters to CMake (during configure) or make, respectively. 
+This project provides a convenience script called `build.sh` that runs cmake to configure and build the project (using as many jobs as your machine has processors). The build.sh script segregates the CMake working directory by machine architecture (e.g. build/amd64, build/arm64, etc.). Additionally, you can set the environmental variables `JAIABOT_CMAKE_FLAGS` and/or `JAIABOT_MAKE_FLAGS` to pass command line parameters to CMake (during configure) or the underlying build tool, respectively. Pass `--make` to `build.sh` to use GNU Make instead of Ninja (e.g. if `ninja-build` isn't installed); switching between the two automatically discards the existing CMake cache, since CMake can't reconfigure a directory with a different generator than the one it was first configured with.
 
 Running the build script will start a parallel build using a number of processors that is equal to the lesser of:
 
@@ -98,8 +99,10 @@ jaia dev build
 jaia dev build jaia
 # set a CMake variable, equivalent to `export JAIABOT_CMAKE_FLAGS="-Dbuild_doc=ON"; ./build.sh`
 jaia dev build --cmake_var build_doc=ON
-# set a variable passed to the underlying build tool (make)
+# set a variable passed to the underlying build tool (Ninja by default)
 jaia dev build --make_var VERBOSE=1
+# use GNU Make instead of the default Ninja generator
+jaia dev build --make
 
 # remove this machine's local build directory (e.g. build/amd64), for a clean rebuild
 jaia dev clean

--- a/src/doc/markdown/page020_build.md
+++ b/src/doc/markdown/page020_build.md
@@ -91,8 +91,12 @@ jaia dev build --cmake_var build_doc=ON
 # set a variable passed to the underlying build tool (make)
 jaia dev build --make_var VERBOSE=1
 
-# remove the entire build directory (all architectures), for a clean rebuild
+# remove this machine's local build directory (e.g. build/amd64), for a clean rebuild
 jaia dev clean
+# also remove the cross-compile build directories from "jaia dev local_deploy" (e.g.
+# build/resolute-3.y-arm64); these are owned by root inside the build container, so this
+# uses sudo to remove them
+jaia dev clean --docker
 ```
 
 `jaia dev build` checks for the tools `jaia dev setup` installs before invoking `build.sh`, so a missing setup step is reported clearly (e.g. "It looks like 'jaia dev setup' has not been (successfully) run on this machine") instead of failing partway through configuration.


### PR DESCRIPTION
## Summary

This PR adds four new subcommands to the `jaia dev` tool to streamline the development workflow:

- **`jaia dev build`**: Wrapper around `./build.sh` with support for passing CMake variables (`--cmake_var`) and make variables (`--make_var`). Validates that required build tools (cmake, arduino-cli, nvm) are installed before attempting to build, providing clear error messages if `jaia dev setup` hasn't been run.

- **`jaia dev clean`**: Removes the build directory to enable clean rebuilds.

- **`jaia dev setup`**: Runs the setup script to install compilers, CMake, build dependencies, arduino-cli, and nvm/npm/webpack required for building.

- **`jaia dev docker`**: Frontend to the `docker` command that automatically scopes operations to jaiabot-specific images and containers (via `--filter label=jaiabot_build=true`).

Key implementation details:
- Added `util.h` with `find_in_repo()` helper to locate scripts from anywhere within the source tree
- Each tool uses `execvp()` to replace the process with the target command/script
- Docker tool intelligently applies filtering only to commands that support `--filter`
- Build tool checks for required dependencies and provides actionable error messages
- Updated `dev.proto` with new enum values and help text
- Updated build scripts to tag Docker images/containers with `label=jaiabot_build=true`
- Updated documentation in `page020_build.md` with usage examples

## Test Procedure

- Verify `jaia dev build` executes `./build.sh` with proper CMake and make variable forwarding
- Verify `jaia dev build` fails with clear error message when required tools are missing
- Verify `jaia dev clean` removes the build directory
- Verify `jaia dev setup` executes the setup script
- Verify `jaia dev docker ps` applies the jaiabot filter automatically
- Verify `jaia dev docker --help` works correctly
- Verify all tools can be run from subdirectories within the source tree

https://claude.ai/code/session_01UpNqZ9DFUcof7Kz62ikqPV