### PR TITLE
feature/arduino-detect-battery-cells-levels

### DIFF
--- a/cmake/JaiaVersions.cmake
+++ b/cmake/JaiaVersions.cmake
@@ -81,4 +81,4 @@ set(PROJECT_SOVERSION "1")
 
 # increment when DCCL messages change. See also src/lib/messages/CMakeLists.txt
 # start at 1 as 0 would be used prior to introducing this version (goby::middleware::Group::broadcast_group == 0)
-set(PROJECT_INTERVEHICLE_API_VERSION 23)
+set(PROJECT_INTERVEHICLE_API_VERSION 24)

--- a/config/templates/bot/jaiabot_driver_arduino.pb.cfg.in
+++ b/config/templates/bot/jaiabot_driver_arduino.pb.cfg.in
@@ -21,6 +21,12 @@ arduino_version_table {
     app_versions_compatible_to: ""
 }
 
+arduino_version_table {
+    arduino_version: 4
+    app_versions_compatible_from: "2.4.0"
+    app_versions_compatible_to: ""
+}
+
 flash_startup_delay_seconds: 15
 
 $jaiabot_driver_arduino_bounds

--- a/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
+++ b/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
@@ -102,7 +102,7 @@ constexpr int BatteryMidpointVoltage = A6;
 constexpr int thermistor_pin = A4;
 
 // Volts per analog unit for the battery midpoint divider
-constexpr double battery_midpoint_volts_per_analog_unit = .0306;
+constexpr double battery_midpoint_volts_per_analog_unit = .021016;
 
 // Generic GPIO Device Pin 
 constexpr int generic_gpio_pin = 7;

--- a/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
+++ b/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
@@ -15,7 +15,7 @@
 // If you are increasing this version than update
 // arduino driver configuration to include the new
 // version
-const int arduino_version = 3;
+const int arduino_version = 4;
 
 // Binary serial protocol
 // [JAIA][2-byte size - big endian][bytes][JAIA]...
@@ -98,7 +98,11 @@ bool target_led_switch_on = false;
 constexpr int VvCurrent = A3;
 constexpr int VccCurrent = A2;
 constexpr int VccVoltage = A0;
+constexpr int BatteryMidpointVoltage = A6;
 constexpr int thermistor_pin = A4;
+
+// Volts per analog unit for the Vcc and battery midpoint dividers
+constexpr double volts_per_analog_unit = .0306;
 
 // Generic GPIO Device Pin 
 constexpr int generic_gpio_pin = 7;
@@ -163,10 +167,15 @@ void send_ack(jaiabot_protobuf_ArduinoStatusCode code, uint32_t crc=0, uint32_t 
     ack.has_thermocouple_temperature_C = false;
   }
 
-  ack.vccvoltage = analogRead(VccVoltage)*.0306;
+  ack.vccvoltage = analogRead(VccVoltage)*volts_per_analog_unit;
   ack.has_vccvoltage = true;
   ack.vvcurrent = ((analogRead(VvCurrent)*.0049)-5)*-.05;
   ack.has_vvcurrent = true;
+
+  // Voltage at the junction of the two series batteries, so the driver can
+  // compare the charge of each battery against the other
+  ack.battery_midpoint_voltage = analogRead(BatteryMidpointVoltage)*volts_per_analog_unit;
+  ack.has_battery_midpoint_voltage = true;
 
   // Vcccurrent
   ack.vcccurrent = Vcccurrent_rolling_average();

--- a/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
+++ b/src/arduino/jaiabot_runtime/jaiabot_runtime.ino
@@ -101,8 +101,8 @@ constexpr int VccVoltage = A0;
 constexpr int BatteryMidpointVoltage = A6;
 constexpr int thermistor_pin = A4;
 
-// Volts per analog unit for the Vcc and battery midpoint dividers
-constexpr double volts_per_analog_unit = .0306;
+// Volts per analog unit for the battery midpoint divider
+constexpr double battery_midpoint_volts_per_analog_unit = .0306;
 
 // Generic GPIO Device Pin 
 constexpr int generic_gpio_pin = 7;
@@ -167,14 +167,14 @@ void send_ack(jaiabot_protobuf_ArduinoStatusCode code, uint32_t crc=0, uint32_t 
     ack.has_thermocouple_temperature_C = false;
   }
 
-  ack.vccvoltage = analogRead(VccVoltage)*volts_per_analog_unit;
+  ack.vccvoltage = analogRead(VccVoltage)*.0306;
   ack.has_vccvoltage = true;
   ack.vvcurrent = ((analogRead(VvCurrent)*.0049)-5)*-.05;
   ack.has_vvcurrent = true;
 
   // Voltage at the junction of the two series batteries, so the driver can
   // compare the charge of each battery against the other
-  ack.battery_midpoint_voltage = analogRead(BatteryMidpointVoltage)*volts_per_analog_unit;
+  ack.battery_midpoint_voltage = analogRead(BatteryMidpointVoltage)*battery_midpoint_volts_per_analog_unit;
   ack.has_battery_midpoint_voltage = true;
 
   // Vcccurrent

--- a/src/bin/drivers/arduino/app.cpp
+++ b/src/bin/drivers/arduino/app.cpp
@@ -340,11 +340,24 @@ void jaiabot::apps::ArduinoDriver::handle_arduino_response(
         auto lower_battery_volts = arduino_response.battery_midpoint_voltage();
         auto upper_battery_volts = arduino_response.vccvoltage() - lower_battery_volts;
 
-        battery_imbalance_volts_ = std::abs(upper_battery_volts - lower_battery_volts);
+        // The junction can only sit somewhere between the ends of the pack, so a reading outside
+        // that is a wiring or scaling fault rather than a battery that needs reporting
+        if (lower_battery_volts <= 0 || upper_battery_volts <= 0)
+        {
+            battery_imbalance_volts_ = 0;
 
-        glog.is_debug2() && glog << group("arduino") << "Lower battery: " << lower_battery_volts
-                                 << ", Upper battery: " << upper_battery_volts
-                                 << ", Imbalance: " << battery_imbalance_volts_ << std::endl;
+            glog.is_warn() && glog << group("arduino") << "Battery midpoint of "
+                                   << lower_battery_volts << " V is not within a pack of "
+                                   << arduino_response.vccvoltage() << " V" << std::endl;
+        }
+        else
+        {
+            battery_imbalance_volts_ = std::abs(upper_battery_volts - lower_battery_volts);
+
+            glog.is_debug2() && glog << group("arduino") << "Lower battery: " << lower_battery_volts
+                                     << ", Upper battery: " << upper_battery_volts
+                                     << ", Imbalance: " << battery_imbalance_volts_ << std::endl;
+        }
     }
 
     glog.is_debug1() && glog << group("arduino")

--- a/src/bin/drivers/arduino/app.cpp
+++ b/src/bin/drivers/arduino/app.cpp
@@ -23,6 +23,7 @@
 #include <goby/middleware/marshalling/protobuf.h>
 // this space intentionally left blank
 #include <algorithm>
+#include <cmath>
 #include <goby/zeromq/application/multi_thread.h>
 
 using namespace std;
@@ -66,6 +67,8 @@ class ArduinoDriver : public zeromq::MultiThreadApplication<config::ArduinoDrive
     void health(goby::middleware::protobuf::ThreadHealth& health) override;
     void check_last_report(goby::middleware::protobuf::ThreadHealth& health,
                            goby::middleware::protobuf::HealthState& health_state);
+    void check_battery_imbalance(goby::middleware::protobuf::ThreadHealth& health,
+                                 goby::middleware::protobuf::HealthState& health_state);
     void request_arduino_flash();
     void setBounds(const jaiabot::protobuf::Bounds& bounds);
     void publish_arduino_commands();
@@ -102,6 +105,9 @@ class ArduinoDriver : public zeromq::MultiThreadApplication<config::ArduinoDrive
 
     // Bot rolled over
     bool bot_rolled_over_{false};
+
+    // Difference in charge between the two series batteries
+    float battery_imbalance_volts_{0};
 
     // Version Table
     std::map<uint32_t, std::pair<std::string, std::string>> arduino_version_compatibility_;
@@ -325,6 +331,20 @@ void jaiabot::apps::ArduinoDriver::handle_arduino_response(
                 glog.is_debug2() && glog << group("main") << "Finsihed Restarting" << std::endl;
             }
         }
+    }
+
+    // The midpoint is the junction of the two series batteries, so it is the voltage of the
+    // lower battery and the remainder of the pack is the voltage of the upper battery
+    if (arduino_response.has_vccvoltage() && arduino_response.has_battery_midpoint_voltage())
+    {
+        auto lower_battery_volts = arduino_response.battery_midpoint_voltage();
+        auto upper_battery_volts = arduino_response.vccvoltage() - lower_battery_volts;
+
+        battery_imbalance_volts_ = std::abs(upper_battery_volts - lower_battery_volts);
+
+        glog.is_debug2() && glog << group("arduino") << "Lower battery: " << lower_battery_volts
+                                 << ", Upper battery: " << upper_battery_volts
+                                 << ", Imbalance: " << battery_imbalance_volts_ << std::endl;
     }
 
     glog.is_debug1() && glog << group("arduino")
@@ -589,6 +609,7 @@ void jaiabot::apps::ArduinoDriver::health(goby::middleware::protobuf::ThreadHeal
     auto health_state = goby::middleware::protobuf::HEALTH__OK;
 
     check_last_report(health, health_state);
+    check_battery_imbalance(health, health_state);
 
     health.set_state(health_state);
 }
@@ -632,6 +653,22 @@ void jaiabot::apps::ArduinoDriver::check_last_report(
     else
     {
         flash_arduino_issue_published_ = false;
+    }
+}
+
+void jaiabot::apps::ArduinoDriver::check_battery_imbalance(
+    goby::middleware::protobuf::ThreadHealth& health,
+    goby::middleware::protobuf::HealthState& health_state)
+{
+    if (battery_imbalance_volts_ > cfg().battery_imbalance_max_volts())
+    {
+        glog.is_warn() && glog << "Battery imbalance of " << battery_imbalance_volts_
+                               << " V exceeds " << cfg().battery_imbalance_max_volts() << " V"
+                               << std::endl;
+
+        health_state = goby::middleware::protobuf::HEALTH__FAILED;
+        health.MutableExtension(jaiabot::protobuf::jaiabot_thread)
+            ->add_error(protobuf::ERROR__VEHICLE__BATTERY_IMBALANCE);
     }
 }
 

--- a/src/bin/drivers/arduino/config.proto
+++ b/src/bin/drivers/arduino/config.proto
@@ -55,4 +55,7 @@ message ArduinoDriverConfig
 
     // Seconds after driver startup before publishing FLASH_ARDUINO on connection/version failure
     optional int32 flash_startup_delay_seconds = 24 [default = 15];
+
+    // Volts of difference between the two series batteries before reporting an imbalance error
+    optional float battery_imbalance_max_volts = 25 [default = 1.0];
 }

--- a/src/bin/simulator/arduino_sim_thread.cpp
+++ b/src/bin/simulator/arduino_sim_thread.cpp
@@ -55,7 +55,7 @@ void jaiabot::apps::ArduinoSimThread::handle_arduino_command(const jaiabot::prot
     //   as if they were coming from the actual Arduino, which is useful for testing 
     //   the driver without needing the physical hardware.
     jaiabot::protobuf::ArduinoResponse arduino_response;
-    arduino_response.set_version(3);
+    arduino_response.set_version(4);
     arduino_response.set_thermistor_voltage(2.5);
 
     if (arduino_command.has_settings())
@@ -84,6 +84,8 @@ void jaiabot::apps::ArduinoSimThread::handle_arduino_command(const jaiabot::prot
     {
         voltage_start_ = voltage_start_ - voltage_step_decrease_;
         arduino_response.set_vccvoltage(voltage_start_);
+        // Simulate two evenly charged batteries in series
+        arduino_response.set_battery_midpoint_voltage(voltage_start_ / 2);
         voltage_updated_ = goby::time::SteadyClock::now();
 
         if (voltage_start_ < reset_voltage_level_)

--- a/src/doc/markdown/page070_hardware.md
+++ b/src/doc/markdown/page070_hardware.md
@@ -8,7 +8,7 @@
 |  3  | PC6/RST     | No Connection    |
 |  4  | +5V         | +5V              |
 |  5  | A7          | J1 - BRK_3       |  
-|  6  | A6          | LED 2 (Doesn't work - can't drive LED from Analog Pin)           |
+|  6  | A6          | Voltage - Battery Midpoint |
 |  7  | A5/D19      | LED 1            |
 |  8  | A4          | LED EXT          |
 |  9  | A3          | Current - 5V     |

--- a/src/doc/markdown/page076_battery_health.md
+++ b/src/doc/markdown/page076_battery_health.md
@@ -6,3 +6,11 @@
 | 50      | WARNING__VEHICLE__LOW_BATTERY          | No limitations, but operator should be prepared to return bot home                                                     |
 | 20   | ERROR__VEHICLE__VERY_LOW_BATTERY       | The bot is unable to dive when it reaches this level. The operator should make it a priority to return home            |
 | 10   | ERROR__VEHICLE__CRITICALLY_LOW_BATTERY | The bot is unable to drive at this point, but will continue to transmit its location for retrieval.                               |
+
+## Battery Imbalance
+The Arduino measures the junction of the two series batteries on A6, and the arduino driver
+compares the charge of each battery against the other.
+
+| Volts | Health Warn/Error                | Limitations |
+| ----- |----------------------------------| ------------|
+| 1.0   | ERROR__VEHICLE__BATTERY_IMBALANCE | One battery is more charged than the other, which indicates a failing battery or a bad connection. The threshold is set by `battery_imbalance_max_volts` in the arduino driver configuration. |

--- a/src/lib/messages/CMakeLists.txt
+++ b/src/lib/messages/CMakeLists.txt
@@ -97,9 +97,9 @@ if(NOT CMAKE_CROSSCOMPILING)
   # and update the hash here (dccl -f src/lib/messages/jaia_dccl.proto -I build/amd64/include -I /usr/include -a -m jaiabot.protobuf.BotStatus -H)
 
   # When adding a new DCCL message (for intervehicle comms), make sure to add it to this list
-  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xc4f31768df8d6cbe")
+  check_dccl_md5_hash("jaiabot.protobuf.BotStatus" "0xa1993e48314f8d3f")
   check_dccl_md5_hash("jaiabot.protobuf.TaskPacket" "0xc2b6ff5101df098c")
   check_dccl_md5_hash("jaiabot.protobuf.Command" "0x0f49a512d736e37c")
   check_dccl_md5_hash("jaiabot.protobuf.Engineering" "0x353435896a1ea1a0")
-  check_dccl_md5_hash("jaiabot.protobuf.Hub2HubData" "0x4b4262065989785d")
+  check_dccl_md5_hash("jaiabot.protobuf.Hub2HubData" "0xed5566a98d30fb49")
 endif()

--- a/src/lib/messages/arduino.proto
+++ b/src/lib/messages/arduino.proto
@@ -49,6 +49,7 @@ message ArduinoResponse
     optional int32 motor = 6;
     optional float thermistor_voltage = 7;
     optional float generic_gpio_voltage = 8;
+    optional float battery_midpoint_voltage = 9;
 
     optional uint32 crc = 50;
     optional uint32 calculated_crc = 51;

--- a/src/lib/messages/health.proto
+++ b/src/lib/messages/health.proto
@@ -220,6 +220,8 @@ enum Error
         [(jaia.ev).rest_api.presence = GUARANTEED];
     ERROR__VEHICLE__MISSING_DATA_BATTERY = 602
         [(jaia.ev).rest_api.presence = GUARANTEED];
+    ERROR__VEHICLE__BATTERY_IMBALANCE = 603
+        [(jaia.ev).rest_api.presence = GUARANTEED];
 
     // arduino driver
     ERROR__VERSION__MISMATCH_ARDUINO = 700


### PR DESCRIPTION
## Summary

This PR makes the bot compare the charge of its two batteries and report an error when one is more charged than the other.

The two batteries are wired in series, and the Arduino already has the junction between them on pin `A6`. Reading that junction gives the voltage of the lower battery, and whatever is left of the pack voltage is the upper battery, so the two can be compared directly. 

## Changes

- Adds `battery_midpoint_voltage` to `ArduinoResponse`, read from `A6` and converted to volts using the divider figure from the electrical team.
- Reports `ERROR__VEHICLE__BATTERY_IMBALANCE` from the arduino driver when the two batteries differ by more than `battery_imbalance_max_volts`, which defaults to 1.0 V and can be changed without reflashing the Arduino.
  - Adding a value to the health error list changed the `BotStatus` and `Hub2HubData` DCCL hashes, because DCCL sizes an enum field by the values it holds and includes their names. The intervehicle API version and both hashes were updated.
- Ignores a midpoint reading that falls outside the pack and reports it as a warning instead, since the junction of two batteries can only sit somewhere between the ends of the pack. A reading outside that is a wiring or conversion fault, not a battery fault, and should not raise a battery error against every bot.
- Moves the Arduino code version to 4 and registers that version in the arduino driver configuration.
- Reports an evenly charged pack in simulation, so the check can be exercised without a bot.
- Corrects the arduino pinout table, which listed `A6` as a non-working LED, and documents the new error on the battery health page.

A bot still running Arduino version 3 does not send the midpoint reading, and reports no imbalance error rather than a false one.

## Testing

### Verified locally

- [x] `jaiabot_messages`, `jaiabot_driver_arduino` and `jaiabot_simulator` all build.
- [x] The DCCL hash checks pass with the updated hashes.
- [x] The Arduino sketch compiles for the Nano and still fits: 59% of program storage, 46% of memory.

### Not yet tested

- [ ] On one bot, compare the reported voltage of each battery against a multimeter reading at the battery terminals and confirm they agree.
- [ ] Confirm a healthy pack reports no error.
- [ ] Confirm a deliberately imbalanced pack raises `ERROR__VEHICLE__BATTERY_IMBALANCE` and that it appears in the web interface.
- [ ] Confirm the error clears once the batteries are balanced again.
- [ ] Confirm the imbalance reading stays steady under motor load rather than drifting with current draw.
