### PR TITLE
3.y / Build the web UI in its own CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,6 @@ job-template-amd64: &job-template-amd64
   working_directory: /root/jaiabot
   steps:
     - checkout
-    - restore_cache: &restore-npm-webpack-cache
-        keys:
-          - jaiabot-npm-webpack-v1-{{ checksum "src/web/package-lock.json" }}
-          - jaiabot-npm-webpack-v1-
     - restore_cache: &restore-ccache
         keys:
           - jaiabot-ccache-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
@@ -98,7 +94,9 @@ job-template-amd64: &job-template-amd64
         command: ccache -z || true
     - run: &run-build
         name: Build
-        command: mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -Denable_testing=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .. && cmake --build . -- -j4
+        # the web UI is built by amd64-resolute-web-build instead: webpack alongside
+        # four concurrent clang jobs exceeds the container's memory
+        command: mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -Denable_testing=ON -Dbuild_web=OFF -Dbuild_jdv=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .. && cmake --build . -- -j4
     - run: &show-ccache-stats
         name: Show ccache stats
         command: ccache -s || true
@@ -106,16 +104,38 @@ job-template-amd64: &job-template-amd64
         key: jaiabot-ccache-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
         paths:
           - /root/.ccache
+    - run: &run-tests
+        name: Run tests
+        command: cd build && ctest --output-on-failure
+
+## The web UI half of job-template-amd64. npm/webpack and the C++ compile have no
+## dependency on each other in CMake, and running them in one job is what puts the
+## container over its memory limit, so each gets its own.
+job-template-web-amd64: &job-template-web-amd64
+  resource_class: large
+  working_directory: /root/jaiabot
+  steps:
+    - checkout
+    - restore_cache: &restore-npm-webpack-cache
+        keys:
+          - jaiabot-npm-webpack-v1-{{ checksum "src/web/package-lock.json" }}
+          - jaiabot-npm-webpack-v1-
+    - run: *run-set-deb-rep-and-version
+    - run: *run-add-jaia-packages-list
+    - run: *run-update-apt
+    - run: &run-build-web
+        name: Build the web UI
+        # the web targets live in the same CMake project as everything else, so this
+        # configures the whole project but builds only those targets
+        command: mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . --target jcc_jed jdv
     - save_cache: &save-npm-webpack-cache
         key: jaiabot-npm-webpack-v1-{{ checksum "src/web/package-lock.json" }}
         paths:
           - /root/.npm
           - /root/.cache/webpack
-    - run: &run-tests
-        name: Run tests
-        command: |
-          cd build && ctest --output-on-failure
-          cd intermediate/web && npm test
+    - run: &run-web-tests
+        name: Run web tests
+        command: cd build/intermediate/web && npm test
 
 job-template-deb-amd64: &job-template-deb-amd64
   <<: *job-template-amd64
@@ -277,6 +297,8 @@ workflows:
   commit:
     jobs:
       - amd64-resolute-build:
+          <<: *filter-template-normal-builds
+      - amd64-resolute-web-build:
           <<: *filter-template-normal-builds
 
       - get-orig-source:
@@ -516,6 +538,14 @@ jobs:
 
   amd64-resolute-build:
     <<: *job-template-amd64
+    docker: *docker-base-resolute
+    environment:
+      <<: *environment-template-common
+      <<: *environment-template-resolute
+      <<: *environment-template-amd64
+
+  amd64-resolute-web-build:
+    <<: *job-template-web-amd64
     docker: *docker-base-resolute
     environment:
       <<: *environment-template-common


### PR DESCRIPTION
`amd64-resolute-build` runs npm/webpack and four concurrent clang jobs in one `large` container (4 vCPU / 8 GB), which is what runs it out of memory. This splits the web half into its own job.

The two halves have no dependency on each other in CMake — nothing in the C++ graph reaches the web targets, and the web targets reach nothing but npm — so no build-system change was needed, just the CMake options that already exist:

| Job | Configure | Build | Test |
|---|---|---|---|
| `amd64-resolute-build` | `-Dbuild_web=OFF -Dbuild_jdv=OFF` | `cmake --build . -- -j4` | `ctest` |
| `amd64-resolute-web-build` (new) | default | `cmake --build . --target jcc_jed jdv` | `npm test` |

Each job also now restores and saves only the cache it actually uses (ccache for one, npm/webpack for the other) instead of both jobs carrying both.

## Verified

Configured this branch both ways locally:

- `-Dbuild_web=OFF -Dbuild_jdv=OFF` configures cleanly and leaves no `jcc_jed`/`jdv`/`npm_dependencies` targets in the build.
- A default configure has all three, and `cmake --build . --target jcc_jed jdv` dry-runs to exactly `install_dependencies.sh` plus the two `npx webpack` invocations — **zero** C++ objects compiled, so the web job is not secretly rebuilding the project.
- Parsed the config with the anchors and merge keys resolved, before and after: `amd64-resolute-deb-build` comes out byte-for-byte identical, and the only changes are the two source-build jobs and the new workflow entry.

## Not included

**The Debian jobs are unchanged.** `dpkg-buildpackage` produces every binary package in one pass, so the same split there needs a build profile wired through `debian/rules`, `Build-Profiles: <!noweb>` on `jaiabot-web`, a "web only" mode that doesn't exist today (there is no switch to turn the C++ half off), and a merge of two sets of `.deb`/`.changes` for `upload`. If the deb builds OOM too, a few lines in `override_dh_auto_build` that build the web targets serially would get the same relief far more cheaply — say the word.

## Where the web build's own memory goes

Splitting the jobs takes the C++ compile out of the picture, but the web side is itself several concurrent compilations:

- `src/web/webpack.config.js` exports an array of two configs (jed and jcc), so one `npx webpack` run builds both concurrently via MultiCompiler.
- `optimization: { minimize: true }` means `terser-webpack-plugin`, which defaults to `parallel: true` — up to one worker per CPU, each holding bundle ASTs.
- `jdv` is a third production compilation, a separate `npx webpack` invocation that make can schedule alongside `jcc_jed`.
- All of them use `cache: { type: "filesystem" }`, whose serialization adds its own spike.

If the web job alone still comes close to the limit, the cheap knobs are webpack's `parallelism` for the two-config array and an explicit `TerserPlugin({ parallel: N })`. Not touching either here — the split should be enough on its own, and this is worth measuring before tuning.

## Note on caches

The ccache key includes `CIRCLE_JOB`, so this set of jobs starts from a cold ccache once, then warms up as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179Kv1vJb4eN1nDYPKoKeon