### PR TITLE
bug/3.y/fix-python-venv-dependencies

### DIFF
--- a/src/python/pyjaia/pyproject.toml
+++ b/src/python/pyjaia/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     'numpy',
     'cmocean',
     'pyturf',
+    'geojson',
     'h5py',
     'plotly',
 ]

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -8,10 +8,16 @@ Adafruit-PlatformDetect==3.88.0
 Adafruit-PureIO==1.1.11
 binho-host-adapter==0.1.6
 cmocean==4.0.3
+dataclasses-json
 digi-xbee==1.5.0
 Flask-Compress==1.24
+geopandas
 h5py-stubs==0.1.2
+networkx
+pytest
 pyturf==0.6.14
+rasterio
+simplejson
 ./pyjaia
 ./pyjaiaprotobuf
 ./Adafruit_CircuitPython_BNO08x


### PR DESCRIPTION
## Summary
Fix Python venv so `src/web/run.sh` works without errors.

## Test Procedure
<!-- Please describe the tests that you ran to verify your changes. -->
`src/web/run.sh`