### PR TITLE
1.y / Major upgrade: go one release at a time / SW-2441

### DIFF
--- a/config/ansible/major_upgrade/tasks/check-versions.yml
+++ b/config/ansible/major_upgrade/tasks/check-versions.yml
@@ -43,5 +43,56 @@
   vars:
     error_message: "No major upgrade to perform: current jaiabot version is greater than new version."
   when: major_upgrade_version_check_result.failed
-  
-  
+
+# Major upgrades go one release at a time (1.y -> 2.y -> 3.y): fleet configs are
+# migrated one version per release, and each release's upgrade tooling only
+# knows the release before it. Older ISOs don't declare previous_major.
+- name: Check that this system runs the release the upgrade expects
+  shell: |
+    current_major=$(echo {{ jaiabot_current_version }} | cut -d '.' -f1)
+    new_major=$(echo {{ major_upgrade_version }} | cut -d '.' -f1)
+    if [ "${current_major}" != "{{ major_upgrade_previous_major }}" ] && [ "${current_major}" != "${new_major}" ]; then
+      echo "Major upgrades must be done one release at a time: this system runs ${current_major}.y, so upgrade to the latest {{ major_upgrade_previous_major }}.y first, then to ${new_major}.y"
+      return 1
+    fi
+  register: previous_major_check_result
+  ignore_errors: yes
+  when: major_upgrade_previous_major is defined
+
+- name: Handle upgrade path check failure
+  include_tasks: handle_failure.yml
+  vars:
+    error_message: "{{ previous_major_check_result.stdout }}"
+  when: previous_major_check_result is not skipped and previous_major_check_result.failed
+
+- name: Install rpi-eeprom package
+  apt:
+    name: rpi-eeprom
+    state: present
+  ignore_errors: yes
+  register: rpi_eeprom_install_result
+
+- name: Check Raspberry Pi 4 EEPROM version
+  shell: |
+    min_version=1669373653
+    json=$(rpi-eeprom-update -j -m /dev/stderr 2>&1 >/dev/null)
+    current_version=$(echo "${json}" | python3 -c "import sys,json; print(json.load(sys.stdin)['BOOTLOADER_CURRENT'])" 2>/dev/null)
+    if [ -z "${current_version}" ]; then
+      echo "Could not determine EEPROM version"
+      return 1
+    fi
+    if [ "${current_version}" -lt "${min_version}" ]; then
+      echo "Raspberry Pi 4 EEPROM version must be at least ${min_version} (2022-11-25) to continue (version: ${current_version})"
+      return 1
+    fi
+  register: eeprom_version_check_result
+  ignore_errors: yes
+  when: rpi_eeprom_install_result is not failed
+
+- name: Handle EEPROM version check failure
+  include_tasks: handle_failure.yml
+  vars:
+    error_message: "{{ eeprom_version_check_result.stdout }}"
+  when: >
+    (rpi_eeprom_install_result is failed) or
+    (eeprom_version_check_result is not skipped and eeprom_version_check_result.failed)

--- a/config/ansible/major_upgrade/tasks/check-versions.yml
+++ b/config/ansible/major_upgrade/tasks/check-versions.yml
@@ -64,35 +64,3 @@
   vars:
     error_message: "{{ previous_major_check_result.stdout }}"
   when: previous_major_check_result is not skipped and previous_major_check_result.failed
-
-- name: Install rpi-eeprom package
-  apt:
-    name: rpi-eeprom
-    state: present
-  ignore_errors: yes
-  register: rpi_eeprom_install_result
-
-- name: Check Raspberry Pi 4 EEPROM version
-  shell: |
-    min_version=1669373653
-    json=$(rpi-eeprom-update -j -m /dev/stderr 2>&1 >/dev/null)
-    current_version=$(echo "${json}" | python3 -c "import sys,json; print(json.load(sys.stdin)['BOOTLOADER_CURRENT'])" 2>/dev/null)
-    if [ -z "${current_version}" ]; then
-      echo "Could not determine EEPROM version"
-      return 1
-    fi
-    if [ "${current_version}" -lt "${min_version}" ]; then
-      echo "Raspberry Pi 4 EEPROM version must be at least ${min_version} (2022-11-25) to continue (version: ${current_version})"
-      return 1
-    fi
-  register: eeprom_version_check_result
-  ignore_errors: yes
-  when: rpi_eeprom_install_result is not failed
-
-- name: Handle EEPROM version check failure
-  include_tasks: handle_failure.yml
-  vars:
-    error_message: "{{ eeprom_version_check_result.stdout }}"
-  when: >
-    (rpi_eeprom_install_result is failed) or
-    (eeprom_version_check_result is not skipped and eeprom_version_check_result.failed)


### PR DESCRIPTION
Jira: [SW-2441](https://jaia-innovation.atlassian.net/browse/SW-2441)

# Toby

Minor fix to block accidental 1.y -> 3.y upgrade which is not designed to work. Major upgrades must go in sequence (1.y -> 2.y -> 3.y) to simplify testing and increase probability of success.

# Claude

Backport of the upgrade-path check from the 3.y fleet config versioning work (https://github.com/jaiarobotics/jaiabot/pull/1691). From release 3 on, fleet configurations are versioned and migrated one release at a time, and each release's upgrade tooling only knows the release before it — so a 1.y system must go to 2.y before 3.y.

## Change

`config/ansible/major_upgrade/tasks/check-versions.yml`: after the existing version checks, refuse an upgrade image whose `major_upgrade_previous_major` (declared in the ISO's `version.txt` from release 3 on) is not this system's major version, with the message "Major upgrades must be done one release at a time: this system runs 1.y, so upgrade to the latest 2.y first, then to 3.y". Images without the declaration (all 2.y ISOs) are accepted exactly as before, so 1→2 upgrades are unaffected.

Nothing else from the 3.y work is needed on 1.y: a 1→2 upgrade renders the 2.y template with the 2.y schema, which is fleet config version 1 on both sides.

## Verification

YAML parses; same task text as on the 2.y (https://github.com/jaiarobotics/jaiabot/pull/1693) and 3.y branches. `get-major-version.yml` on 1.y already turns every `key=value` line of `version.txt` into a fact, so no parsing change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVZS7mGRaLvSd7EfS7diE


[SW-2441]: https://jaia-innovation.atlassian.net/browse/SW-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ