### PR TITLE
2.y / Fail the major upgrade if any bot still uses the deprecated BNO055 IMU / SW-2166

### DIFF
--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -53,6 +53,7 @@
   tasks:
     - name: Run Major Upgrade with Hub cleanup
       block:
+        - include_tasks: tasks/check-imu-type.yml
         - include_tasks: ../tasks/get-version.yml
         - include_tasks: tasks/check-latest-minor-version-installed.yml
         - include_tasks: tasks/get-major-version.yml

--- a/config/ansible/major_upgrade/tasks/check-imu-type.yml
+++ b/config/ansible/major_upgrade/tasks/check-imu-type.yml
@@ -11,5 +11,5 @@
 - name: Handle deprecated BNO055 IMU
   include_tasks: handle_failure.yml
   vars:
-    error_message: "The BNO055 IMU is no longer supported and must be replaced with a BNO085 IMU before a major upgrade can be run. Still using a BNO055: {{ bno055_bots | join(', ') }}. After fitting the new IMU, run 'sudo dpkg-reconfigure jaiabot-embedded' on each of these bots to set the imu type to bno085."
+    error_message: "The BNO055 IMU is no longer supported and must be replaced with a BNO085 IMU before a major upgrade can be run. Still using a BNO055: {{ bno055_bots | join(', ') }}. After fitting the new IMU, set the imu type to bno085 on each of these bots with 'sudo dpkg-reconfigure jaiabot-embedded', and regenerate the fleet configuration with 'jaia admin fleet create' so that the upgraded system is configured for the new IMU as well."
   when: bno055_bots | length > 0

--- a/config/ansible/major_upgrade/tasks/check-imu-type.yml
+++ b/config/ansible/major_upgrade/tasks/check-imu-type.yml
@@ -1,0 +1,15 @@
+- name: Determine the IMU type in use
+  set_fact:
+    jaia_imu_type_in_use: "{{ jaiabot_embedded_imu_type | default('none') if jaiabot_embedded_type == 'bot' else 'none' }}"
+
+- name: Find any bots using the deprecated BNO055 IMU
+  set_fact:
+    bno055_bots: "{{ ansible_play_hosts | map('extract', hostvars) | selectattr('jaia_imu_type_in_use', 'defined') | selectattr('jaia_imu_type_in_use', 'equalto', 'bno055') | map(attribute='inventory_hostname') | list }}"
+
+# Fail every machine, not just the offending bots: a fleet split across two major
+# versions can't operate, so the whole upgrade must wait for the new hardware.
+- name: Handle deprecated BNO055 IMU
+  include_tasks: handle_failure.yml
+  vars:
+    error_message: "The BNO055 IMU is no longer supported and must be replaced with a BNO085 IMU before a major upgrade can be run. Still using a BNO055: {{ bno055_bots | join(', ') }}. After fitting the new IMU, run 'sudo dpkg-reconfigure jaiabot-embedded' on each of these bots to set the imu type to bno085."
+  when: bno055_bots | length > 0

--- a/src/doc/markdown/page091_major_upgrade.md
+++ b/src/doc/markdown/page091_major_upgrade.md
@@ -4,6 +4,16 @@ A major software upgrade is defined as updating the Ubuntu release as well as th
 
 ## Preparing for major upgrade
 
+### Ensure all bots have a BNO085 IMU
+
+The BNO055 IMU is no longer supported. Any bot still fitted with one must have it replaced with a BNO085 before the fleet can be upgraded, and the new IMU recorded by setting the imu type to `bno085` with:
+
+```
+sudo dpkg-reconfigure jaiabot-embedded
+```
+
+The major upgrade playbook checks this on every bot and aborts the entire fleet upgrade if any bot still reports `imu_type` as `bno055`.
+
 ### Ensure the Hub has a valid Fleet Configuration
 
 If this fleet was generated prior to fleet configuration files (this includes most 1.y fleets), one will need to be created for the current fleet. This can be done using `jaia admin fleet create` as described in the [Embedded Board Deployment](page025_embedded_setup.md) document.

--- a/src/doc/markdown/page091_major_upgrade.md
+++ b/src/doc/markdown/page091_major_upgrade.md
@@ -6,13 +6,12 @@ A major software upgrade is defined as updating the Ubuntu release as well as th
 
 ### Ensure all bots have a BNO085 IMU
 
-The BNO055 IMU is no longer supported. Any bot still fitted with one must have it replaced with a BNO085 before the fleet can be upgraded, and the new IMU recorded by setting the imu type to `bno085` with:
+The BNO055 IMU is no longer supported. Any bot still fitted with one must have it replaced with a BNO085 before the fleet can be upgraded. For each of those bots:
 
-```
-sudo dpkg-reconfigure jaiabot-embedded
-```
+1. Set the imu type to `bno085` on the bot itself with `sudo dpkg-reconfigure jaiabot-embedded`. This is what the major upgrade checks.
+2. Regenerate the fleet configuration with `jaia admin fleet create` so that `imu_type` is `bno085` there too, since the upgraded system is configured from the fleet configuration rather than from the current debconf database. If the fleet configuration is embedded in the upgrade image, re-embed the new one (see the next sections).
 
-The major upgrade playbook checks this on every bot and aborts the entire fleet upgrade if any bot still reports `imu_type` as `bno055`.
+The major upgrade playbook checks every bot and aborts the entire fleet upgrade if any bot still reports `imu_type` as `bno055`.
 
 ### Ensure the Hub has a valid Fleet Configuration
 


### PR DESCRIPTION
Jira: [SW-2166](https://jaia-innovation.atlassian.net/browse/SW-2166)

Backport of the major upgrade check from jaiarobotics/jaiabot#1692 (3.y). This is the branch that matters most for the check: 2.y fleets are the ones that will run a 2.y → 3.y major upgrade, and `check-latest-minor-version-installed.yml` already forces them onto the latest 2.y minor first, so the check is guaranteed to be in place before the upgrade can start.

## Changes

- New `config/ansible/major_upgrade/tasks/check-imu-type.yml`: reads the `imu_type` debconf setting (already gathered by `read-debconf.yml`) on every bot in the play and fails via the existing `handle_failure.yml` if any bot reports `bno055`. The error names the offending bots and surfaces in the Upgrade UI through `major_upgrade_error` like the other pre-flight checks.
- The check is the first step in the major upgrade block, so it runs before the apt update, disk-space, and staging work.
- The failure applies to every machine in the play — hubs and compliant bots included — rather than just the offending bots, so a fleet is never left split across two major versions. Hubs are excluded from the `bno055` test itself since `imu_type` is never asked for a hub and keeps its `bno055` default in the debconf database.
- Documented the requirement in `src/doc/markdown/page091_major_upgrade.md` under "Preparing for major upgrade".

Differences from the 3.y version: the remediation instruction is `sudo dpkg-reconfigure jaiabot-embedded` rather than `jaia admin debconf set imu_type bno085`, since `jaia admin debconf` does not exist on 2.y.

**Not backported:** the removal of BNO055 runtime support that accompanies the 3.y change. Fielded 2.y bots are still running that hardware, so 2.y keeps the driver, the debconf choice and the generated service — it only refuses the major upgrade.

## Testing

Ran the new task file under `ansible-playbook` against a simulated fleet inventory, feeding it canned `debconf-show` output through 2.y's own `read-debconf.yml` fact-naming expression:

- hub + one `bno085` bot + one `bno055` bot → all three hosts fail with the BNO055 message naming only the offending bot (the hub's default `bno055` debconf value is correctly ignored).
- hub + `bno085` bot + `none` bot + a bot with no `imu_type` set at all → check skips and the play continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019STJTyARAGMMgvAkPNEtdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019STJTyARAGMMgvAkPNEtdZ)_


[SW-2166]: https://jaia-innovation.atlassian.net/browse/SW-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ