### PR TITLE
3.y / Add CloudHub major upgrade support with ISO download / SW-2461

### DIFF
--- a/config/ansible/major_upgrade/major-upgrade.yml
+++ b/config/ansible/major_upgrade/major-upgrade.yml
@@ -17,8 +17,20 @@
         state: directory
   
     - include_tasks: ../tasks/read-debconf.yml
+    - include_tasks: ../tasks/get-version.yml
+
+    - name: Create the upgrade base working directory
+      file:
+        path: '{{ upgrade_dir_base }}'
+        state: directory
+
+    - name: Check for CloudHub environment
+      stat:
+        path: /etc/jaiabot/cloud.env
+      register: cloud_env_file
 
   tasks:
+    - include_tasks: tasks/hub-fetch-iso.yml
     - include_tasks: tasks/hub-mount-updates-disk.yml
     - include_tasks: tasks/set-fleet-config-facts.yml
     - include_tasks: tasks/hub-stage-fleet-config.yml
@@ -33,8 +45,7 @@
     - vars/disk-space.yml
     - vars/staging.yml
   vars:
-    - upgrade_dir_base: '/var/log/jaiabot/major_upgrade'
-    - do_backup: yes
+    do_backup: yes
       
   pre_tasks:
     - name: Stop Jaiabot

--- a/config/ansible/major_upgrade/tasks/check-versions.yml
+++ b/config/ansible/major_upgrade/tasks/check-versions.yml
@@ -44,12 +44,23 @@
     error_message: "No major upgrade to perform: current jaiabot version is greater than new version."
   when: major_upgrade_version_check_result.failed
 
+- name: Check whether this is a Raspberry Pi
+  shell: "grep -qs 'Raspberry Pi' /proc/device-tree/model"
+  register: raspberry_pi_check
+  failed_when: false
+  changed_when: false
+
+- name: Set Raspberry Pi fact
+  set_fact:
+    is_raspberry_pi: "{{ raspberry_pi_check.rc == 0 }}"
+
 - name: Install rpi-eeprom package
   apt:
     name: rpi-eeprom
     state: present
   ignore_errors: yes
   register: rpi_eeprom_install_result
+  when: is_raspberry_pi | bool
 
 - name: Check Raspberry Pi 4 EEPROM version
   shell: |
@@ -66,12 +77,13 @@
     fi
   register: eeprom_version_check_result
   ignore_errors: yes
-  when: rpi_eeprom_install_result is not failed
+  when: is_raspberry_pi | bool and rpi_eeprom_install_result is not failed
 
 - name: Handle EEPROM version check failure
   include_tasks: handle_failure.yml
   vars:
-    error_message: "{{ eeprom_version_check_result.stdout }}"
+    error_message: "{{ eeprom_version_check_result.stdout | default('Failed to install rpi-eeprom') }}"
   when: >
-    (rpi_eeprom_install_result is failed) or
-    (eeprom_version_check_result is not skipped and eeprom_version_check_result.failed)
+    is_raspberry_pi | bool and
+    ((rpi_eeprom_install_result is failed) or
+     (eeprom_version_check_result is not skipped and eeprom_version_check_result.failed))

--- a/config/ansible/major_upgrade/tasks/fetch-reuse-files.yml
+++ b/config/ansible/major_upgrade/tasks/fetch-reuse-files.yml
@@ -4,3 +4,27 @@
     for file in /etc/wireguard/*; do
       rsync -aPR $file {{ upgrade_reuse_dir }}
     done
+
+- name: Check for CloudHub environment
+  stat:
+    path: /etc/jaiabot/cloud.env
+  register: cloud_env_file
+
+- name: Fetch CloudHub files to reuse on new image
+  shell: |
+    set -e
+    for file in /etc/sysctl.d/wg.conf \
+                /etc/ufw/ufw.conf /etc/ufw/user.rules /etc/ufw/user6.rules \
+                /etc/systemd/system/multi-user.target.wants/wg-quick@wg_cloudhub.service \
+                /etc/systemd/system/multi-user.target.wants/wg-quick@wg_virtualfleet.service \
+                /etc/jaiabot/vfleet-inventory.yml /etc/jaiabot/virtualfleet.cfg \
+                /home/jaia/.ssh/cloudhub_to_vfleet /home/jaia/.ssh/cloudhub_to_vfleet.pub \
+                /home/jaia/.ssh/virtualhub /home/jaia/.ssh/virtualhub.pub; do
+      [ -e "$file" ] && rsync -aPR "$file" {{ upgrade_reuse_dir }}
+    done
+    # jaia_fleet_index was renamed to jaia_fleet_id in 3.y
+    mkdir -p {{ upgrade_reuse_dir }}/etc/jaiabot
+    sed 's/^jaia_fleet_index=/jaia_fleet_id=/' /etc/jaiabot/cloud.env > {{ upgrade_reuse_dir }}/etc/jaiabot/cloud.env
+    # the S3 data bucket mount is not part of the base image's fstab
+    grep 'fuse.s3fs' /etc/fstab > {{ upgrade_dir }}/fstab.extra || true
+  when: cloud_env_file.stat.exists

--- a/config/ansible/major_upgrade/tasks/get-major-version.yml
+++ b/config/ansible/major_upgrade/tasks/get-major-version.yml
@@ -1,10 +1,17 @@
+- name: Use the local web server when this host is the updates hub
+  set_fact:
+    hub_ip: '127.0.0.1'
+  when: jaiabot_embedded_type == 'hub' and jaiabot_embedded_hub_id | int == hub_id | int
+
 - name: Get IP address for Hub
   shell: "jaia_ip h{{ hub_id }}f{{ jaiabot_embedded_fleet_id }}"
   register: hub_ip_result
+  when: hub_ip is not defined
   
 - name: Set hub IP
   set_fact:
-    hub_ip: '{{ hub_ip_result.stdout}}'
+    hub_ip: '{{ hub_ip_result.stdout }}'
+  when: hub_ip is not defined
     
 - name: Check if version.txt exists
   uri:

--- a/config/ansible/major_upgrade/tasks/hub-fetch-iso.yml
+++ b/config/ansible/major_upgrade/tasks/hub-fetch-iso.yml
@@ -1,0 +1,66 @@
+- name: Use the upgrade ISO given on the command line
+  set_fact:
+    major_upgrade_iso_path: "{{ major_upgrade_iso }}"
+  when: major_upgrade_iso | length > 0
+
+- name: Read CloudHub environment
+  include_tasks: ../../cloud/tasks/read-env.yml
+  when: cloud_env_file.stat.exists
+
+- name: Default to downloading the upgrade ISO from the CloudHub's repository
+  set_fact:
+    major_upgrade_iso_repo: "{{ cloud_env_vars.jaia_aws_virtualfleet_repository | default('release') }}"
+  when:
+    - major_upgrade_iso_path is not defined
+    - major_upgrade_iso_url_base | length == 0
+    - major_upgrade_iso_repo | length == 0
+    - cloud_env_file.stat.exists
+
+- name: Default to the next major version
+  set_fact:
+    major_upgrade_iso_version: "{{ (jaiabot_current_version.split('.')[0] | int) + 1 }}.y"
+  when:
+    - major_upgrade_iso_repo | length > 0
+    - major_upgrade_iso_version | length == 0
+
+- name: Set the upgrade ISO URL from the repository and version
+  set_fact:
+    major_upgrade_iso_url_base: "{{ major_upgrade_iso_s3_base }}/{{ major_upgrade_iso_repo }}/{{ major_upgrade_iso_version }}/vbox"
+  when:
+    - major_upgrade_iso_path is not defined
+    - major_upgrade_iso_url_base | length == 0
+    - major_upgrade_iso_repo | length > 0
+
+- name: Download the upgrade ISO
+  when:
+    - major_upgrade_iso_path is not defined
+    - major_upgrade_iso_url_base | length > 0
+  block:
+    - name: Download the upgrade image version.txt
+      get_url:
+        url: "{{ major_upgrade_iso_url_base }}/version.txt"
+        dest: "{{ upgrade_dir_base }}/iso-version.txt"
+        force: true
+      register: iso_version_download
+      until: iso_version_download is success
+      retries: 3
+      delay: 10
+
+    - name: Read the ISO name
+      shell: "grep '^iso_name=' {{ upgrade_dir_base }}/iso-version.txt | cut -d= -f2-"
+      register: iso_name_result
+      changed_when: false
+      failed_when: iso_name_result.stdout | length == 0
+
+    - name: Download the upgrade ISO (skipped if already present)
+      get_url:
+        url: "{{ major_upgrade_iso_url_base }}/{{ iso_name_result.stdout | urlencode }}"
+        dest: "{{ upgrade_dir_base }}/{{ iso_name_result.stdout }}"
+      register: iso_download
+      until: iso_download is success
+      retries: 3
+      delay: 10
+
+    - name: Set the upgrade ISO path
+      set_fact:
+        major_upgrade_iso_path: "{{ upgrade_dir_base }}/{{ iso_name_result.stdout }}"

--- a/config/ansible/major_upgrade/tasks/hub-mount-updates-disk.yml
+++ b/config/ansible/major_upgrade/tasks/hub-mount-updates-disk.yml
@@ -1,3 +1,18 @@
+- name: Mount upgrade ISO
+  shell: |
+    mkdir -p /var/www/html/updates
+    umount /var/www/html/updates 2> /dev/null || true
+    mount -o loop,ro "{{ major_upgrade_iso_path }}" /var/www/html/updates
+  register: mount_iso_result
+  ignore_errors: yes
+  when: major_upgrade_iso_path is defined
+
+- name: Handle Mount ISO failure
+  include_tasks: handle_failure.yml
+  vars:
+    error_message: "Mounting upgrade ISO {{ major_upgrade_iso_path }} failed: {{ mount_iso_result.stderr | default('') }}"
+  when: major_upgrade_iso_path is defined and mount_iso_result.failed
+
 - name: Mount updates disk
   mount:
     path: /var/www/html/updates
@@ -6,10 +21,10 @@
     fstype: auto
   register: mount_updates_result
   ignore_errors: yes
-
+  when: major_upgrade_iso_path is not defined
 
 - name: Handle Mount updates failure
   include_tasks: handle_failure.yml
   vars:
     error_message: "Mounting updates disk failed: Ensure USB key or CD is installed in hub"
-  when: mount_updates_result.failed
+  when: major_upgrade_iso_path is not defined and mount_updates_result.failed

--- a/config/ansible/major_upgrade/tasks/hub-stage-fleet-config.yml
+++ b/config/ansible/major_upgrade/tasks/hub-stage-fleet-config.yml
@@ -3,33 +3,28 @@
     iso_fleet_cfg: "/var/www/html/updates/major_upgrade/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
     existing_fleet_cfg: "/etc/jaiabot/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
 
-- name: Check if the iso fleet config file exists 
+- name: Set candidate fleet configuration files (first that exists is used)
+  set_fact:
+    fleet_cfg_candidates: "{{ ([fleet_cfg] if fleet_cfg | length > 0 else []) + [iso_fleet_cfg, existing_fleet_cfg] }}"
+
+- name: Check which fleet configuration files exist
   stat:
-    path: "{{ iso_fleet_cfg }}"
-  register: iso_fleet_file
+    path: "{{ item }}"
+  register: fleet_cfg_stats
+  loop: "{{ fleet_cfg_candidates }}"
 
-- name: Check if the existing fleet config file exists 
-  stat:
-    path: "{{ existing_fleet_cfg }}"
-  register: existing_fleet_file
-  when: not iso_fleet_file.stat.exists
-
-- name: Stage the iso fleet config file if it exists
-  copy:
-    src: "{{ iso_fleet_cfg }}"
-    dest: "{{ hub_staging_dir }}"
-    remote_src: yes
-  when: iso_fleet_file.stat.exists
-
-- name: Stage the existing fleet config file if the iso config does not exist
-  copy:
-    src: "{{ existing_fleet_cfg }}"
-    dest: "{{ hub_staging_dir }}"
-    remote_src: yes
-  when: not iso_fleet_file.stat.exists and existing_fleet_file.stat.exists
+- name: Select the fleet configuration file
+  set_fact:
+    selected_fleet_cfg: "{{ fleet_cfg_stats.results | selectattr('stat.exists') | map(attribute='item') | first | default('') }}"
 
 - name: Handle fleet config failure
   include_tasks: handle_failure.yml
   vars:
-    error_message: "Failed to find fleet configuration: Please contact JaiaRobotics for a USB key or CD with an embedded fleet configuration."
-  when: not iso_fleet_file.stat.exists and not existing_fleet_file.stat.exists
+    error_message: "Failed to find fleet configuration (looked for {{ fleet_cfg_candidates | join(', ') }}): Please contact JaiaRobotics for a USB key or CD with an embedded fleet configuration, or provide one with -e fleet_cfg=/path/to/fleet{{ jaiabot_embedded_fleet_id }}.cfg"
+  when: selected_fleet_cfg | length == 0
+
+- name: Stage the fleet configuration file
+  copy:
+    src: "{{ selected_fleet_cfg }}"
+    dest: "{{ staged_fleet_cfg }}"
+    remote_src: yes

--- a/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
+++ b/config/ansible/major_upgrade/templates/do-major-upgrade.sh.j2
@@ -84,6 +84,10 @@ if [ "{{ upgrade_type }}" = "embedded" ]; then
 
     rsync -aP {{ upgrade_reuse_dir }}/ ${new_ro_rootfs_mountpoint}/
 
+    if [ -e {{ upgrade_dir }}/fstab.extra ]; then
+        cat {{ upgrade_dir }}/fstab.extra >> ${new_ro_rootfs_mountpoint}/etc/fstab
+    fi
+
     ###############################
     # Write new boot dir
     ###############################
@@ -127,6 +131,8 @@ if [ "{{ upgrade_type }}" = "embedded" ]; then
     rm {{ upgrade_dir }}/*.rootfs.tar.gz
     rm {{ upgrade_dir }}/do-major-upgrade.sh
     rm {{ upgrade_dir }}/fleet*.cfg
+    rm -f {{ upgrade_dir }}/fstab.extra
+    rm -f {{ upgrade_dir_base }}/*.iso {{ upgrade_dir_base }}/iso-version.txt
     mv {{ upgrade_dir_base }}/version.txt {{ upgrade_dir }}
 fi
 
@@ -165,18 +171,30 @@ if [ -e /boot/grub/grub.cfg ]; then
     fi
 
     # update grub
-    if ! which cloud-init || [ "$(cloud-init query cloud_id)" = "nocloud" ] || [ "$(cloud-init query cloud_id)" = "" ]; then
-        # VirtualBox cloud init source
-        sed -i 's|\(GRUB_CMDLINE_LINUX_DEFAULT=".*\)"|\1 ds=nocloud\\;s=file:///etc/jaiabot/init/ network-config=disabled"|' /etc/default/grub
-    elif [ "$(cloud-init query cloud_id)" = "aws" ]; then       
+    cloud_id=""
+    if which cloud-init > /dev/null; then
+        cloud_id=$(cloud-init query cloud_id 2> /dev/null || true)
+    fi
+
+    if [ "${cloud_id}" = "aws" ]; then
         # Enable serial console for AWS debugging
         sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 console=ttyS0"/' /etc/default/grub
+    fi
+
+    # An in-place upgrade seeds first boot from the fleet configuration written
+    # to the boot partition, never from the cloud provider's original user data
+    # (which would regenerate keys and rewrite the CloudHub configuration).
+    # Only a fresh AMI build (upgrade_type aws_ami) keeps the EC2 datasource.
+    if [ "{{ upgrade_type }}" = "embedded" ] || [ "${cloud_id}" != "aws" ]; then
+        sed -i 's|\(GRUB_CMDLINE_LINUX_DEFAULT=".*\)"|\1 ds=nocloud\\;s=file:///etc/jaiabot/init/ network-config=disabled"|' /etc/default/grub
     fi
        
     update-grub
 fi
 
 if [ "{{ upgrade_type }}" = "embedded" ]; then
-    systemctl reboot --force
+    sync
+    # after pivot_root the old systemd may refuse the request; fall back to a direct reboot
+    systemctl reboot --force || systemctl reboot --force --force
 fi
 

--- a/config/ansible/major_upgrade/vars/staging.yml
+++ b/config/ansible/major_upgrade/vars/staging.yml
@@ -1,1 +1,13 @@
 hub_staging_dir: "/tmp/jaiabot/major_upgrade/staging"
+upgrade_dir_base: "/var/log/jaiabot/major_upgrade"
+
+# Alternatives to a USB key/CD labeled "updates" (e.g. for the CloudHub):
+# a local ISO, a full URL base, or a repository whose ISO is fetched from S3.
+major_upgrade_iso: ""
+major_upgrade_iso_url_base: ""
+major_upgrade_iso_repo: ""
+major_upgrade_iso_version: ""
+major_upgrade_iso_s3_base: "https://jaia-disk-images.s3.us-east-1.amazonaws.com"
+
+# Fleet configuration file to use instead of the one embedded in the ISO or /etc/jaiabot
+fleet_cfg: ""

--- a/config/gen/common/hub.py
+++ b/config/gen/common/hub.py
@@ -26,3 +26,17 @@ def expected_hubs_from_inventory():
         default_hub_id = 1
         return [default_hub_id]
     
+
+def cloud_env():
+    env = {}
+    try:
+        with open('/etc/jaiabot/cloud.env', 'r') as file:
+            for line in file:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, value = line.split('=', 1)
+                env[key] = value.strip('"')
+    except FileNotFoundError:
+        pass
+    return env

--- a/config/gen/hub.py
+++ b/config/gen/hub.py
@@ -230,8 +230,19 @@ elif common.app == 'goby_liaison_prelaunch':
         vfleet_playbooks=''
 
     limit=''
+    major_upgrade_limit=''
+    major_upgrade_input_vars=''
     if is_cloudhub:
         limit='limit: "all"'
+        # the CloudHub inventory reaches the real fleet over the CloudHub VPN,
+        # so a major upgrade must only touch the CloudHub itself
+        major_upgrade_limit='limit: "' + this_hub + '"'
+        repos=['release', 'beta', 'continuous']
+        default_repo=common.hub.cloud_env().get('jaia_aws_virtualfleet_repository', 'release')
+        if default_repo in repos:
+            repos.remove(default_repo)
+        repos.insert(0, default_repo)
+        major_upgrade_input_vars='input_var { name: "major_upgrade_iso_repo" display_name: "Repository to download the major upgrade image from" ' + ' '.join('value: "' + r + '"' for r in repos) + ' }'
     print(config.template_substitute(templates_dir+'/hub/goby_liaison_prelaunch.pb.cfg.in',
                                      app_block=app_common,
                                      http_port=liaison_port,
@@ -242,6 +253,8 @@ elif common.app == 'goby_liaison_prelaunch':
                                      vfleet_playbooks=vfleet_playbooks,
                                      this_hub_id=hub_id,
                                      limit=limit,
+                                     major_upgrade_limit=major_upgrade_limit,
+                                     major_upgrade_input_vars=major_upgrade_input_vars,
                                      ansible_log_dir=common.jaia_log_dir + '/ansible'))
 elif common.app == 'goby_gps':
     print(config.template_substitute(templates_dir+'/goby_gps.pb.cfg.in',

--- a/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
+++ b/config/templates/hub/goby_liaison_prelaunch.pb.cfg.in
@@ -108,7 +108,7 @@ add_commander_tab: false
 
     ansible_playbook {
         file: "major_upgrade/major-upgrade.yml" 
-        name: "Major Upgrade Jaiabot and Ubuntu release (Requires Major Upgrade image to be connected to this Hub via USB Key or CD)"
+        name: "Major Upgrade Jaiabot and Ubuntu release (Requires Major Upgrade image to be connected to this Hub via USB Key or CD, or downloaded from the repository on a CloudHub)"
         section: "Upgrade"
         role: USER
 
@@ -125,13 +125,15 @@ add_commander_tab: false
             value: "no"
         }
 
+        $major_upgrade_input_vars
+
         output_var {
             name: "major_upgrade_error"
             display_name: "Error"
         }
         
         causes_hub_reboot: true
-        $limit
+        $major_upgrade_limit
     }
 
     

--- a/rootfs/cloud/aws/cloud-init-user-data.sh.in
+++ b/rootfs/cloud/aws/cloud-init-user-data.sh.in
@@ -95,15 +95,6 @@ jaia_aws_virtualfleet_repository_version={{REPO_VERSION}}
 jaia_jcc_hub_ip={{JCC_HUB_IP}}
 EOF
 
-## Ansible jobs for VFleet need boto3
-apt-get -y install python3-boto3
-
-cd /tmp
-AWSCLI_VERSION=2.18.8
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o "awscliv2.zip"
-unzip -q awscliv2.zip
-./aws/install
-
 ## Add s3 entry for data
 cat <<EOF >> /etc/fstab
 {{CLOUDHUB_DATA_BUCKET}} /var/log/jaiabot/bot_offload/ fuse.s3fs _netdev,allow_other,use_path_request_style,iam_role=auto,url=https://s3.{{REGION}}.amazonaws.com,dbglevel=warn,endpoint={{REGION}} 0 0

--- a/rootfs/cloud/aws/create_vpc.sh
+++ b/rootfs/cloud/aws/create_vpc.sh
@@ -360,6 +360,11 @@ done
 ssh -o PasswordAuthentication=No -o StrictHostKeyChecking=no jaia@${PUBLIC_IPV4_ADDRESS} "sudo ufw allow in on eth0 proto udp to any port 51820; sudo ufw allow in on eth0 proto udp to any port 51821; sudo ufw allow in on wg_cloudhub; sudo ufw --force enable"
 echo ">>>>>> Updated CloudHub ufw firewall rules to exclude connecting on VirtualFleet VPN"
 
+# Major upgrades regenerate the CloudHub from this file
+scp -o PasswordAuthentication=No -o StrictHostKeyChecking=no ${FLEET_CONFIG} jaia@${PUBLIC_IPV4_ADDRESS}:/tmp/fleet${FLEET_ID}.cfg
+ssh -o PasswordAuthentication=No -o StrictHostKeyChecking=no jaia@${PUBLIC_IPV4_ADDRESS} "sudo install -m 0644 /tmp/fleet${FLEET_ID}.cfg /etc/jaiabot/fleet${FLEET_ID}.cfg && rm /tmp/fleet${FLEET_ID}.cfg"
+echo ">>>>>> Installed fleet configuration at /etc/jaiabot/fleet${FLEET_ID}.cfg on CloudHub"
+
 run "" aws ec2 revoke-security-group-ingress --group-id $CLOUDHUB_SECURITY_GROUP_ID --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges='[{CidrIp=0.0.0.0/0}]',Ipv6Ranges='[{CidrIpv6=::/0}]'
 echo ">>>>>> Removed SSH (port 22) on Security Group"
 

--- a/rootfs/customization/includes.chroot/etc/jaiabot/init/first-boot.preseed.yml.j2
+++ b/rootfs/customization/includes.chroot/etc/jaiabot/init/first-boot.preseed.yml.j2
@@ -52,3 +52,8 @@ runcmd:
   - networkctl reload
   - networkctl up wlan0
   - /etc/jaiabot/init/configure-wireguard-service-vpn.sh
+{%- if this.type == "hub" and this.id == 30 %}
+  # CloudHub tools (VirtualFleet management and S3 data) that are not part of the base image
+  - apt-get -y install python3-boto3
+  - (cd /tmp && curl -sS "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.18.8.zip" -o awscliv2.zip && unzip -q -o awscliv2.zip && ./aws/install --update)
+{%- endif %}

--- a/src/doc/markdown/page056_cloud.md
+++ b/src/doc/markdown/page056_cloud.md
@@ -179,6 +179,8 @@ fd0f:77ac:4fdf:2::1e cloudhub-fleet1
 - http://hub1-virtualfleet1 for the VirtualFleet JCC (command and monitoring of Virtual Fleet).
 - http://hub1-virtualfleet1:9091 for the VirtualFleet Jaiabot Fleet Upgrade and Configuration (for updating the VirtualFleet).
 
+To move a CloudHub to a new Ubuntu/Jaiabot major release in place, see [Major software upgrade](page091_major_upgrade.md).
+
 ## Specialty Servers
 
 In addition to the CloudHub and VirtualFleet mentioned above, Jaia runs a number of "speciality" AWS servers, each with a specific primary task:

--- a/src/doc/markdown/page091_major_upgrade.md
+++ b/src/doc/markdown/page091_major_upgrade.md
@@ -53,6 +53,25 @@ where `hub_id` is the hub in use (the one with the upgrade USB flash key or CD c
 
 To upgrade multiple Hubs, you will need to re-run this command (with the update hub_id) after moving the USB flash key to the new hub. Any number of bots will be updated from a single Hub as part of this command.
 
+## Upgrading a CloudHub (or other virtual machine)
+
+A CloudHub is upgraded in place with the same `major-upgrade.yml` playbook, with a few differences from a physical hub:
+
+- There is no USB key or CD. The upgrade ISO is downloaded from the `jaia-disk-images` S3 bucket (`https://jaia-disk-images.s3.us-east-1.amazonaws.com/{repo}/{version}/vbox/`) into `/var/log/jaiabot/major_upgrade` and loop-mounted at `/var/www/html/updates`. On a machine with `/etc/jaiabot/cloud.env` this happens automatically, using the repository from `jaia_aws_virtualfleet_repository` and the next major version (e.g. `3.y` when 2.y is installed). Override with `-e major_upgrade_iso_repo=beta`, `-e major_upgrade_iso_version=3.y`, `-e major_upgrade_iso_url_base=URL`, or `-e major_upgrade_iso=/path/to/local.iso` (also usable on a physical hub).
+- The fleet configuration must contain hub 30 (the CloudHub). CloudHubs created with 3.y `create_vpc.sh` store it at `/etc/jaiabot/fleetN.cfg`; for older CloudHubs copy it there first, or pass it with `-e fleet_cfg=/path/to/fleetN.cfg`.
+- The CloudHub inventory also lists the real fleet over the CloudHub VPN, so the run must be limited to the CloudHub itself (the JCU does this automatically):
+
+```
+cd /usr/share/jaiabot/config/ansible/major_upgrade
+ansible-playbook -i /etc/jaiabot/inventory.yml major-upgrade.yml -e hub_id=30 -e do_backup=no --limit hub30-fleetN
+```
+
+- The CloudHub's own configuration survives the upgrade: `/etc/wireguard`, `/etc/jaiabot/cloud.env` (the 2.y key `jaia_fleet_index` is renamed to `jaia_fleet_id`), the WireGuard sysctl and service enablement, `ufw` rules, the S3 data bucket `fstab` entry, and the VirtualFleet SSH keys and inventory.
+- The new root filesystem boots with the same NoCloud `cloud-init` seed as a VirtualBox VM (kernel command line `ds=nocloud;s=file:///etc/jaiabot/init/`), so first boot is configured from the fleet configuration rather than from the EC2 user data used to create the instance (which would regenerate the VPN keys). The AWS CLI and boto3 are installed by first boot on hub 30.
+- VirtualFleet machines are not upgraded; recreate them from the JCU once the CloudHub is running the new release.
+
+Because the playbook runs from the release installed on the machine being upgraded, the release must contain this CloudHub support (2.y from the version that first backported it).
+
 ## Major upgrade design
 
 The major upgrade extracts a new filesystem image and configures it, much like a generating a new bot or hub as described in the [Embedded Board Deployment](page025_embedded_setup.md) document. This means that the state of the previous installation filesystem is largely irrelevant.


### PR DESCRIPTION
Jira: [SW-2461](https://jaia-innovation.atlassian.net/browse/SW-2461)

## Summary

This PR adds support for major upgrades on CloudHub (virtual machine) instances, which previously required physical USB keys or CDs. The changes enable:

1. **ISO Download**: New `hub-fetch-iso.yml` task automatically downloads upgrade ISOs from the S3 bucket for CloudHub instances, with configurable repository, version, and URL options.

2. **CloudHub Configuration Preservation**: Extended `fetch-reuse-files.yml` to preserve CloudHub-specific configuration during upgrades, including WireGuard VPN settings, ufw rules, SSH keys, VirtualFleet inventory, and S3 data bucket mount configuration. Handles migration of the `jaia_fleet_index` to `jaia_fleet_id` naming convention.

3. **Fleet Configuration Flexibility**: Refactored `hub-stage-fleet-config.yml` to support multiple fleet configuration sources (command-line provided, ISO-embedded, or existing system config) with a priority-based selection mechanism.

4. **Improved Raspberry Pi Handling**: Added explicit Raspberry Pi detection in `check-versions.yml` to conditionally apply EEPROM checks only on Pi hardware.

5. **Boot Configuration**: Updated `do-major-upgrade.sh` to:
   - Preserve fstab entries for S3 data bucket mounts
   - Properly configure cloud-init datasource for in-place upgrades (NoCloud seed instead of EC2 user data)
   - Ensure AWS CLI and boto3 are installed on hub 30 (CloudHub) during first boot
   - Improve reboot reliability with fallback mechanism

6. **JCU Integration**: Updated `hub.py` to generate appropriate Ansible playbook limits and input variables for CloudHub major upgrades, with repository selection based on CloudHub configuration.

7. **Documentation**: Added comprehensive CloudHub upgrade instructions to `page091_major_upgrade.md` covering prerequisites, configuration, and upgrade-specific behavior.

## Test Procedure

- Verify ISO download and mounting on a CloudHub instance with `/etc/jaiabot/cloud.env`
- Confirm fleet configuration is correctly selected from multiple sources
- Test that CloudHub configuration (WireGuard, ufw, SSH keys) persists after upgrade
- Verify Raspberry Pi EEPROM checks only run on Pi hardware
- Confirm boot configuration uses NoCloud datasource for in-place upgrades
- Test JCU generates correct Ansible limits and input variables for CloudHub instances

https://claude.ai/code/session_012rjUjavFuoB5CtEP6w3g1R


[SW-2461]: https://jaia-innovation.atlassian.net/browse/SW-2461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ