### PR TITLE
Fix a simulated fleet coming up with every bot failed

### DIFF
--- a/config/gen/bot.py
+++ b/config/gen/bot.py
@@ -63,7 +63,6 @@ jaia_motor_harness_type="NONE"
 if "jaia_motor_harness_type" in os.environ:
     jaia_motor_harness_type=os.environ['jaia_motor_harness_type']
 
-bot_index = -1
 try:
     bot_id=int(os.environ['jaia_bot_id'])
 except:
@@ -240,12 +239,12 @@ elif common.app == 'goby_coroner':
 elif common.app == 'jaiabot_health':
     ignore_powerstate_changes=is_simulation() and not common.is_vfleet
     print(config.template_substitute(templates_dir+'/bot/jaiabot_health.pb.cfg.in',
-                                     bot_id=bot_index,
-                                     fleet_id=fleet_index,
+                                     bot_id=bot_id,
+                                     fleet_id=fleet_id,
                                      app_block=app_common,
                                      interprocess_block = interprocess_common,
                                      bind_port=common.udp.motor_cpp_udp_port(),
-                                     remote_port=common.udp.motor_py_udp_port(bot_index),
+                                     remote_port=common.udp.motor_py_udp_port(bot_id),
                                      # do not power off or restart the simulator computer unless we're a VirtualFleet
                                      ignore_powerstate_changes=ignore_powerstate_changes,
                                      is_in_sim=is_simulation(),
@@ -421,4 +420,4 @@ else:
                                      imu_type=imu_type,
                                      pressure_sensor_type=pressure_sensor_type,
                                      log_file_dir=log_file_dir,
-                                     motor_py_udp_port=common.udp.motor_py_udp_port(bot_index)))
+                                     motor_py_udp_port=common.udp.motor_py_udp_port(bot_id)))

--- a/src/bin/simulator/arduino_sim_thread.cpp
+++ b/src/bin/simulator/arduino_sim_thread.cpp
@@ -67,8 +67,6 @@ void jaiabot::apps::ArduinoSimThread::handle_arduino_command(
         arduino_response.set_status_code(jaiabot::protobuf::ArduinoStatusCode::ACK);
     }
 
-    auto now = goby::time::SteadyClock::now();
-
     if (arduino_command.has_actuators())
     {
         auto actuators = arduino_command.actuators();
@@ -78,18 +76,42 @@ void jaiabot::apps::ArduinoSimThread::handle_arduino_command(
         }
     }
 
-    // Simulate the voltage decreasing over time, and resetting when it gets too low
+    update_voltage(arduino_response);
+
+    interprocess().publish<groups::arduino_to_pi>(arduino_response);
+}
+
+// jaiabot_driver_arduino runs on real hardware only, so in simulation nothing sends the
+// commands that the handler above answers. Report unprompted as the Arduino itself does,
+// otherwise no vccvoltage ever reaches jaiabot_fusion and every simulated bot fails its
+// health check on a battery level it never received.
+void jaiabot::apps::ArduinoSimThread::loop()
+{
+    jaiabot::protobuf::ArduinoResponse arduino_response;
+    arduino_response.set_status_code(jaiabot::protobuf::ArduinoStatusCode::ACK);
+    arduino_response.set_version(3);
+    arduino_response.set_thermistor_voltage(2.5);
+
+    update_voltage(arduino_response);
+
+    interprocess().publish<groups::arduino_to_pi>(arduino_response);
+}
+
+// Simulate the voltage decreasing over time, and resetting when it gets too low
+void jaiabot::apps::ArduinoSimThread::update_voltage(
+    jaiabot::protobuf::ArduinoResponse& arduino_response)
+{
+    auto now = goby::time::SteadyClock::now();
+
     if ((voltage_updated_ + std::chrono::seconds(voltage_period_)) < now)
     {
         voltage_start_ = voltage_start_ - voltage_step_decrease_;
         arduino_response.set_vccvoltage(voltage_start_);
-        voltage_updated_ = goby::time::SteadyClock::now();
+        voltage_updated_ = now;
 
         if (voltage_start_ < reset_voltage_level_)
         {
             voltage_start_ = cfg().voltage_start();
         }
     }
-
-    interprocess().publish<groups::arduino_to_pi>(arduino_response);
 }

--- a/src/bin/simulator/simulator_thread.h
+++ b/src/bin/simulator/simulator_thread.h
@@ -64,6 +64,10 @@ class ArduinoSimThread : public SimulatorThread<jaiabot::config::ArduinoSimThrea
     virtual void handle_arduino_command(const jaiabot::protobuf::ArduinoCommand& arduino_command);
 
   private:
+    void loop() override;
+    void update_voltage(jaiabot::protobuf::ArduinoResponse& arduino_response);
+
+  private:
     int voltage_period_{1};
     double voltage_step_decrease_{0.1};
     double voltage_start_{24.0};


### PR DESCRIPTION
The 2.y merge left three references to bot_index and fleet_index in config/gen/bot.py, which 3.y calls bot_id and fleet_id. fleet_index does not exist, so generating the jaiabot_health config raised a NameError, and since every jaiabot app on a bot is BindsTo=jaiabot_health.service, one bot lost its whole stack and never reported to a hub. bot_index did exist, as a leftover -1 stub, so the motor driver port was 20004 rather than 20005 + bot id.

The same merge turned ArduinoSimThread from a periodic publisher into one that only answers an ArduinoCommand. Nothing sends those in simulation, because jaiabot_driver_arduino runs in runtime mode only, so no vccvoltage reached jaiabot_fusion, battery_percent stayed at 0 and every simulated bot sat in PRE_DEPLOYMENT__FAILED on ERROR__VEHICLE__CRITICALLY_LOW_BATTERY. Report the voltage unprompted again while keeping the command response path.